### PR TITLE
Move MCU mailbox to scratch-backed lite APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,9 +1005,8 @@ dependencies = [
 name = "caliptra-mcu-common-commands"
 version = "0.1.0"
 dependencies = [
- "async-trait",
- "caliptra-api",
  "caliptra-mcu-mbox-common",
+ "mcu-caliptra-api-lite",
  "zerocopy",
 ]
 
@@ -1691,9 +1690,7 @@ dependencies = [
 name = "caliptra-mcu-mbox-lib"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
  "caliptra-mcu-common-commands",
- "caliptra-mcu-libapi-caliptra",
  "caliptra-mcu-libsyscall-caliptra",
  "caliptra-mcu-libtock_alarm",
  "caliptra-mcu-libtock_console",
@@ -1707,6 +1704,7 @@ dependencies = [
  "defmt",
  "embassy-executor",
  "embassy-sync",
+ "mcu-caliptra-api-lite",
  "zerocopy",
 ]
 
@@ -1723,7 +1721,6 @@ dependencies = [
 name = "caliptra-mcu-mctp-vdm-lib"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "caliptra-mcu-common-commands",
  "caliptra-mcu-libsyscall-caliptra",
  "caliptra-mcu-libtock_alarm",
@@ -6917,7 +6914,6 @@ dependencies = [
 name = "user-app"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "async-trait",
  "caliptra-api",
  "caliptra-mcu-common-commands",

--- a/caliptra-util-host/apps/mailbox/client/src/validator.rs
+++ b/caliptra-util-host/apps/mailbox/client/src/validator.rs
@@ -1536,6 +1536,7 @@ impl Validator {
 
                     let token_req = match signer.sign_debug_unlock_token(&challenge, unlock_level) {
                         Ok(t) => ProdDebugUnlockTokenRequest {
+                            checksum: 0,
                             length: t.length,
                             unique_device_identifier: t.unique_device_identifier,
                             unlock_level: t.unlock_level,

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -305,6 +305,7 @@ pub fn run_prod_debug_unlock(
 
                 let token = match signer.sign_debug_unlock_token(&challenge, unlock_level) {
                     Ok(t) => ProdDebugUnlockTokenRequest {
+                        checksum: 0,
                         length: t.length,
                         unique_device_identifier: t.unique_device_identifier,
                         unlock_level: t.unlock_level,

--- a/caliptra-util-host/command-types/src/debug_unlock.rs
+++ b/caliptra-util-host/command-types/src/debug_unlock.rs
@@ -28,6 +28,9 @@ pub const ECC_SIGNATURE_WORD_SIZE: usize = 24;
 /// ML-DSA signature size in u32 words
 pub const MLDSA_SIGNATURE_WORD_SIZE: usize = 1157;
 
+/// Caliptra RT mailbox command ID for PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.
+const CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN: u32 = 0x5044_5554; // "PDUT"
+
 // ---- Production Debug Unlock Request (Challenge) ----
 
 #[repr(C)]
@@ -80,6 +83,7 @@ impl CommandResponse for ProdDebugUnlockReqResponse {}
 #[repr(C)]
 #[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
 pub struct ProdDebugUnlockTokenRequest {
+    pub checksum: u32,
     pub length: u32,
     pub unique_device_identifier: [u8; UNIQUE_DEVICE_ID_SIZE],
     pub unlock_level: u8,
@@ -94,6 +98,7 @@ pub struct ProdDebugUnlockTokenRequest {
 impl Default for ProdDebugUnlockTokenRequest {
     fn default() -> Self {
         Self {
+            checksum: 0,
             length: 0,
             unique_device_identifier: [0u8; UNIQUE_DEVICE_ID_SIZE],
             unlock_level: 0,
@@ -104,6 +109,20 @@ impl Default for ProdDebugUnlockTokenRequest {
             ecc_signature: [0u32; ECC_SIGNATURE_WORD_SIZE],
             mldsa_signature: [0u32; MLDSA_SIGNATURE_WORD_SIZE],
         }
+    }
+}
+
+impl ProdDebugUnlockTokenRequest {
+    /// Populate the Caliptra request checksum carried as the first command word.
+    pub fn populate_checksum(&mut self) {
+        let bytes = self.as_bytes();
+        let checksum = CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN
+            .to_le_bytes()
+            .iter()
+            .chain(bytes.iter().skip(core::mem::size_of::<u32>()))
+            .fold(0u32, |sum, byte| sum.wrapping_add(*byte as u32))
+            .wrapping_neg();
+        self.checksum = checksum;
     }
 }
 
@@ -127,3 +146,21 @@ impl CommandRequest for ProdDebugUnlockTokenRequest {
 }
 
 impl CommandResponse for ProdDebugUnlockTokenResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_checksum_covers_caliptra_command_and_body() {
+        let mut request = ProdDebugUnlockTokenRequest {
+            length: 1,
+            unlock_level: 2,
+            ..Default::default()
+        };
+
+        request.populate_checksum();
+
+        assert_eq!(request.checksum, 0xffff_fec0);
+    }
+}

--- a/caliptra-util-host/commands/src/api/debug_unlock.rs
+++ b/caliptra-util-host/commands/src/api/debug_unlock.rs
@@ -62,8 +62,10 @@ pub fn caliptra_cmd_prod_debug_unlock_token(
     session: &mut CaliptraSession,
     request: &ProdDebugUnlockTokenRequest,
 ) -> CaliptraResult<ProdDebugUnlockTokenResponse> {
+    let mut request = request.clone();
+    request.populate_checksum();
     session
-        .execute_command_with_id(CaliptraCommandId::ProdDebugUnlockToken, request)
+        .execute_command_with_id(CaliptraCommandId::ProdDebugUnlockToken, &request)
         .map_err(|_| {
             CaliptraApiError::SessionError("Production debug unlock token command execution failed")
         })

--- a/caliptra-util-host/transport/src/transports/mailbox/debug_unlock.rs
+++ b/caliptra-util-host/transport/src/transports/mailbox/debug_unlock.rs
@@ -101,6 +101,7 @@ impl VariableSizeBytes for ExtCmdProdDebugUnlockReqResponse {}
 #[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
 pub struct ExtCmdProdDebugUnlockTokenRequest {
     pub chksum: u32,
+    pub caliptra_chksum: u32,
     pub length: u32,
     pub unique_device_identifier: [u8; UNIQUE_DEVICE_ID_SIZE],
     pub unlock_level: u8,
@@ -116,6 +117,7 @@ impl Default for ExtCmdProdDebugUnlockTokenRequest {
     fn default() -> Self {
         Self {
             chksum: 0,
+            caliptra_chksum: 0,
             length: 0,
             unique_device_identifier: [0u8; UNIQUE_DEVICE_ID_SIZE],
             unlock_level: 0,
@@ -138,29 +140,11 @@ pub struct ExtCmdProdDebugUnlockTokenResponse {
 
 impl FromInternalRequest<ProdDebugUnlockTokenRequest> for ExtCmdProdDebugUnlockTokenRequest {
     fn from_internal(internal: &ProdDebugUnlockTokenRequest, command_code: u32) -> Self {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&internal.length.to_le_bytes());
-        payload.extend_from_slice(&internal.unique_device_identifier);
-        payload.push(internal.unlock_level);
-        payload.extend_from_slice(&internal.reserved);
-        payload.extend_from_slice(&internal.challenge);
-        for word in &internal.ecc_public_key {
-            payload.extend_from_slice(&word.to_le_bytes());
-        }
-        for word in &internal.mldsa_public_key {
-            payload.extend_from_slice(&word.to_le_bytes());
-        }
-        for word in &internal.ecc_signature {
-            payload.extend_from_slice(&word.to_le_bytes());
-        }
-        for word in &internal.mldsa_signature {
-            payload.extend_from_slice(&word.to_le_bytes());
-        }
-
-        let chksum = calc_checksum(command_code, &payload);
+        let chksum = calc_checksum(command_code, internal.as_bytes());
 
         Self {
             chksum,
+            caliptra_chksum: internal.checksum,
             length: internal.length,
             unique_device_identifier: internal.unique_device_identifier,
             unlock_level: internal.unlock_level,
@@ -208,3 +192,30 @@ define_command!(
     ExtCmdProdDebugUnlockTokenRequest,
     ExtCmdProdDebugUnlockTokenResponse
 );
+
+#[cfg(test)]
+mod tests {
+    use super::super::checksum::verify_checksum;
+    use super::*;
+
+    #[test]
+    fn token_request_preserves_caliptra_checksum_inside_mailbox_request() {
+        const MCU_CMD: u32 = 0x4D50_5554; // "MPUT"
+
+        let mut internal = ProdDebugUnlockTokenRequest {
+            length: 1,
+            unlock_level: 2,
+            ..Default::default()
+        };
+        internal.populate_checksum();
+
+        let external = ExtCmdProdDebugUnlockTokenRequest::from_internal(&internal, MCU_CMD);
+
+        assert_eq!(external.caliptra_chksum, internal.checksum);
+        assert!(verify_checksum(
+            external.chksum,
+            MCU_CMD,
+            &external.as_bytes()[core::mem::size_of::<u32>()..],
+        ));
+    }
+}

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -33,9 +33,6 @@ use caliptra_mcu_core_util_host_command_types::debug_unlock::{
 use caliptra_mcu_core_util_host_command_types::*;
 use zerocopy::IntoBytes;
 
-/// Caliptra RT mailbox command ID for PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.
-const CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN: u32 = 0x5044_5554; // "PDUT"
-
 // ---------------------------------------------------------------------------
 // Helper: build VDM request, send via driver, validate response header
 // ---------------------------------------------------------------------------
@@ -516,34 +513,36 @@ pub fn handle_prod_debug_unlock_req(
     let req = ProdDebugUnlockReqRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
 
-    // VDM payload: [unlock_level(1)]
-    let vdm_payload = [req.unlock_level];
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let resp_len = send_vdm_request(
         CaliptraVdmCommand::RequestDebugUnlock,
-        &vdm_payload,
+        req.as_bytes(),
         driver,
         &mut resp_buf,
     )?;
 
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
 
-    // Response data: [unique_device_identifier(32), challenge(48)]
-    if data.len() != UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+    // Response data: [length(4), unique_device_identifier(32), challenge(48)]
+    if data.len()
+        != core::mem::size_of::<u32>() + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE
+    {
         return Err(TransportError::InvalidMessage);
     }
+    let length = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+    let challenge_data = &data[core::mem::size_of::<u32>()..];
 
     let mut unique_device_identifier = [0u8; UNIQUE_DEVICE_ID_SIZE];
-    unique_device_identifier.copy_from_slice(&data[..UNIQUE_DEVICE_ID_SIZE]);
+    unique_device_identifier.copy_from_slice(&challenge_data[..UNIQUE_DEVICE_ID_SIZE]);
 
     let mut challenge = [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE];
     challenge.copy_from_slice(
-        &data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+        &challenge_data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
     );
 
     let internal_resp = ProdDebugUnlockReqResponse {
         common: CommonResponse { fips_status: 0 },
-        length: 0,
+        length,
         unique_device_identifier,
         challenge,
     };
@@ -563,30 +562,13 @@ pub fn handle_prod_debug_unlock_token(
     driver: &mut dyn SpdmVdmDriver,
     response_buffer: &mut [u8],
 ) -> Result<usize, TransportError> {
-    use crate::transports::mailbox::checksum::calc_checksum;
-    use alloc::vec;
-
     let req = ProdDebugUnlockTokenRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
-
-    // DebugUnlock is intentionally transported as Caliptra RT mailbox bytes so
-    // the MCU can stream the host-provided request directly into the Caliptra
-    // mailbox FIFO. The checksum must be the first mailbox word and covers the
-    // token body, so building it on the host avoids staging the whole token in
-    // MCU RAM before forwarding.
-    let token_bytes = req.as_bytes();
-    let hdr_size = core::mem::size_of::<u32>(); // MailboxReqHeader = chksum(u32)
-    let total_len = hdr_size + token_bytes.len();
-
-    let mut mbox_payload = vec![0u8; total_len];
-    mbox_payload[hdr_size..].copy_from_slice(token_bytes);
-    let chksum = calc_checksum(CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN, &mbox_payload);
-    mbox_payload[..hdr_size].copy_from_slice(&chksum.to_le_bytes());
 
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let _resp_len = send_vdm_request(
         CaliptraVdmCommand::AuthorizeDebugUnlockToken,
-        &mbox_payload,
+        req.as_bytes(),
         driver,
         &mut resp_buf,
     )?;
@@ -769,7 +751,13 @@ mod tests {
     #[test]
     fn debug_unlock_req_rejects_trailing_response_bytes() {
         let req = ProdDebugUnlockReqRequest::new(1);
-        let mut data = vec![0xA5; UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE + 1];
+        let mut data = vec![
+            0xA5;
+            core::mem::size_of::<u32>()
+                + UNIQUE_DEVICE_ID_SIZE
+                + DEBUG_UNLOCK_CHALLENGE_SIZE
+                + 1
+        ];
         let mut driver = FakeDriver {
             response: success_response(CaliptraVdmCommand::RequestDebugUnlock, &data),
             last_request: Vec::new(),
@@ -780,10 +768,14 @@ mod tests {
             .expect_err("DebugUnlock response with trailing bytes must be rejected");
 
         assert!(matches!(err, TransportError::InvalidMessage));
-        data.truncate(UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE);
+        data.truncate(
+            core::mem::size_of::<u32>() + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
+        );
+        data[..core::mem::size_of::<u32>()].copy_from_slice(&21u32.to_le_bytes());
         driver.response = success_response(CaliptraVdmCommand::RequestDebugUnlock, &data);
         handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer)
             .expect("exact-length DebugUnlock response should be accepted");
+        assert_eq!(&driver.last_request[2..], req.as_bytes());
     }
 
     #[test]

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_api::mailbox::CommandId as CaliptraCommandId;
 pub use caliptra_api::mailbox::{
     CmAesDecryptInitReq, CmAesDecryptUpdateReq, CmAesEncryptInitReq, CmAesEncryptInitResp,
     CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq, CmAesGcmDecryptFinalReq,
@@ -1324,7 +1325,10 @@ impl Response for McuProdDebugUnlockReqResp {}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
-pub struct McuProdDebugUnlockTokenReq(pub ProductionAuthDebugUnlockToken);
+pub struct McuProdDebugUnlockTokenReq {
+    pub hdr: MailboxReqHeader,
+    pub token: ProductionAuthDebugUnlockToken,
+}
 impl Request for McuProdDebugUnlockTokenReq {
     const ID: CommandId = CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN;
     type Resp = McuProdDebugUnlockTokenResp;
@@ -1332,7 +1336,25 @@ impl Request for McuProdDebugUnlockTokenReq {
 
 impl Default for McuProdDebugUnlockTokenReq {
     fn default() -> Self {
-        Self(ProductionAuthDebugUnlockToken::new_zeroed())
+        Self {
+            hdr: MailboxReqHeader::default(),
+            token: ProductionAuthDebugUnlockToken::new_zeroed(),
+        }
+    }
+}
+
+impl McuProdDebugUnlockTokenReq {
+    /// Populate the Caliptra command checksum carried inside the token.
+    pub fn populate_caliptra_chksum(&mut self) -> McuMboxResult<()> {
+        let token_bytes = self.token.as_bytes();
+        let token_body = token_bytes
+            .get(size_of::<MailboxReqHeader>()..)
+            .ok_or(McuMboxError::MCU_RUNTIME_INSUFFICIENT_MEMORY)?;
+        self.token.hdr.chksum = calc_checksum(
+            CaliptraCommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.into(),
+            token_body,
+        );
+        Ok(())
     }
 }
 

--- a/firmware-bundler/reference/fpga/user-app.toml
+++ b/firmware-bundler/reference/fpga/user-app.toml
@@ -30,5 +30,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0xae00
+stack = 0x9e00
 grant_space = 0x4000

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -7,7 +7,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-arrayvec.workspace = true
 async-trait.workspace = true
 caliptra-api.workspace = true
 constant_time_eq.workspace = true
@@ -73,6 +72,13 @@ streaming-boot = []
 flash-boot = []
 firmware-update = []
 mcu-mbox-service = []
+# Test-only mock command HANDLER: device-identity queries (firmware version,
+# device ID, UID, capabilities) return hardcoded `config::TEST_*` values for
+# integration tests. Off by default — production wires the real
+# `CaliptraCmdBackend`, whose unimplemented info queries return
+# `UnsupportedOperation`. (The command *authorizer* is separate and stays wired
+# in production; only the handler is gated here.)
+mcu-mbox-test-handlers = ["mcu-mbox-service"]
 # Measurement boot init (off by default). Runs DPE Handle Storage / Software PCR
 # Storage cold-boot and hitless-update initialization. Cold boot rotates MCU-RT
 # off the default DPE handle, so keep this off until the SPDM evidence path is
@@ -137,21 +143,21 @@ test-mcu-rom-flash-access = []
 test-mctp-capsule-loopback = []
 # --- Test features: user-app ---
 test-do-nothing = []
-test-defmt-logging-mailbox = ["userspace-log", "mcu-mbox-service"]
-test-defmt-logging-release = ["userspace-log", "mcu-mbox-service"]
-test-defmt-logging-vdm = ["userspace-log", "mcu-mbox-service", "mctp-vdm-service"]
+test-defmt-logging-mailbox = ["userspace-log", "mcu-mbox-test-handlers"]
+test-defmt-logging-release = ["userspace-log", "mcu-mbox-test-handlers"]
+test-defmt-logging-vdm = ["userspace-log", "mcu-mbox-test-handlers", "mctp-vdm-service"]
 test-flash-based-boot = ["flash-boot"]
 test-firmware-activate = ["firmware-update"]
 test-firmware-update-flash = ["flash-boot", "firmware-update"]
 test-firmware-update-streaming = []
 test-firmware-v2 = []
 test-streaming-boot-flash-write-back = ["streaming-boot", "firmware-update"]
-test-mcu-mbox-fips-periodic = ["mcu-mbox-service", "caliptra-mcu-mbox-lib/periodic-fips-self-test"]
+test-mcu-mbox-fips-periodic = ["mcu-mbox-test-handlers", "caliptra-mcu-mbox-lib/periodic-fips-self-test"]
 test-mctp-vdm-cmds = ["mctp-vdm-service"]
 test-caliptra-util-host-mctp-vdm-validator = ["mctp-vdm-service"]
-test-caliptra-util-host-validator = ["mcu-mbox-service"]
-test-mcu-mbox-cmds = ["mcu-mbox-service"]
-test-mcu-mbox-fips-self-test = ["mcu-mbox-service"]
+test-caliptra-util-host-validator = ["mcu-mbox-test-handlers"]
+test-mcu-mbox-cmds = ["mcu-mbox-test-handlers"]
+test-mcu-mbox-fips-self-test = ["mcu-mbox-test-handlers"]
 test-pldm-discovery = []
 test-pldm-fw-update = []
 test-pldm-fw-update-e2e = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -1,0 +1,169 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_mcu_common_commands::{
+    CaliptraCmdResult, CaliptraCompletionCode, DEBUG_UNLOCK_CHALLENGE_SIZE,
+    DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
+};
+use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_platform::ErrorCode;
+use constant_time_eq::constant_time_eq;
+use mcu_caliptra_api_lite::{
+    cm_hmac, cm_import, fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87,
+    request_debug_unlock_challenge, rng_generate, ApiAlloc, CmKeyUsage, McuErrorCode,
+    PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
+};
+
+const ALGO_ECC_P384: u32 = 0x0001;
+const ALGO_MLDSA87: u32 = 0x0002;
+
+/// Symmetric test HMAC key used by emulator command-auth validator paths.
+///
+/// This is not a production secret source; production should provision or
+/// derive authorization material outside firmware.
+pub(crate) const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
+    0x72, 0xec, 0x12, 0x02, 0x77, 0x69, 0xb9, 0xdc, 0x04, 0xbd, 0xd0, 0xc0, 0x86, 0xca, 0x1b, 0x20,
+    0x2f, 0x47, 0x1e, 0xee, 0xf2, 0x8c, 0x2d, 0xa8, 0xc5, 0x4c, 0x75, 0xc2, 0x48, 0xa6, 0x80, 0x0a,
+    0x11, 0xbf, 0xd5, 0xcd, 0x09, 0xed, 0x57, 0x0c, 0xb4, 0xc2, 0xa1, 0x37, 0x6b, 0xa2, 0xcb, 0xcd,
+];
+
+pub async fn request_debug_unlock<A: ApiAlloc>(
+    alloc: &A,
+    unlock_level: u8,
+    out: &mut [u8],
+) -> CaliptraCmdResult<usize> {
+    let needed = DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
+    if out.len() < needed {
+        return Err(CaliptraCompletionCode::InsufficientResources);
+    }
+
+    request_debug_unlock_challenge(alloc, unlock_level, out)
+        .await
+        .map_err(map_mcu_err)
+}
+
+/// Relay a debug-unlock token to Caliptra.
+///
+/// The debug-unlock token is (potentially) delivered in streamed chunks, so
+/// firmware cannot recompute a `MailboxReqHeader` checksum over data it never
+/// fully buffers. The requester therefore supplies the checksum as part of a
+/// complete Caliptra RT mailbox request, and both transports (MCU mailbox and
+/// SPDM VDM) relay it as a pure pass-through — firmware never synthesizes a
+/// header. This differs from other Caliptra commands, whose checksum the lite
+/// API builds from in-firmware parameters.
+pub async fn authorize_debug_unlock_token<A: ApiAlloc>(
+    _alloc: &A,
+    token_request: &[u8],
+) -> CaliptraCmdResult<()> {
+    // 8-byte response header is a write-only throwaway, so use a stack buffer.
+    // `_alloc` is kept for a uniform device-op signature but ignored at this size.
+    let mut resp_buf = [0u8; PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN];
+
+    Mailbox::<DefaultSyscalls>::new()
+        .execute_with_payload_slice(
+            PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD,
+            None,
+            token_request,
+            &mut resp_buf,
+        )
+        .await
+        .map_err(map_mailbox_error)?;
+    Ok(())
+}
+
+pub async fn export_attested_csr(
+    device_key_id: u32,
+    algorithm: u32,
+    nonce: &[u8; 32],
+    out: &mut [u8],
+) -> CaliptraCmdResult<usize> {
+    let result = match algorithm {
+        ALGO_ECC_P384 => get_attested_csr_ecc384(device_key_id, nonce, out).await,
+        ALGO_MLDSA87 => get_attested_csr_mldsa87(device_key_id, nonce, out).await,
+        _ => return Err(CaliptraCompletionCode::InvalidParameter),
+    };
+    result.map_err(map_mcu_err)
+}
+
+pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResult<[u8; 32]> {
+    let mut challenge = [0u8; 32];
+    rng_generate(alloc, &mut challenge)
+        .await
+        .map_err(map_mcu_err)?;
+    Ok(challenge)
+}
+
+pub async fn verify_authorized_mac<A: ApiAlloc>(
+    alloc: &A,
+    key: &[u8],
+    cmd_id: u32,
+    payload: &[u8],
+    challenge: &[u8; 32],
+    mac: &[u8; 48],
+) -> CaliptraCmdResult<()> {
+    let cmk = cm_import(alloc, CmKeyUsage::Hmac, key)
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+    let input_len = core::mem::size_of::<u32>()
+        .checked_add(payload.len())
+        .and_then(|len| len.checked_add(challenge.len()))
+        .filter(|len| *len <= 256)
+        .ok_or(CaliptraCompletionCode::InsufficientResources)?;
+    // Keep the larger staging buffer in scratch so it does not inflate task state.
+    let mut hmac_input = alloc
+        .alloc(input_len)
+        .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
+    let (cmd_out, remainder) = hmac_input
+        .split_at_mut_checked(core::mem::size_of::<u32>())
+        .ok_or(CaliptraCompletionCode::InsufficientResources)?;
+    cmd_out.copy_from_slice(&cmd_id.to_be_bytes());
+    let (payload_out, challenge_out) = remainder
+        .split_at_mut_checked(payload.len())
+        .ok_or(CaliptraCompletionCode::InsufficientResources)?;
+    payload_out.copy_from_slice(payload);
+    challenge_out.copy_from_slice(challenge);
+
+    let mut computed_mac = [0u8; 48];
+    let mac_len = cm_hmac(alloc, &cmk, &hmac_input, &mut computed_mac)
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    if mac_len != 48 {
+        return Err(CaliptraCompletionCode::OperationFailed);
+    }
+
+    if constant_time_eq(&computed_mac, mac) {
+        Ok(())
+    } else {
+        Err(CaliptraCompletionCode::AccessDenied)
+    }
+}
+
+pub async fn program_field_entropy<A: ApiAlloc>(
+    alloc: &A,
+    partition: u32,
+) -> CaliptraCmdResult<()> {
+    fe_prog(alloc, partition).await.map_err(map_mcu_err)
+}
+
+pub(crate) fn map_mcu_err(e: McuErrorCode) -> CaliptraCompletionCode {
+    use mcu_error::codes;
+    if e == codes::MAILBOX_BUSY {
+        CaliptraCompletionCode::CaliptraMailboxBusy
+    } else if e == codes::INVARIANT || e == codes::INTERNAL_BUG {
+        CaliptraCompletionCode::OperationFailed
+    } else if e.domain() == mcu_error::domain::MEMORY {
+        CaliptraCompletionCode::InsufficientResources
+    } else {
+        CaliptraCompletionCode::GeneralError
+    }
+}
+
+pub(crate) fn map_mailbox_error(e: MailboxError) -> CaliptraCompletionCode {
+    match e {
+        MailboxError::ErrorCode(ErrorCode::Busy) => CaliptraCompletionCode::CaliptraMailboxBusy,
+        MailboxError::ErrorCode(_) | MailboxError::MailboxError(_) => {
+            CaliptraCompletionCode::OperationFailed
+        }
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -1,22 +1,16 @@
 // Licensed under the Apache-2.0 license
 
-extern crate alloc;
-
 pub(crate) mod debug_log;
+pub(crate) mod device_ops;
 
-use alloc::boxed::Box;
-use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
     DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, LogType,
 };
-use caliptra_mcu_libapi_caliptra::certificate::{CertContext, IDEV_ECC_CSR_MAX_SIZE};
-use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
-use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
+use mcu_caliptra_api_lite::ApiAlloc;
 
 pub struct CaliptraCmdBackend;
 
-#[async_trait]
 impl CaliptraCmdHandler for CaliptraCmdBackend {
     async fn get_firmware_version(
         &self,
@@ -41,75 +35,15 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
 
-    async fn export_attested_csr(
+    async fn export_attested_csr<Alloc: ApiAlloc>(
         &self,
+        _alloc: &Alloc,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize> {
-        let algo =
-            AsymAlgo::try_from_u32(algorithm).ok_or(CaliptraCompletionCode::InvalidParameter)?;
-
-        let mut cert_ctx = CertContext::new();
-
-        let len = cert_ctx
-            .get_attested_csr(algo, device_key_id, nonce, csr_buf)
-            .await
-            .map_err(|e| match e {
-                CaliptraApiError::MailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
-                CaliptraApiError::BufferTooSmall => CaliptraCompletionCode::CaliptraBufferTooSmall,
-                CaliptraApiError::InvalidResponse
-                | CaliptraApiError::Mailbox(_)
-                | CaliptraApiError::Syscall(_) => CaliptraCompletionCode::OperationFailed,
-                // Any other variant is not produced by get_attested_csr's call
-                // chain today. Reaching here means a deeper call started
-                // returning an unanticipated variant — surface it loudly.
-                _ => CaliptraCompletionCode::GeneralError,
-            })?;
-
-        Ok(len)
-    }
-
-    async fn export_idevid_csr(
-        &self,
-        algorithm: u32,
-        csr_buf: &mut [u8],
-    ) -> CaliptraCmdResult<usize> {
-        let algo =
-            AsymAlgo::try_from_u32(algorithm).ok_or(CaliptraCompletionCode::InvalidParameter)?;
-
-        let mut cert_ctx = CertContext::new();
-
-        match algo {
-            AsymAlgo::EccP384 => {
-                let mut csr_der = [0u8; IDEV_ECC_CSR_MAX_SIZE];
-                let len = cert_ctx
-                    .get_idev_csr(&mut csr_der)
-                    .await
-                    .map_err(|e| match e {
-                        CaliptraApiError::MailboxBusy => {
-                            CaliptraCompletionCode::CaliptraMailboxBusy
-                        }
-                        CaliptraApiError::UnprovisionedCsr => CaliptraCompletionCode::InvalidState,
-                        CaliptraApiError::InvalidResponse
-                        | CaliptraApiError::Mailbox(_)
-                        | CaliptraApiError::Syscall(_) => CaliptraCompletionCode::OperationFailed,
-                        // Any other variant is not produced by get_idev_csr's
-                        // call chain today; surface it as GeneralError.
-                        _ => CaliptraCompletionCode::GeneralError,
-                    })?;
-                if len > csr_buf.len() {
-                    return Err(CaliptraCompletionCode::CaliptraBufferTooSmall);
-                }
-                csr_buf[..len].copy_from_slice(&csr_der[..len]);
-                Ok(len)
-            }
-            AsymAlgo::MlDsa87 => {
-                // MLDSA IDevID CSR not yet supported at the mailbox level
-                Err(CaliptraCompletionCode::UnsupportedOperation)
-            }
-        }
+        device_ops::export_attested_csr(device_key_id, algorithm, nonce, csr_buf).await
     }
 
     /// Drain entries of `log_type` from the backing store.
@@ -136,98 +70,42 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         }
     }
 
-    async fn program_field_entropy(&self, partition: u32) -> CaliptraCmdResult<()> {
-        use caliptra_api::mailbox::{CommandId, FeProgReq};
-        use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
-        use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
-        use zerocopy::IntoBytes;
-
-        let mailbox = Mailbox::new();
-        let mut req = FeProgReq {
-            partition,
-            ..Default::default()
-        };
-
-        let mut resp_buf = [0u8; 8];
-        execute_mailbox_cmd(
-            &mailbox,
-            CommandId::FE_PROG.0,
-            req.as_mut_bytes(),
-            &mut resp_buf,
-        )
-        .await
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
-        Ok(())
+    async fn program_field_entropy<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        partition: u32,
+    ) -> CaliptraCmdResult<()> {
+        device_ops::program_field_entropy(alloc, partition).await
     }
 
-    async fn request_debug_unlock(
+    async fn request_debug_unlock<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         unlock_level: u8,
         challenge: &mut DebugUnlockChallenge,
     ) -> CaliptraCmdResult<()> {
-        use caliptra_api::mailbox::{
-            CommandId, MailboxReqHeader, ProductionAuthDebugUnlockChallenge,
-            ProductionAuthDebugUnlockReq,
-        };
-        use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
-        use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
-        use zerocopy::{FromBytes, IntoBytes};
-
-        let mailbox = Mailbox::new();
-        let mut req = ProductionAuthDebugUnlockReq {
-            hdr: MailboxReqHeader::default(),
-            length: 2,
-            unlock_level,
-            reserved: [0; 3],
-        };
-
-        let mut resp_buf = [0u8; core::mem::size_of::<ProductionAuthDebugUnlockChallenge>()];
-
-        execute_mailbox_cmd(
-            &mailbox,
-            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.0,
-            req.as_mut_bytes(),
-            &mut resp_buf,
-        )
-        .await
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
-        let resp = ProductionAuthDebugUnlockChallenge::ref_from_bytes(&resp_buf)
-            .map_err(|_| CaliptraCompletionCode::GeneralError)?;
-
-        challenge
-            .unique_device_identifier
-            .copy_from_slice(&resp.unique_device_identifier);
-        challenge.challenge.copy_from_slice(&resp.challenge);
-
+        let mut out = [0u8; caliptra_mcu_common_commands::DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
+            + caliptra_mcu_common_commands::DEBUG_UNLOCK_CHALLENGE_SIZE];
+        let len = device_ops::request_debug_unlock(alloc, unlock_level, &mut out).await?;
+        if len != out.len() {
+            return Err(CaliptraCompletionCode::OperationFailed);
+        }
+        challenge.unique_device_identifier.copy_from_slice(
+            &out[..caliptra_mcu_common_commands::DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+        );
+        challenge.challenge.copy_from_slice(
+            &out[caliptra_mcu_common_commands::DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE..],
+        );
         Ok(())
     }
 
-    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
-        use alloc::vec;
-        use caliptra_api::mailbox::{CommandId, MailboxReqHeader, MailboxRespHeader};
-        use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
-        use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
-
-        let mailbox = Mailbox::new();
-
-        // Build full request: MailboxReqHeader (zeroed, checksum computed by execute_mailbox_cmd) + token_data
-        let hdr_len = core::mem::size_of::<MailboxReqHeader>();
-        let mut req = vec![0u8; hdr_len + token_data.len()];
-        req[hdr_len..].copy_from_slice(token_data);
-
-        let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
-
-        execute_mailbox_cmd(
-            &mailbox,
-            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.0,
-            &mut req,
-            &mut resp_buf,
-        )
-        .await
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
-        Ok(())
+    async fn authorize_debug_unlock_token<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        token_request: &[u8],
+    ) -> CaliptraCmdResult<()> {
+        // Pass-through: the requester sends a complete Caliptra request
+        // (including the mailbox checksum header), identical to the VDM path.
+        device_ops::authorize_debug_unlock_token(alloc, token_request).await
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -1,37 +1,21 @@
 // Licensed under the Apache-2.0 license
-use async_trait::async_trait;
 use caliptra_mcu_common_commands::{AuthorizationError, AuthorizationResult, CommandAuthorizer};
-use caliptra_mcu_libapi_caliptra::crypto::hmac::Hmac;
-use caliptra_mcu_libapi_caliptra::crypto::import::{CmKeyUsage, Import};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq,
     MailboxReqHeader, McuFeProgReq, ProvisionVendorPkHashReq,
 };
-use constant_time_eq::constant_time_eq;
 use core::mem::size_of;
-use zerocopy::IntoBytes;
-extern crate alloc;
-use alloc::boxed::Box;
-
-/// NOTE: because this is a symmetric secret, this should come from a provisioned secret from OTP
-/// instead of embedded into firmware. To keep the implementation generic, this does not add OTP
-/// syscalls to get this value, in case a platform chooses another verification method like
-/// asymmetric key verification.
-const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
-    0x72, 0xec, 0x12, 0x02, 0x77, 0x69, 0xb9, 0xdc, 0x04, 0xbd, 0xd0, 0xc0, 0x86, 0xca, 0x1b, 0x20,
-    0x2f, 0x47, 0x1e, 0xee, 0xf2, 0x8c, 0x2d, 0xa8, 0xc5, 0x4c, 0x75, 0xc2, 0x48, 0xa6, 0x80, 0x0a,
-    0x11, 0xbf, 0xd5, 0xcd, 0x09, 0xed, 0x57, 0x0c, 0xb4, 0xc2, 0xa1, 0x37, 0x6b, 0xa2, 0xcb, 0xcd,
-];
+use mcu_caliptra_api_lite::ApiAlloc;
 
 #[derive(Default)]
 pub struct MockCommandAuthorizer {
     challenge: Option<[u8; 32]>,
 }
 
-#[async_trait]
 impl CommandAuthorizer for MockCommandAuthorizer {
-    async fn is_authorized<'a>(
+    async fn is_authorized<'a, Alloc: ApiAlloc>(
         &mut self,
+        alloc: &Alloc,
         cmd_id: CommandId,
         req: &'a [u8],
     ) -> AuthorizationResult<&'a [u8]> {
@@ -52,41 +36,31 @@ impl CommandAuthorizer for MockCommandAuthorizer {
             .get(size_of::<MailboxReqHeader>()..cmd_len)
             .ok_or(AuthorizationError)?;
 
-        self.verify_mac(u32::from(cmd_id), cmd_body, received_mac)
+        self.verify_mac(alloc, u32::from(cmd_id), cmd_body, received_mac)
             .await?;
 
         Ok(&req[..cmd_len])
     }
 
-    async fn verify_mac(
+    async fn verify_mac<Alloc: ApiAlloc>(
         &mut self,
+        alloc: &Alloc,
         cmd_id: u32,
         payload: &[u8],
         mac: &[u8],
     ) -> Result<(), AuthorizationError> {
         let challenge = self.challenge.take().ok_or(AuthorizationError)?;
-
-        // Import the key using Caliptra API
-        let import_resp = Import::import(CmKeyUsage::Hmac, &TEST_AUTH_CMD_HMAC_KEY)
-            .await
-            .map_err(|_| AuthorizationError)?;
-
-        // Reconstruct the buffer to hash: cmd_id(BE,4) + payload + challenge(32)
-        let mut buf = arrayvec::ArrayVec::<u8, 256>::new();
-        buf.extend(cmd_id.to_be_bytes());
-        buf.extend(payload.iter().copied());
-        buf.extend(challenge.iter().copied());
-
-        // Compute HMAC using Caliptra API
-        let hmac_resp = Hmac::hmac(&import_resp.cmk, buf.as_slice())
-            .await
-            .map_err(|_| AuthorizationError)?;
-
-        let computed_mac = &hmac_resp.mac.as_bytes()[..48];
-
-        if !constant_time_eq(computed_mac, mac) {
-            Err(AuthorizationError)?;
-        }
+        let mac: &[u8; 48] = mac.try_into().map_err(|_| AuthorizationError)?;
+        crate::caliptra_cmd_handler::device_ops::verify_authorized_mac(
+            alloc,
+            &crate::caliptra_cmd_handler::device_ops::TEST_AUTH_CMD_HMAC_KEY,
+            cmd_id,
+            payload,
+            &challenge,
+            mac,
+        )
+        .await
+        .map_err(|_| AuthorizationError)?;
         Ok(())
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -1,15 +1,12 @@
 // Licensed under the Apache-2.0 license
 
-extern crate alloc;
-
-use alloc::boxed::Box;
-use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
     DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, Uid,
     MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use caliptra_mcu_mbox_common::config;
+use mcu_caliptra_api_lite::ApiAlloc;
 
 use crate::caliptra_cmd_handler::CaliptraCmdBackend;
 
@@ -22,7 +19,6 @@ pub struct NonCryptoCmdHandlerMock;
 /// This handler provides mock responses for firmware version queries,
 /// device ID, device information, and device capabilities. Intended to use for
 /// integration testing on the emulator platform.
-#[async_trait]
 impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
     async fn get_firmware_version(
         &self,
@@ -89,8 +85,9 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         Ok(())
     }
 
-    async fn export_attested_csr(
+    async fn export_attested_csr<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
@@ -99,32 +96,31 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         // Delegate to real CaliptraCmdBackend for actual Caliptra mailbox interaction
         let handler = CaliptraCmdBackend;
         handler
-            .export_attested_csr(device_key_id, algorithm, nonce, csr_buf)
+            .export_attested_csr(alloc, device_key_id, algorithm, nonce, csr_buf)
             .await
     }
 
-    async fn export_idevid_csr(
+    async fn request_debug_unlock<Alloc: ApiAlloc>(
         &self,
-        algorithm: u32,
-        csr_buf: &mut [u8],
-    ) -> CaliptraCmdResult<usize> {
-        // Delegate to real CaliptraCmdBackend for actual Caliptra mailbox interaction
-        let handler = CaliptraCmdBackend;
-        handler.export_idevid_csr(algorithm, csr_buf).await
-    }
-
-    async fn request_debug_unlock(
-        &self,
+        alloc: &Alloc,
         unlock_level: u8,
         challenge: &mut DebugUnlockChallenge,
     ) -> CaliptraCmdResult<()> {
         let handler = CaliptraCmdBackend;
-        handler.request_debug_unlock(unlock_level, challenge).await
+        handler
+            .request_debug_unlock(alloc, unlock_level, challenge)
+            .await
     }
 
-    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
+    async fn authorize_debug_unlock_token<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        token_request: &[u8],
+    ) -> CaliptraCmdResult<()> {
         let handler = CaliptraCmdBackend;
-        handler.authorize_debug_unlock_token(token_data).await
+        handler
+            .authorize_debug_unlock_token(alloc, token_request)
+            .await
     }
 
     async fn get_log(&self, log_type: u32, data: &mut [u8]) -> CaliptraCmdResult<GetLogResult> {
@@ -137,7 +133,13 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         CaliptraCmdBackend.clear_log(log_type).await
     }
 
-    async fn program_field_entropy(&self, partition: u32) -> CaliptraCmdResult<()> {
-        CaliptraCmdBackend.program_field_entropy(partition).await
+    async fn program_field_entropy<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        partition: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .program_field_entropy(alloc, partition)
+            .await
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -2,19 +2,52 @@
 
 #[cfg(feature = "mcu-mbox-service")]
 pub(crate) mod cmd_auth_mock;
-#[cfg(feature = "mcu-mbox-service")]
+#[cfg(feature = "mcu-mbox-test-handlers")]
 mod cmd_handler_mock;
 
 use caliptra_mcu_libsyscall_caliptra::system::System;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
 use caliptra_mcu_libtock_platform::ErrorCode;
+#[cfg(feature = "mcu-mbox-service")]
+use caliptra_mcu_mbox_lib::cmd_interface::McuMboxScratch;
+#[cfg(feature = "mcu-mbox-service")]
+use caliptra_mcu_spdm_pal::{
+    BitmapAllocator, BitmapBytes, StaticBitmapAllocatorCell, BITMAP_SLOT_SIZE,
+};
 #[allow(unused_imports)]
 use core::fmt::Write;
+#[cfg(feature = "mcu-mbox-service")]
+use core::ptr::NonNull;
 #[allow(unused)]
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[allow(unused)]
 use embassy_sync::signal::Signal;
+
+#[cfg(feature = "mcu-mbox-service")]
+const MCU_MBOX_SCRATCH_SIZE: usize = 12 * 1024;
+
+#[cfg(feature = "mcu-mbox-service")]
+struct McuMboxScratchAlloc(&'static BitmapAllocator);
+
+#[cfg(feature = "mcu-mbox-service")]
+impl mcu_caliptra_api_lite::ApiAlloc for McuMboxScratchAlloc {
+    type Buf<'a>
+        = BitmapBytes<'a>
+    where
+        Self: 'a;
+
+    fn alloc(&self, len: usize) -> mcu_error::McuResult<Self::Buf<'_>> {
+        self.0.alloc_bytes(len)
+    }
+}
+
+#[cfg(feature = "mcu-mbox-service")]
+impl McuMboxScratch for McuMboxScratchAlloc {
+    fn shrink(buf: &mut BitmapBytes<'_>, new_len: usize) -> mcu_error::McuResult<()> {
+        buf.shrink(new_len)
+    }
+}
 
 #[embassy_executor::task]
 pub async fn mcu_mbox_task() {
@@ -32,7 +65,32 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
 
     #[cfg(feature = "mcu-mbox-service")]
     {
+        #[repr(C, align(64))]
+        struct ScratchBuf([u8; MCU_MBOX_SCRATCH_SIZE]);
+        static mut MCU_MBOX_SCRATCH: ScratchBuf = ScratchBuf([0u8; MCU_MBOX_SCRATCH_SIZE]);
+        // SAFETY: this task is the sole owner of `MCU_MBOX_SCRATCH`.
+        let scratch_ptr: NonNull<u8> =
+            unsafe { NonNull::new_unchecked(MCU_MBOX_SCRATCH.0.as_mut_ptr()) };
+        debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
+
+        // SAFETY: `init_once` is called once per task lifetime; backing memory
+        // (`MCU_MBOX_SCRATCH`) is `'static` and exclusive to this task.
+        static MCU_MBOX_ALLOC_CELL: StaticBitmapAllocatorCell = StaticBitmapAllocatorCell::new();
+        let scratch_allocator: &'static BitmapAllocator =
+            unsafe { MCU_MBOX_ALLOC_CELL.init_once(scratch_ptr, MCU_MBOX_SCRATCH_SIZE) };
+        let scratch = McuMboxScratchAlloc(scratch_allocator);
+
+        // Command handler: production wires the real `CaliptraCmdBackend`
+        // (unimplemented device-identity queries return `UnsupportedOperation`).
+        // Test builds (`mcu-mbox-test-handlers`) wire the mock that returns
+        // `config::TEST_*` identity for integration tests.
+        #[cfg(feature = "mcu-mbox-test-handlers")]
         let handler = cmd_handler_mock::NonCryptoCmdHandlerMock;
+        #[cfg(not(feature = "mcu-mbox-test-handlers"))]
+        let handler = crate::caliptra_cmd_handler::CaliptraCmdBackend;
+        // Authorizer: HMAC-based command authorization stays wired in production
+        // (uses a placeholder test key for now; to be replaced with real
+        // provisioned key material later).
         let mut cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer::default();
         let mut transport = caliptra_mcu_mbox_lib::transport::McuMboxTransport::new(
             caliptra_mcu_libsyscall_caliptra::mcu_mbox::MCU_MBOX0_DRIVER_NUM,
@@ -41,7 +99,7 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
             &handler,
             &mut cmd_authorizer,
             &mut transport,
-            crate::EXECUTOR.get().spawner(),
+            &scratch,
         );
         crate::log_info!(
             console_writer,

--- a/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
@@ -9,7 +9,7 @@ use caliptra_mcu_libtock::runtime::set_main;
 use core::fmt::Write;
 use core::mem::MaybeUninit;
 use embedded_alloc::Heap;
-const HEAP_SIZE: usize = 0x6000;
+const HEAP_SIZE: usize = 0x2000;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -7,42 +7,24 @@
 //! VDM commands. The protocol/dispatch/framing all live in the
 //! `caliptra-mcu-spdm-vdm-handler` lib; this hook only supplies the device ops.
 
-extern crate alloc;
-
-use arrayvec::ArrayVec;
 use caliptra_mcu_common_commands::{
     CaliptraCompletionCode as CommonCompletionCode, GetLogResult, DEBUG_UNLOCK_CHALLENGE_SIZE,
     DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
 };
 use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
-use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::{
     CaliptraCompletionCode, CaliptraVdmCommands, CaliptraVdmLogResult, CaliptraVdmResult,
 };
-use constant_time_eq::constant_time_eq;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use mcu_caliptra_api_lite::{
-    cm_hmac, cm_import, fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87,
-    request_debug_unlock_challenge, rng_generate, ApiAlloc, CmKeyUsage, McuErrorCode,
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
 
-/// AsymAlgo wire encoding (`EccP384 = 1`, `MlDsa87 = 2`), mirrored locally so
-/// the hook does not depend on caliptra-api.
-const ALGO_ECC_P384: u32 = 0x0001;
-const ALGO_MLDSA87: u32 = 0x0002;
-
 /// HMAC command ID used by the host for the FE_PROG authorized sub-command.
 const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
-/// Symmetric test HMAC key used by the emulator validator path.
-const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
-    0x72, 0xec, 0x12, 0x02, 0x77, 0x69, 0xb9, 0xdc, 0x04, 0xbd, 0xd0, 0xc0, 0x86, 0xca, 0x1b, 0x20,
-    0x2f, 0x47, 0x1e, 0xee, 0xf2, 0x8c, 0x2d, 0xa8, 0xc5, 0x4c, 0x75, 0xc2, 0x48, 0xa6, 0x80, 0x0a,
-    0x11, 0xbf, 0xd5, 0xcd, 0x09, 0xed, 0x57, 0x0c, 0xb4, 0xc2, 0xa1, 0x37, 0x6b, 0xa2, 0xcb, 0xcd,
-];
 
 static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex::new(None);
 // Kernel chunked-mailbox state rejects other processes; this flag serializes this
@@ -101,9 +83,9 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
             return Err(CaliptraCompletionCode::InsufficientResources);
         }
 
-        request_debug_unlock_challenge(scratch, unlock_level, out)
+        crate::caliptra_cmd_handler::device_ops::request_debug_unlock(scratch, unlock_level, out)
             .await
-            .map_err(map_mcu_err)
+            .map_err(map_common_completion)
     }
 
     async fn authorize_debug_unlock_token<A: SpdmPalAlloc>(
@@ -111,18 +93,12 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         token_data: &[u8],
         scratch: &A,
     ) -> CaliptraVdmResult<()> {
-        let cmd = PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD;
         // The host sends AuthorizeDebugUnlockToken as a complete Caliptra RT
         // mailbox request, including MailboxReqHeader.checksum. Preserve those
         // payload bytes exactly; do not synthesize another mailbox header here.
-        let mut resp_buf = ApiAlloc::alloc(scratch, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN)
-            .map_err(map_mcu_err)?;
-
-        Mailbox::<DefaultSyscalls>::new()
-            .execute_with_payload_slice(cmd, None, token_data, &mut resp_buf)
+        crate::caliptra_cmd_handler::device_ops::authorize_debug_unlock_token(scratch, token_data)
             .await
-            .map_err(map_mailbox_error)?;
-        Ok(())
+            .map_err(map_common_completion)
     }
 
     async fn start_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
@@ -176,26 +152,24 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
 
     async fn finish_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
         &self,
-        scratch: &A,
+        _scratch: &A,
     ) -> CaliptraVdmResult<()> {
         let mut active = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
         if !*active {
             return Err(CaliptraCompletionCode::InvalidState);
         }
         let mailbox = Mailbox::<DefaultSyscalls>::new();
-        let mut resp_buf =
-            match ApiAlloc::alloc(scratch, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN) {
-                Ok(buf) => buf,
-                Err(err) => {
-                    let _ = mailbox.abort_chunked_request().await;
-                    *active = false;
-                    return Err(map_mcu_err(err));
-                }
-            };
+        // 8-byte response header is a write-only throwaway; a stack buffer avoids
+        // the scratch alloc and its failure/cleanup path for a fixed tiny size.
+        let mut resp_buf = [0u8; PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN];
         let result = mailbox
             .execute_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp_buf)
             .await
-            .map_err(map_mailbox_error);
+            .map_err(|e| {
+                map_common_completion(crate::caliptra_cmd_handler::device_ops::map_mailbox_error(
+                    e,
+                ))
+            });
         *active = false;
         result?;
         Ok(())
@@ -219,12 +193,14 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         _scratch: &A,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize> {
-        let result = match algorithm {
-            ALGO_ECC_P384 => get_attested_csr_ecc384(device_key_id, nonce, out).await,
-            ALGO_MLDSA87 => get_attested_csr_mldsa87(device_key_id, nonce, out).await,
-            _ => return Err(CaliptraCompletionCode::InvalidParameter),
-        };
-        result.map_err(map_mcu_err)
+        crate::caliptra_cmd_handler::device_ops::export_attested_csr(
+            device_key_id,
+            algorithm,
+            nonce,
+            out,
+        )
+        .await
+        .map_err(map_common_completion)
     }
 
     async fn get_auth_challenge<A: SpdmPalAlloc>(
@@ -232,10 +208,9 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         scratch: &A,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize> {
-        let mut challenge = [0u8; 32];
-        rng_generate(scratch, &mut challenge)
+        let challenge = crate::caliptra_cmd_handler::device_ops::generate_auth_challenge(scratch)
             .await
-            .map_err(map_mcu_err)?;
+            .map_err(map_common_completion)?;
         *AUTH_CHALLENGE.lock().await = Some(challenge);
         copy_bytes(&challenge, out)
     }
@@ -247,30 +222,16 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         scratch: &A,
     ) -> CaliptraVdmResult<()> {
         verify_fe_prog_mac(scratch, partition, mac).await?;
-        fe_prog(scratch, partition).await.map_err(map_mcu_err)
-    }
-}
-
-fn map_mcu_err(e: McuErrorCode) -> CaliptraCompletionCode {
-    use mcu_error::codes;
-    if e == codes::MAILBOX_BUSY {
-        CaliptraCompletionCode::CaliptraMailboxBusy
-    } else if e == codes::INVARIANT || e == codes::INTERNAL_BUG {
-        CaliptraCompletionCode::OperationFailed
-    } else if e.domain() == mcu_error::domain::MEMORY {
-        CaliptraCompletionCode::InsufficientResources
-    } else {
-        CaliptraCompletionCode::GeneralError
+        crate::caliptra_cmd_handler::device_ops::program_field_entropy(scratch, partition)
+            .await
+            .map_err(map_common_completion)
     }
 }
 
 fn map_mailbox_error(e: MailboxError) -> CaliptraCompletionCode {
-    match e {
-        MailboxError::ErrorCode(ErrorCode::Busy) => CaliptraCompletionCode::CaliptraMailboxBusy,
-        MailboxError::ErrorCode(_) | MailboxError::MailboxError(_) => {
-            CaliptraCompletionCode::OperationFailed
-        }
-    }
+    map_common_completion(crate::caliptra_cmd_handler::device_ops::map_mailbox_error(
+        e,
+    ))
 }
 
 fn copy_bytes(src: &[u8], out: &mut [u8]) -> CaliptraVdmResult<usize> {
@@ -283,7 +244,7 @@ fn copy_bytes(src: &[u8], out: &mut [u8]) -> CaliptraVdmResult<usize> {
     Ok(src.len())
 }
 
-async fn verify_fe_prog_mac<A: ApiAlloc>(
+async fn verify_fe_prog_mac<A: mcu_caliptra_api_lite::ApiAlloc>(
     scratch: &A,
     partition: u32,
     mac: &[u8; 48],
@@ -293,34 +254,18 @@ async fn verify_fe_prog_mac<A: ApiAlloc>(
         .await
         .take()
         .ok_or(CaliptraCompletionCode::AccessDenied)?;
+    let partition_bytes = partition.to_le_bytes();
 
-    let cmk = cm_import(scratch, CmKeyUsage::Hmac, &TEST_AUTH_CMD_HMAC_KEY)
-        .await
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
-    let mut hmac_input = ArrayVec::<u8, 256>::new();
-    hmac_input
-        .try_extend_from_slice(&FE_PROG_CMD_ID.to_be_bytes())
-        .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
-    hmac_input
-        .try_extend_from_slice(&partition.to_le_bytes())
-        .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
-    hmac_input
-        .try_extend_from_slice(&challenge)
-        .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
-
-    let mut computed_mac = [0u8; 48];
-    let mac_len = cm_hmac(scratch, &cmk, hmac_input.as_slice(), &mut computed_mac)
-        .await
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-    if mac_len != 48 {
-        return Err(CaliptraCompletionCode::OperationFailed);
-    }
-    if constant_time_eq(&computed_mac, mac) {
-        Ok(())
-    } else {
-        Err(CaliptraCompletionCode::AccessDenied)
-    }
+    crate::caliptra_cmd_handler::device_ops::verify_authorized_mac(
+        scratch,
+        &crate::caliptra_cmd_handler::device_ops::TEST_AUTH_CMD_HMAC_KEY,
+        FE_PROG_CMD_ID,
+        &partition_bytes,
+        &challenge,
+        mac,
+    )
+    .await
+    .map_err(map_common_completion)
 }
 
 fn map_common_completion(code: CommonCompletionCode) -> CaliptraCompletionCode {

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
@@ -1,16 +1,13 @@
 // Licensed under the Apache-2.0 license
 
-extern crate alloc;
-
 use crate::caliptra_cmd_handler::CaliptraCmdBackend;
-use alloc::boxed::Box;
-use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
     DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, Uid,
     MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use caliptra_mcu_mbox_common::config;
+use mcu_caliptra_api_lite::ApiAlloc;
 
 #[derive(Default)]
 pub struct NonCryptoCmdHandlerMock;
@@ -20,7 +17,6 @@ pub struct NonCryptoCmdHandlerMock;
 /// This handler provides mock responses for firmware version queries,
 /// device ID, device information, and device capabilities. Intended to use for
 /// integration testing on the emulator platform.
-#[async_trait]
 impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
     async fn get_firmware_version(
         &self,
@@ -87,8 +83,9 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         Ok(())
     }
 
-    async fn export_attested_csr(
+    async fn export_attested_csr<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
@@ -96,30 +93,31 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
     ) -> CaliptraCmdResult<usize> {
         let handler = CaliptraCmdBackend;
         handler
-            .export_attested_csr(device_key_id, algorithm, nonce, csr_buf)
+            .export_attested_csr(alloc, device_key_id, algorithm, nonce, csr_buf)
             .await
     }
 
-    async fn request_debug_unlock(
+    async fn request_debug_unlock<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         unlock_level: u8,
         challenge: &mut DebugUnlockChallenge,
     ) -> CaliptraCmdResult<()> {
         let handler = CaliptraCmdBackend;
-        handler.request_debug_unlock(unlock_level, challenge).await
+        handler
+            .request_debug_unlock(alloc, unlock_level, challenge)
+            .await
     }
 
-    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
-        let handler = CaliptraCmdBackend;
-        handler.authorize_debug_unlock_token(token_data).await
-    }
-
-    async fn export_idevid_csr(
+    async fn authorize_debug_unlock_token<Alloc: ApiAlloc>(
         &self,
-        _algorithm: u32,
-        _csr_buf: &mut [u8],
-    ) -> CaliptraCmdResult<usize> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        alloc: &Alloc,
+        token_request: &[u8],
+    ) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler
+            .authorize_debug_unlock_token(alloc, token_request)
+            .await
     }
 
     async fn get_log(&self, log_type: u32, data: &mut [u8]) -> CaliptraCmdResult<GetLogResult> {
@@ -133,7 +131,13 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         CaliptraCmdBackend.clear_log(log_type).await
     }
 
-    async fn program_field_entropy(&self, partition: u32) -> CaliptraCmdResult<()> {
-        CaliptraCmdBackend.program_field_entropy(partition).await
+    async fn program_field_entropy<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        partition: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .program_field_entropy(alloc, partition)
+            .await
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
@@ -49,7 +49,10 @@ async fn start_vdm_service() -> Result<(), ErrorCode> {
         static TRANSPORT: StaticCell<caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport> =
             StaticCell::new();
         static CMD_INTERFACE: StaticCell<
-            caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<'static>,
+            caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<
+                'static,
+                cmd_handler_mock::NonCryptoCmdHandlerMock,
+            >,
         > = StaticCell::new();
 
         let handler: &'static cmd_handler_mock::NonCryptoCmdHandlerMock =
@@ -69,6 +72,7 @@ async fn start_vdm_service() -> Result<(), ErrorCode> {
         // Create the command interface with static storage
         let cmd_interface: &'static mut caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<
             'static,
+            cmd_handler_mock::NonCryptoCmdHandlerMock,
         > = CMD_INTERFACE.init(caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface::new(
             transport, handler,
         ));
@@ -78,16 +82,7 @@ async fn start_vdm_service() -> Result<(), ErrorCode> {
             "Starting MCTP VDM service for integration tests..."
         );
 
-        if let Err(e) = caliptra_mcu_mctp_vdm_lib::daemon::spawn_vdm_responder(
-            crate::EXECUTOR.get().spawner(),
-            cmd_interface,
-        ) {
-            crate::log_error!(
-                console_writer,
-                "USER_APP: Error starting MCTP VDM service: {}",
-                crate::Dbg(e)
-            );
-        }
+        caliptra_mcu_mctp_vdm_lib::daemon::vdm_responder(cmd_interface).await;
         let suspend_signal: Signal<CriticalSectionRawMutex, ()> = Signal::new();
         suspend_signal.wait().await;
     }

--- a/runtime/userspace/api/caliptra-api-lite/src/debug_unlock.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/debug_unlock.rs
@@ -29,7 +29,7 @@ pub const PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN: usize = MBOX_RESP_HEADER_S
 /// `out` and returns [`DEBUG_UNLOCK_CHALLENGE_LEN`].
 #[inline(never)]
 pub async fn request_debug_unlock_challenge<A: ApiAlloc>(
-    alloc: &A,
+    _alloc: &A,
     unlock_level: u8,
     out: &mut [u8],
 ) -> McuResult<usize> {
@@ -37,15 +37,16 @@ pub async fn request_debug_unlock_challenge<A: ApiAlloc>(
         return Err(OUT_OF_MEMORY);
     }
 
+    // Fixed small buffers stay inline; scratch allocation costs more code here.
     // Request layout: `chksum(4) | length_dwords(4) | unlock_level(1) | reserved(3)`.
-    let mut req = alloc.alloc(REQ_LEN)?;
+    let mut req = [0u8; REQ_LEN];
     req.fill(0);
     req[4..8].copy_from_slice(&2u32.to_le_bytes());
     req[8] = unlock_level;
     let checksum = calc_checksum(CMD_PRODUCTION_AUTH_DEBUG_UNLOCK_REQ, &req[4..]);
     req[..4].copy_from_slice(&checksum.to_le_bytes());
 
-    let mut rsp = alloc.alloc(RSP_LEN)?;
+    let mut rsp = [0u8; RSP_LEN];
     let rsp_len = mbox_execute(CMD_PRODUCTION_AUTH_DEBUG_UNLOCK_REQ, &req, &mut rsp).await?;
     if rsp_len != RSP_LEN {
         return Err(INTERNAL_BUG);

--- a/runtime/userspace/api/caliptra-api-lite/src/fe_prog.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/fe_prog.rs
@@ -13,14 +13,15 @@ const FE_PROG_REQ_LEN: usize = 8;
 /// Program field entropy for `partition`. Returns once Caliptra has
 /// completed the operation.
 #[inline(never)]
-pub async fn fe_prog<A: ApiAlloc>(alloc: &A, partition: u32) -> McuResult<()> {
-    let mut req = alloc.alloc(FE_PROG_REQ_LEN)?;
+pub async fn fe_prog<A: ApiAlloc>(_alloc: &A, partition: u32) -> McuResult<()> {
+    // Fixed 8-byte buffers stay inline; scratch allocation costs more code here.
+    let mut req = [0u8; FE_PROG_REQ_LEN];
     req.fill(0);
     req[4..8].copy_from_slice(&partition.to_le_bytes());
     let checksum = calc_checksum(CMD_FE_PROG, &req[4..]);
     req[..4].copy_from_slice(&checksum.to_le_bytes());
 
-    let mut rsp = alloc.alloc(MBOX_RESP_HEADER_SIZE)?;
+    let mut rsp = [0u8; MBOX_RESP_HEADER_SIZE];
     let _rsp_len = crate::wire::mbox_execute(CMD_FE_PROG, &req, &mut rsp).await?;
     Ok(())
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/fw_info.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/fw_info.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache-2.0 license
+
+//! Minimal `FW_INFO` mailbox helper.
+
+use crate::raw::{raw_mailbox_execute, CMD_FW_INFO};
+use crate::ApiAlloc;
+use mcu_error::codes::INVARIANT;
+use mcu_error::McuResult;
+
+const REQ_SIZE: usize = 4;
+const RSP_SIZE: usize = 376;
+const FW_SVN_OFFSET: usize = 12;
+const IMAGE_MANIFEST_PQC_TYPE_OFFSET: usize = 364;
+const VENDOR_ECC384_PUB_KEY_INDEX_OFFSET: usize = 368;
+const VENDOR_PQC_PUB_KEY_INDEX_OFFSET: usize = 372;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FwInfo {
+    pub fw_svn: u32,
+    pub image_manifest_pqc_type: u32,
+    pub vendor_ecc384_pub_key_index: u32,
+    pub vendor_pqc_pub_key_index: u32,
+}
+
+pub async fn fw_info<A: ApiAlloc>(alloc: &A) -> McuResult<FwInfo> {
+    let mut req = alloc.alloc(REQ_SIZE)?;
+    req.fill(0);
+    let mut rsp = alloc.alloc(RSP_SIZE)?;
+
+    let len = raw_mailbox_execute(CMD_FW_INFO, &mut req, &mut rsp).await?;
+    if len < RSP_SIZE {
+        return Err(INVARIANT);
+    }
+
+    Ok(FwInfo {
+        fw_svn: read_u32(&rsp, FW_SVN_OFFSET)?,
+        image_manifest_pqc_type: read_u32(&rsp, IMAGE_MANIFEST_PQC_TYPE_OFFSET)?,
+        vendor_ecc384_pub_key_index: read_u32(&rsp, VENDOR_ECC384_PUB_KEY_INDEX_OFFSET)?,
+        vendor_pqc_pub_key_index: read_u32(&rsp, VENDOR_PQC_PUB_KEY_INDEX_OFFSET)?,
+    })
+}
+
+fn read_u32(buf: &[u8], offset: usize) -> McuResult<u32> {
+    let bytes: [u8; 4] = buf
+        .get(offset..offset + 4)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(INVARIANT)?;
+    Ok(u32::from_le_bytes(bytes))
+}

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -31,8 +31,10 @@ mod dpe;
 pub mod eat;
 mod ecdh;
 mod fe_prog;
+mod fw_info;
 mod hmac;
 mod import;
+pub mod raw;
 mod rng;
 mod sha;
 pub mod signed_eat;
@@ -61,6 +63,7 @@ pub use ecdh::{
     ecdh_finish, ecdh_generate, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,
 };
 pub use fe_prog::fe_prog;
+pub use fw_info::{fw_info, FwInfo};
 pub use hmac::{cm_hmac, hkdf_expand, hkdf_extract, HkdfSalt, CMB_HMAC_MAX_SIZE};
 pub use import::{cm_delete, cm_import};
 pub use rng::rng_generate;

--- a/runtime/userspace/api/caliptra-api-lite/src/raw.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/raw.rs
@@ -1,0 +1,61 @@
+// Licensed under the Apache-2.0 license
+
+//! Raw Caliptra mailbox command execution for caller-owned wire buffers.
+//!
+//! This is for transport pass-through paths that already own a complete
+//! command request/response buffer. It keeps checksum and mailbox error
+//! handling in `caliptra-api-lite` without importing the full `caliptra-api`
+//! crate.
+
+use mcu_error::McuResult;
+
+pub const CMD_SELF_TEST_START: u32 = 0x4650_4C54; // "FPLT"
+pub const CMD_SELF_TEST_GET_RESULTS: u32 = 0x4650_4C67; // "FPLg"
+pub const CMD_FW_INFO: u32 = 0x494E_464F; // "INFO"
+
+pub const CMD_CM_SHA_INIT: u32 = 0x434D_5349; // "CMSI"
+pub const CMD_CM_SHA_UPDATE: u32 = 0x434D_5355; // "CMSU"
+pub const CMD_CM_SHA_FINAL: u32 = 0x434D_5346; // "CMSF"
+pub const CMD_CM_HMAC: u32 = 0x434D_484D; // "CMHM"
+pub const CMD_CM_HMAC_KDF_COUNTER: u32 = 0x434D_4B43; // "CMKC"
+pub const CMD_CM_HKDF_EXTRACT: u32 = 0x434D_4B54; // "CMKT"
+pub const CMD_CM_HKDF_EXPAND: u32 = 0x434D_4B50; // "CMKP"
+pub const CMD_CM_IMPORT: u32 = 0x434D_494D; // "CMIM"
+pub const CMD_CM_DELETE: u32 = 0x434D_444C; // "CMDL"
+pub const CMD_CM_STATUS: u32 = 0x434D_5354; // "CMST"
+pub const CMD_CM_RANDOM_GENERATE: u32 = 0x434D_5247; // "CMRG"
+pub const CMD_CM_RANDOM_STIR: u32 = 0x434D_5253; // "CMRS"
+
+pub const CMD_CM_AES_ENCRYPT_INIT: u32 = 0x434D_4149; // "CMAI"
+pub const CMD_CM_AES_ENCRYPT_UPDATE: u32 = 0x434D_4155; // "CMAU"
+pub const CMD_CM_AES_DECRYPT_INIT: u32 = 0x434D_414A; // "CMAJ"
+pub const CMD_CM_AES_DECRYPT_UPDATE: u32 = 0x434D_4156; // "CMAV"
+
+pub const CMD_CM_AES_GCM_ENCRYPT_INIT: u32 = 0x434D_4749; // "CMGI"
+pub const CMD_CM_AES_GCM_ENCRYPT_UPDATE: u32 = 0x434D_4755; // "CMGU"
+pub const CMD_CM_AES_GCM_ENCRYPT_FINAL: u32 = 0x434D_4746; // "CMGF"
+pub const CMD_CM_AES_GCM_DECRYPT_INIT: u32 = 0x434D_4449; // "CMDI"
+pub const CMD_CM_AES_GCM_DECRYPT_UPDATE: u32 = 0x434D_4455; // "CMDU"
+pub const CMD_CM_AES_GCM_DECRYPT_FINAL: u32 = 0x434D_4446; // "CMDF"
+
+pub const CMD_CM_ECDH_GENERATE: u32 = 0x434D_4547; // "CMEG"
+pub const CMD_CM_ECDH_FINISH: u32 = 0x434D_4546; // "CMEF"
+pub const CMD_CM_ECDSA_PUBLIC_KEY: u32 = 0x434D_4550; // "CMEP"
+pub const CMD_CM_ECDSA_SIGN: u32 = 0x434D_4553; // "CMES"
+pub const CMD_CM_ECDSA_VERIFY: u32 = 0x434D_4556; // "CMEV"
+pub const CMD_CM_MLDSA_PUBLIC_KEY: u32 = 0x434D_4D50; // "CMMP"
+pub const CMD_CM_MLDSA_SIGN: u32 = 0x434D_4D53; // "CMMS"
+pub const CMD_CM_MLDSA_VERIFY: u32 = 0x434D_4D56; // "CMMV"
+
+pub const CMD_PRODUCTION_AUTH_DEBUG_UNLOCK_REQ: u32 = 0x5044_5552; // "PDUR"
+pub const CMD_PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN: u32 = 0x5044_5554; // "PDUT"
+pub const MAILBOX_RESP_HEADER_SIZE: usize = 8;
+
+pub fn mailbox_checksum(cmd: u32, data: &[u8]) -> u32 {
+    crate::wire::calc_checksum(cmd, data)
+}
+
+pub async fn raw_mailbox_execute(cmd: u32, req: &mut [u8], rsp: &mut [u8]) -> McuResult<usize> {
+    crate::wire::populate_checksum(cmd, req)?;
+    crate::wire::mbox_execute(cmd, req, rsp).await
+}

--- a/runtime/userspace/api/caliptra-api-lite/src/rng.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/rng.rs
@@ -28,12 +28,13 @@ const RSP_HEADER_SIZE: usize = MBOX_RESP_HEADER_SIZE + 4; // +data_len field
 
 /// Generate `out.len()` random bytes from Caliptra RNG.
 #[inline(never)]
-pub async fn rng_generate<A: ApiAlloc>(alloc: &A, out: &mut [u8]) -> McuResult<()> {
+pub async fn rng_generate<A: ApiAlloc>(_alloc: &A, out: &mut [u8]) -> McuResult<()> {
     if out.is_empty() || out.len() > MAX_RANDOM_SIZE {
         return Err(INVARIANT);
     }
 
-    let mut req = alloc.alloc(REQ_SIZE)?;
+    // The fixed request and bounded 60-byte response are cheaper inline.
+    let mut req = [0u8; REQ_SIZE];
     req.fill(0);
     {
         let r = RandomGenReq::mut_from_bytes(&mut req[..REQ_SIZE]).map_err(|_| INVARIANT)?;
@@ -42,8 +43,7 @@ pub async fn rng_generate<A: ApiAlloc>(alloc: &A, out: &mut [u8]) -> McuResult<(
     let checksum = calc_checksum(CMD_CM_RANDOM_GENERATE, &req);
     *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
 
-    let rsp_max = RSP_HEADER_SIZE + MAX_RANDOM_SIZE;
-    let mut rsp = alloc.alloc(rsp_max)?;
+    let mut rsp = [0u8; RSP_HEADER_SIZE + MAX_RANDOM_SIZE];
     let rsp_len = crate::wire::mbox_execute(CMD_CM_RANDOM_GENERATE, &req, &mut rsp).await?;
 
     // Parse data_len from response.

--- a/runtime/userspace/api/caliptra-common-commands/Cargo.toml
+++ b/runtime/userspace/api/caliptra-common-commands/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-async-trait.workspace = true
-caliptra-api.workspace = true
 caliptra-mcu-mbox-common.workspace = true
+mcu-caliptra-api-lite.workspace = true
 zerocopy.workspace = true

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -1,15 +1,13 @@
 // Licensed under the Apache-2.0 license
 
 #![cfg_attr(target_arch = "riscv32", no_std)]
+#![allow(async_fn_in_trait)]
 
-extern crate alloc;
-
-use alloc::boxed::Box;
-use async_trait::async_trait;
 use caliptra_mcu_mbox_common::messages::CommandId;
+use mcu_caliptra_api_lite::ApiAlloc;
 use zerocopy::{Immutable, IntoBytes};
 
-pub use caliptra_api::mailbox::MAX_ATTESTED_CSR_RESP_DATA_SIZE as MAX_ATTESTED_CSR_DATA_LEN;
+pub const MAX_ATTESTED_CSR_DATA_LEN: usize = 12_800;
 pub const MAX_FW_VERSION_LEN: usize = 32;
 pub const MAX_UID_LEN: usize = 32;
 
@@ -161,8 +159,7 @@ impl Default for DebugUnlockChallenge {
 ///
 /// Each function represents a transport-agnostic command handler. Implementors should provide
 /// the specific logic for each command as required by their application.
-#[async_trait]
-pub trait CaliptraCmdHandler: Send + Sync {
+pub trait CaliptraCmdHandler {
     /// Retrieves the firmware version for the given index.
     ///
     /// # Arguments
@@ -218,25 +215,12 @@ pub trait CaliptraCmdHandler: Send + Sync {
     ///
     /// # Returns
     /// * `CaliptraCmdResult<usize>` - Number of bytes written on success, or an error.
-    async fn export_attested_csr(
+    async fn export_attested_csr<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
-        csr_buf: &mut [u8],
-    ) -> CaliptraCmdResult<usize>;
-
-    /// Exports an IDevID CSR (manufacturing mode only).
-    ///
-    /// # Arguments
-    /// * `algorithm` - The asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87).
-    /// * `csr_buf` - Mutable buffer to write the CSR DER data into directly.
-    ///
-    /// # Returns
-    /// * `CaliptraCmdResult<usize>` - Number of bytes written on success, or an error.
-    async fn export_idevid_csr(
-        &self,
-        algorithm: u32,
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize>;
 
@@ -248,23 +232,29 @@ pub trait CaliptraCmdHandler: Send + Sync {
     ///
     /// # Returns
     /// * `CaliptraCmdResult<()>` - Ok on success, or an error.
-    async fn request_debug_unlock(
+    async fn request_debug_unlock<Alloc: ApiAlloc>(
         &self,
+        alloc: &Alloc,
         unlock_level: u8,
         challenge: &mut DebugUnlockChallenge,
     ) -> CaliptraCmdResult<()>;
 
     /// Submits a signed debug unlock token.
     ///
-    /// The token payload is streamed in chunks via the chunked mailbox API
-    /// because it can be very large (~7.5KB due to MLDSA keys/signatures).
+    /// The request includes the requester-computed Caliptra mailbox checksum.
+    /// This permits transports such as SPDM VDM to relay the request in chunks
+    /// without buffering the complete token to compute its checksum.
     ///
     /// # Arguments
-    /// * `token_data` - The complete token payload bytes (excluding checksum header).
+    /// * `token_request` - The complete Caliptra request, including its checksum header.
     ///
     /// # Returns
     /// * `CaliptraCmdResult<()>` - Ok on success, or an error.
-    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()>;
+    async fn authorize_debug_unlock_token<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        token_request: &[u8],
+    ) -> CaliptraCmdResult<()>;
 
     /// Drain log entries of `log_type` into `data`.
     ///
@@ -315,8 +305,12 @@ pub trait CaliptraCmdHandler: Send + Sync {
     ///
     /// # Returns
     /// * `CaliptraCmdResult<()>` - Ok on success, or an error.
-    async fn program_field_entropy(&self, partition: u32) -> CaliptraCmdResult<()> {
-        let _ = partition;
+    async fn program_field_entropy<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        partition: u32,
+    ) -> CaliptraCmdResult<()> {
+        let _ = (alloc, partition);
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
 }
@@ -325,7 +319,6 @@ pub struct AuthorizationError;
 
 pub type AuthorizationResult<T> = Result<T, AuthorizationError>;
 
-#[async_trait]
 pub trait CommandAuthorizer {
     /// Validates if a message is authorized.
     ///
@@ -339,8 +332,9 @@ pub trait CommandAuthorizer {
     ///
     /// # Returns
     /// * `Result<&[u8], CommandError>` - Unpacked command or Error
-    async fn is_authorized<'a>(
+    async fn is_authorized<'a, Alloc: ApiAlloc>(
         &mut self,
+        alloc: &Alloc,
         cmd_id: CommandId,
         req: &'a [u8],
     ) -> Result<&'a [u8], AuthorizationError>;
@@ -357,8 +351,9 @@ pub trait CommandAuthorizer {
     /// * `cmd_id` - Raw command identifier (u32, serialized big-endian in HMAC)
     /// * `payload` - Command-specific payload bytes
     /// * `mac` - The 48-byte MAC received from the host
-    async fn verify_mac(
+    async fn verify_mac<Alloc: ApiAlloc>(
         &mut self,
+        alloc: &Alloc,
         cmd_id: u32,
         payload: &[u8],
         mac: &[u8],

--- a/runtime/userspace/api/mctp-vdm-lib/Cargo.toml
+++ b/runtime/userspace/api/mctp-vdm-lib/Cargo.toml
@@ -7,7 +7,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait.workspace = true
 defmt = { workspace = true, optional = true }
 embassy-executor.workspace = true
 embassy-sync.workspace = true

--- a/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
@@ -23,17 +23,14 @@ use core::convert::TryFrom;
 use zerocopy::IntoBytes;
 
 /// Command interface for handling VDM commands.
-pub struct CmdInterface<'a> {
+pub struct CmdInterface<'a, H: CaliptraCmdHandler> {
     transport: &'a mut MctpVdmTransport,
-    unified_handler: &'a dyn CaliptraCmdHandler,
+    unified_handler: &'a H,
 }
 
-impl<'a> CmdInterface<'a> {
+impl<'a, H: CaliptraCmdHandler> CmdInterface<'a, H> {
     /// Create a new command interface.
-    pub fn new(
-        transport: &'a mut MctpVdmTransport,
-        unified_handler: &'a dyn CaliptraCmdHandler,
-    ) -> Self {
+    pub fn new(transport: &'a mut MctpVdmTransport, unified_handler: &'a H) -> Self {
         Self {
             transport,
             unified_handler,

--- a/runtime/userspace/api/mctp-vdm-lib/src/daemon.rs
+++ b/runtime/userspace/api/mctp-vdm-lib/src/daemon.rs
@@ -1,13 +1,13 @@
 // Licensed under the Apache-2.0 license
 
 use crate::cmd_interface::CmdInterface;
+use caliptra_mcu_common_commands::CaliptraCmdHandler;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
 use caliptra_mcu_userlog::{log_error, Dbg};
 #[allow(unused_imports)]
 use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
-use embassy_executor::Spawner;
 
 /// Maximum size of VDM message buffer (implementation-defined limit).
 pub const MAX_VDM_MSG_SIZE: usize = 1024;
@@ -22,42 +22,6 @@ pub enum VdmServiceError {
 /// Global running flag for the VDM service.
 static VDM_SERVICE_RUNNING: AtomicBool = AtomicBool::new(false);
 
-/// Spawn the VDM responder task.
-///
-/// This function spawns an async task that handles VDM requests. The caller is
-/// responsible for providing a `CmdInterface` with `'static` lifetime, typically
-/// by creating it with static storage using `StaticCell` or similar.
-///
-/// # Arguments
-///
-/// * `spawner` - The embassy executor spawner.
-/// * `cmd_interface` - A mutable reference to the command interface with `'static` lifetime.
-///
-/// # Example
-///
-/// ```ignore
-/// static CMD_INTERFACE: StaticCell<CmdInterface<'static>> = StaticCell::new();
-///
-/// let cmd_interface = CMD_INTERFACE.init(CmdInterface::new(transport, handler));
-/// spawn_vdm_responder(spawner, cmd_interface)?;
-/// ```
-pub fn spawn_vdm_responder(
-    spawner: Spawner,
-    cmd_interface: &'static mut CmdInterface<'static>,
-) -> Result<(), VdmServiceError> {
-    if VDM_SERVICE_RUNNING.load(Ordering::SeqCst) {
-        return Err(VdmServiceError::StartError);
-    }
-
-    VDM_SERVICE_RUNNING.store(true, Ordering::SeqCst);
-
-    spawner
-        .spawn(vdm_responder_task(cmd_interface, &VDM_SERVICE_RUNNING))
-        .map_err(|_| VdmServiceError::StartError)?;
-
-    Ok(())
-}
-
 /// Stop the VDM service.
 ///
 /// Signals the responder task to stop processing new requests.
@@ -70,22 +34,13 @@ pub fn is_vdm_service_running() -> bool {
     VDM_SERVICE_RUNNING.load(Ordering::SeqCst)
 }
 
-/// VDM responder task.
-#[embassy_executor::task]
-pub async fn vdm_responder_task(
-    cmd_interface: &'static mut CmdInterface<'static>,
-    running: &'static AtomicBool,
-) {
-    vdm_responder(cmd_interface, running).await;
-}
-
 /// VDM responder loop.
-pub async fn vdm_responder(
-    cmd_interface: &'static mut CmdInterface<'static>,
-    running: &'static AtomicBool,
+pub async fn vdm_responder<H: CaliptraCmdHandler>(
+    cmd_interface: &'static mut CmdInterface<'static, H>,
 ) {
     let mut msg_buffer = [0u8; MAX_VDM_MSG_SIZE];
-    while running.load(Ordering::SeqCst) {
+    VDM_SERVICE_RUNNING.store(true, Ordering::SeqCst);
+    while VDM_SERVICE_RUNNING.load(Ordering::SeqCst) {
         if let Err(e) = cmd_interface.handle_responder_msg(&mut msg_buffer).await {
             log_error!(
                 Console::<DefaultSyscalls>::writer(),

--- a/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
+++ b/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
@@ -12,8 +12,7 @@ embassy-executor.workspace = true
 embassy-sync.workspace = true
 mcu-error.workspace = true
 caliptra-mcu-common-commands.workspace = true
-caliptra-api.workspace = true
-caliptra-mcu-libapi-caliptra.workspace = true
+mcu-caliptra-api-lite.workspace = true
 caliptra-mcu-libsyscall-caliptra.workspace = true
 caliptra-mcu-libtock_alarm.workspace = true
 caliptra-mcu-libtock_console.workspace = true
@@ -30,6 +29,5 @@ default = []
 periodic-fips-self-test = []
 release = [
 	"dep:defmt",
-	"caliptra-mcu-libapi-caliptra/release",
 	"caliptra-mcu-userlog/defmt-transport",
 ]

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -2,28 +2,26 @@
 
 use crate::errors;
 use crate::transport::McuMboxTransport;
-use caliptra_api::mailbox::{populate_checksum, CommandId as CaliptraCommandId, MailboxReqHeader};
 use caliptra_mcu_common_commands::{
-    CaliptraCmdHandler, CommandAuthorizer, DeviceCapabilities, DeviceId, DeviceInfo,
-    FirmwareVersion, GetLogResult, MAX_UID_LEN,
+    CaliptraCmdHandler, CommandAuthorizer, DebugUnlockChallenge, DeviceCapabilities, DeviceId,
+    DeviceInfo, FirmwareVersion, GetLogResult, MAX_UID_LEN,
 };
-use caliptra_mcu_libapi_caliptra::crypto::rng::Rng;
-use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
 use caliptra_mcu_libsyscall_caliptra::otp::Otp;
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
-use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
 use caliptra_mcu_mbox_common::messages::{
     ClearLogReq, ClearLogResp, CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp,
-    DeviceInfoReq, DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
-    FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
-    FuseLockPartitionReq, FuseLockPartitionResp, FuseReadReq, FuseReadResp,
-    FuseRevokeVendorPkHashReq, FuseRevokeVendorPkHashResp, FuseRevokeVendorPubKeyReq,
-    FuseRevokeVendorPubKeyResp, FuseWriteReq, FuseWriteResp, GetAuthCmdChallengeReq,
-    GetAuthCmdChallengeResp, GetLogReq, GetLogResp, MailboxRespHeader, MailboxRespHeaderVarSize,
-    McuFeProgReq, McuResponseVarSize, ProvisionVendorPkHashReq, ProvisionVendorPkHashResp,
-    RevokeVendorPubKeyType, DEVICE_CAPS_SIZE, MAX_FUSE_DATA_SIZE, MAX_FW_VERSION_STR_LEN,
-    MAX_RESP_DATA_SIZE,
+    DeviceInfoReq, DeviceInfoResp, ExportAttestedCsrReq, FirmwareVersionReq, FirmwareVersionResp,
+    FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp, FuseLockPartitionReq,
+    FuseLockPartitionResp, FuseReadReq, FuseReadResp, FuseRevokeVendorPkHashReq,
+    FuseRevokeVendorPkHashResp, FuseRevokeVendorPubKeyReq, FuseRevokeVendorPubKeyResp,
+    FuseWriteReq, FuseWriteResp, GetAuthCmdChallengeReq, GetAuthCmdChallengeResp, GetLogReq,
+    MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize, McuFeProgReq, McuMailboxReq,
+    McuMailboxResp, McuProdDebugUnlockReqReq, McuProdDebugUnlockReqResp,
+    McuProdDebugUnlockTokenReq, McuResponseVarSize, ProvisionVendorPkHashReq,
+    ProvisionVendorPkHashResp, RevokeVendorPubKeyType, DEVICE_CAPS_SIZE, MAX_FUSE_DATA_SIZE,
+    MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{
@@ -32,29 +30,37 @@ use caliptra_mcu_mbox_common::messages::{
 };
 use caliptra_mcu_romtime::{fuse_read_dai_params, PartitionId};
 use core::sync::atomic::{AtomicBool, Ordering};
+use mcu_caliptra_api_lite::{raw, ApiAlloc, FwInfo};
 use mcu_error::McuResult;
 use zerocopy::{FromBytes, IntoBytes};
 
+pub trait McuMboxScratch: ApiAlloc {
+    fn shrink(buf: &mut Self::Buf<'_>, new_len: usize) -> McuResult<()>;
+}
+
 /// Command interface for handling MCU mailbox commands.
-pub struct CmdInterface<'a> {
+pub struct CmdInterface<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch> {
     transport: &'a mut McuMboxTransport,
-    non_crypto_cmds_handler: &'a dyn CaliptraCmdHandler,
-    cmd_authorizer: &'a mut dyn CommandAuthorizer,
-    caliptra_mbox: caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox, // Handle crypto commands via caliptra mailbox
+    non_crypto_cmds_handler: &'a H,
+    cmd_authorizer: &'a mut A,
+    scratch: &'a Alloc,
     busy: AtomicBool,
 }
 
-impl<'a> CmdInterface<'a> {
+impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
+    CmdInterface<'a, H, A, Alloc>
+{
     pub fn new(
         transport: &'a mut McuMboxTransport,
-        non_crypto_cmds_handler: &'a dyn CaliptraCmdHandler,
-        cmd_authorizer: &'a mut dyn CommandAuthorizer,
+        non_crypto_cmds_handler: &'a H,
+        cmd_authorizer: &'a mut A,
+        scratch: &'a Alloc,
     ) -> Self {
         Self {
             transport,
             non_crypto_cmds_handler,
             cmd_authorizer,
-            caliptra_mbox: Mailbox::new(),
+            scratch,
             busy: AtomicBool::new(false),
         }
     }
@@ -100,7 +106,7 @@ impl<'a> CmdInterface<'a> {
                     }
 
                     // Generate response checksum
-                    populate_checksum(resp);
+                    populate_response_checksum(resp)?;
 
                     self.transport.send_response(resp).await.map_err(|_| {
                         let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
@@ -113,6 +119,48 @@ impl<'a> CmdInterface<'a> {
         };
 
         // Finalize the response as the last step of handling the message.
+        self.transport
+            .finalize_response(status)
+            .map_err(|_| errors::TRANSPORT_ERROR)?;
+
+        Ok(())
+    }
+
+    pub async fn handle_responder_msg_from_scratch(&mut self) -> McuResult<()> {
+        let mut req_buf = self.scratch.alloc(size_of::<McuMailboxReq>())?;
+        let (cmd_id, req_len) = match self.transport.receive_request(&mut req_buf).await {
+            Ok((c, slice)) => (c, slice.len()),
+            Err(_) => {
+                let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
+                return Err(errors::TRANSPORT_ERROR);
+            }
+        };
+        Alloc::shrink(&mut req_buf, req_len)?;
+
+        let mut resp_buf = self.scratch.alloc(response_buffer_size(cmd_id))?;
+        let status = match self
+            .process_request(&mut req_buf, req_len, cmd_id, &mut resp_buf)
+            .await
+        {
+            Ok((resp, status)) => {
+                if status == MbxCmdStatus::Complete {
+                    if resp.len() < size_of::<MailboxRespHeader>() {
+                        let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
+                        return Err(errors::MCU_MBOX_COMMON);
+                    }
+
+                    populate_response_checksum(resp)?;
+
+                    self.transport.send_response(resp).await.map_err(|_| {
+                        let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
+                        errors::TRANSPORT_ERROR
+                    })?;
+                }
+                status
+            }
+            Err(_) => MbxCmdStatus::Failure,
+        };
+
         self.transport
             .finalize_response(status)
             .map_err(|_| errors::TRANSPORT_ERROR)?;
@@ -169,6 +217,12 @@ impl<'a> CmdInterface<'a> {
                 }
                 CommandId::MC_EXPORT_ATTESTED_CSR => {
                     self.handle_export_attested_csr(req, resp_buf).await
+                }
+                CommandId::MC_PROD_DEBUG_UNLOCK_REQ => {
+                    self.handle_prod_debug_unlock_req(req, resp_buf).await
+                }
+                CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN => {
+                    self.handle_prod_debug_unlock_token(req, resp_buf).await
                 }
                 _ => Err(errors::UNSUPPORTED_COMMAND),
             }
@@ -363,36 +417,42 @@ impl<'a> CmdInterface<'a> {
         // Reserve the first 4 bytes of the variable-length payload for the
         // `more_data` flag; the rest is filled by the handler.
         const MORE_DATA_FIELD_LEN: usize = core::mem::size_of::<u32>();
-        let mut resp = GetLogResp::default();
+        let (hdr_bytes, data) = resp_buf
+            .split_at_mut_checked(size_of::<MailboxRespHeaderVarSize>())
+            .ok_or(errors::INVALID_PARAMS)?;
+        let data = data
+            .get_mut(..MAX_RESP_DATA_SIZE)
+            .ok_or(errors::INVALID_PARAMS)?;
         let result = self
             .non_crypto_cmds_handler
-            .get_log(req.log_type, &mut resp.data[MORE_DATA_FIELD_LEN..])
+            .get_log(req.log_type, &mut data[MORE_DATA_FIELD_LEN..])
             .await;
 
-        let mbox_cmd_status = match result {
+        let (mbox_cmd_status, resp_len) = match result {
             Ok(GetLogResult {
                 bytes_written,
                 more_data,
             }) => {
                 let more_data_bytes: u32 = if more_data { 1 } else { 0 };
-                resp.data[..MORE_DATA_FIELD_LEN].copy_from_slice(&more_data_bytes.to_le_bytes());
-                resp.hdr = MailboxRespHeaderVarSize {
+                data[..MORE_DATA_FIELD_LEN].copy_from_slice(&more_data_bytes.to_le_bytes());
+                let hdr = MailboxRespHeaderVarSize {
                     data_len: (MORE_DATA_FIELD_LEN + bytes_written) as u32,
                     ..Default::default()
                 };
-                MbxCmdStatus::Complete
+                hdr_bytes.copy_from_slice(hdr.as_bytes());
+                (
+                    MbxCmdStatus::Complete,
+                    size_of::<MailboxRespHeaderVarSize>() + MORE_DATA_FIELD_LEN + bytes_written,
+                )
             }
             Err(_) => {
-                resp = GetLogResp::default();
-                MbxCmdStatus::Failure
+                let hdr = MailboxRespHeaderVarSize::default();
+                hdr_bytes.copy_from_slice(hdr.as_bytes());
+                (MbxCmdStatus::Failure, size_of::<MailboxRespHeaderVarSize>())
             }
         };
 
-        let resp_bytes = resp
-            .as_bytes_partial()
-            .map_err(|_| errors::MCU_MBOX_COMMON)?;
-        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
-        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
+        Ok((&mut resp_buf[..resp_len], mbox_cmd_status))
     }
 
     /// Handle `MC_CLEAR_LOG` (0x4D43_4C47).
@@ -421,10 +481,21 @@ impl<'a> CmdInterface<'a> {
     ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
         let req = ExportAttestedCsrReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
 
-        let mut data = [0u8; MAX_RESP_DATA_SIZE];
+        let (hdr_bytes, data) = resp_buf
+            .split_at_mut_checked(size_of::<MailboxRespHeaderVarSize>())
+            .ok_or(errors::INVALID_PARAMS)?;
+        let data = data
+            .get_mut(..MAX_RESP_DATA_SIZE)
+            .ok_or(errors::INVALID_PARAMS)?;
         let ret = self
             .non_crypto_cmds_handler
-            .export_attested_csr(req.device_key_id, req.algorithm, &req.nonce, &mut data)
+            .export_attested_csr(
+                self.scratch,
+                req.device_key_id,
+                req.algorithm,
+                &req.nonce,
+                data,
+            )
             .await;
 
         let (mbox_cmd_status, data_len) = match ret {
@@ -432,25 +503,82 @@ impl<'a> CmdInterface<'a> {
             Err(_) => (MbxCmdStatus::Failure, 0),
         };
 
-        let resp = if mbox_cmd_status == MbxCmdStatus::Complete {
-            ExportAttestedCsrResp {
-                hdr: MailboxRespHeaderVarSize {
-                    data_len: data_len as u32,
-                    ..Default::default()
-                },
-                data,
-            }
+        let resp_len = if mbox_cmd_status == MbxCmdStatus::Complete {
+            let hdr = MailboxRespHeaderVarSize {
+                data_len: data_len as u32,
+                ..Default::default()
+            };
+            hdr_bytes.copy_from_slice(hdr.as_bytes());
+            size_of::<MailboxRespHeaderVarSize>() + data_len
         } else {
-            ExportAttestedCsrResp::default()
+            let hdr = MailboxRespHeaderVarSize::default();
+            hdr_bytes.copy_from_slice(hdr.as_bytes());
+            size_of::<MailboxRespHeaderVarSize>()
         };
 
-        let resp_bytes = resp
-            .as_bytes_partial()
-            .map_err(|_| errors::MCU_MBOX_COMMON)?;
+        Ok((&mut resp_buf[..resp_len], mbox_cmd_status))
+    }
 
-        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+    async fn handle_prod_debug_unlock_token<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
+        let req =
+            McuProdDebugUnlockTokenReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
+        let (resp, _) =
+            MailboxRespHeader::mut_from_prefix(resp_buf).map_err(|_| errors::INVALID_PARAMS)?;
 
-        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
+        let status = match self
+            .non_crypto_cmds_handler
+            .authorize_debug_unlock_token(self.scratch, req.token.as_bytes())
+            .await
+        {
+            Ok(()) => MbxCmdStatus::Complete,
+            Err(_) => MbxCmdStatus::Failure,
+        };
+
+        *resp = MailboxRespHeader::default();
+        let resp_len = resp.as_bytes().len();
+        Ok((&mut resp_buf[..resp_len], status))
+    }
+
+    async fn handle_prod_debug_unlock_req<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
+        const REQUEST_LENGTH_DWORDS: u32 = 2;
+        const RESPONSE_LENGTH_DWORDS: u32 = 21;
+
+        let req =
+            McuProdDebugUnlockReqReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
+        if req.0.length != REQUEST_LENGTH_DWORDS {
+            return Err(errors::INVALID_PARAMS);
+        }
+
+        let (resp, _) = McuProdDebugUnlockReqResp::mut_from_prefix(resp_buf)
+            .map_err(|_| errors::INVALID_PARAMS)?;
+        let mut challenge = DebugUnlockChallenge::default();
+        let status = match self
+            .non_crypto_cmds_handler
+            .request_debug_unlock(self.scratch, req.0.unlock_level, &mut challenge)
+            .await
+        {
+            Ok(()) => {
+                resp.0 = Default::default();
+                resp.0.length = RESPONSE_LENGTH_DWORDS;
+                resp.0
+                    .unique_device_identifier
+                    .copy_from_slice(&challenge.unique_device_identifier);
+                resp.0.challenge.copy_from_slice(&challenge.challenge);
+                MbxCmdStatus::Complete
+            }
+            Err(_) => MbxCmdStatus::Failure,
+        };
+
+        let resp_len = resp.as_bytes().len();
+        Ok((&mut resp_buf[..resp_len], status))
     }
 
     async fn handle_get_auth_cmd_challenge<'r>(
@@ -465,7 +593,7 @@ impl<'a> CmdInterface<'a> {
             .map_err(|_| errors::INVALID_PARAMS)?;
         *resp = GetAuthCmdChallengeResp::default();
 
-        Rng::generate_random_number(&mut resp.challenge)
+        mcu_caliptra_api_lite::rng_generate(self.scratch, &mut resp.challenge)
             .await
             .map_err(|_| errors::MCU_MBOX_COMMON)?;
 
@@ -486,8 +614,7 @@ impl<'a> CmdInterface<'a> {
         // Clear the header checksum field because it was computed for the MCU mailbox CmdID and payload.
         req[..core::mem::size_of::<MailboxReqHeader>()].fill(0);
 
-        let status =
-            execute_mailbox_cmd(&self.caliptra_mbox, caliptra_cmd_code, req, resp_buf).await;
+        let status = raw::raw_mailbox_execute(caliptra_cmd_code, req, resp_buf).await;
 
         match status {
             Ok(resp_len) => Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete)),
@@ -503,7 +630,7 @@ impl<'a> CmdInterface<'a> {
     ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
         let cmd = self
             .cmd_authorizer
-            .is_authorized(cmd_id, req)
+            .is_authorized(self.scratch, cmd_id, req)
             .await
             .map_err(|_| errors::UNAUTHORIZED_COMMAND)?;
         match cmd_id {
@@ -715,21 +842,10 @@ impl<'a> CmdInterface<'a> {
         let (resp, _) =
             FuseWriteResp::mut_from_prefix(resp_buf).map_err(|_| errors::INVALID_PARAMS)?;
 
-        // Prepare Caliptra request
-        let mut caliptra_req = caliptra_api::mailbox::FeProgReq {
-            partition: req.partition,
-            ..Default::default()
-        };
-
-        // Invoke Caliptra mailbox API (checksum is computed by execute_mailbox_cmd)
-        let _caliptra_resp_len = execute_mailbox_cmd(
-            &self.caliptra_mbox,
-            CaliptraCommandId::FE_PROG.into(),
-            caliptra_req.as_mut_bytes(),
-            resp.as_mut_bytes(),
-        )
-        .await
-        .map_err(|_| errors::MCU_MBOX_COMMON)?;
+        self.non_crypto_cmds_handler
+            .program_field_entropy(self.scratch, req.partition)
+            .await
+            .map_err(|_| errors::MCU_MBOX_COMMON)?;
 
         *resp = FuseWriteResp::default();
         let resp_len = resp.as_bytes().len();
@@ -841,44 +957,10 @@ impl<'a> CmdInterface<'a> {
         Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete))
     }
 
-    async fn get_caliptra_fw_info(&self) -> McuResult<caliptra_api::mailbox::FwInfoResp> {
-        let mut req = caliptra_api::mailbox::MailboxReqHeader::default();
-        let mut caliptra_info = caliptra_api::mailbox::FwInfoResp {
-            hdr: Default::default(),
-            pl0_pauser: Default::default(),
-            fw_svn: Default::default(),
-            min_fw_svn: Default::default(),
-            cold_boot_fw_svn: Default::default(),
-            attestation_disabled: Default::default(),
-            rom_revision: Default::default(),
-            fmc_revision: Default::default(),
-            runtime_revision: Default::default(),
-            rom_sha256_digest: Default::default(),
-            fmc_sha384_digest: Default::default(),
-            runtime_sha384_digest: Default::default(),
-            owner_pub_key_hash: Default::default(),
-            authman_sha384_digest: Default::default(),
-            most_recent_fw_error: Default::default(),
-            vendor_pub_key_hash: Default::default(),
-            image_manifest_pqc_type: Default::default(),
-            vendor_ecc384_pub_key_index: Default::default(),
-            vendor_pqc_pub_key_index: Default::default(),
-        };
-
-        // Invoke Caliptra mailbox API
-        let len = execute_mailbox_cmd(
-            &self.caliptra_mbox,
-            caliptra_api::mailbox::CommandId::FW_INFO.into(),
-            req.as_mut_bytes(),
-            caliptra_info.as_mut_bytes(),
-        )
-        .await
-        .map_err(|_| errors::MCU_MBOX_COMMON)?;
-
-        if len < size_of_val(&caliptra_info) {
-            return Err(errors::MCU_MBOX_COMMON);
-        }
-        Ok(caliptra_info)
+    async fn get_caliptra_fw_info(&self) -> McuResult<FwInfo> {
+        mcu_caliptra_api_lite::fw_info(self.scratch)
+            .await
+            .map_err(|_| errors::MCU_MBOX_COMMON)
     }
 
     #[cfg(feature = "periodic-fips-self-test")]
@@ -942,43 +1024,57 @@ impl<'a> CmdInterface<'a> {
 /// pure passthrough commands. Returns `None` for commands handled locally.
 fn caliptra_passthrough_cmd(cmd: CommandId) -> Option<u32> {
     let code = match cmd {
-        CommandId::MC_FIPS_SELF_TEST_START => CaliptraCommandId::SELF_TEST_START,
-        CommandId::MC_FIPS_SELF_TEST_GET_RESULTS => CaliptraCommandId::SELF_TEST_GET_RESULTS,
-        CommandId::MC_SHA_INIT => CaliptraCommandId::CM_SHA_INIT,
-        CommandId::MC_SHA_UPDATE => CaliptraCommandId::CM_SHA_UPDATE,
-        CommandId::MC_SHA_FINAL => CaliptraCommandId::CM_SHA_FINAL,
-        CommandId::MC_HMAC => CaliptraCommandId::CM_HMAC,
-        CommandId::MC_HMAC_KDF_COUNTER => CaliptraCommandId::CM_HMAC_KDF_COUNTER,
-        CommandId::MC_HKDF_EXTRACT => CaliptraCommandId::CM_HKDF_EXTRACT,
-        CommandId::MC_HKDF_EXPAND => CaliptraCommandId::CM_HKDF_EXPAND,
-        CommandId::MC_IMPORT => CaliptraCommandId::CM_IMPORT,
-        CommandId::MC_DELETE => CaliptraCommandId::CM_DELETE,
-        CommandId::MC_CM_STATUS => CaliptraCommandId::CM_STATUS,
-        CommandId::MC_RANDOM_GENERATE => CaliptraCommandId::CM_RANDOM_GENERATE,
-        CommandId::MC_RANDOM_STIR => CaliptraCommandId::CM_RANDOM_STIR,
-        CommandId::MC_AES_ENCRYPT_INIT => CaliptraCommandId::CM_AES_ENCRYPT_INIT,
-        CommandId::MC_AES_ENCRYPT_UPDATE => CaliptraCommandId::CM_AES_ENCRYPT_UPDATE,
-        CommandId::MC_AES_DECRYPT_INIT => CaliptraCommandId::CM_AES_DECRYPT_INIT,
-        CommandId::MC_AES_DECRYPT_UPDATE => CaliptraCommandId::CM_AES_DECRYPT_UPDATE,
-        CommandId::MC_AES_GCM_ENCRYPT_INIT => CaliptraCommandId::CM_AES_GCM_ENCRYPT_INIT,
-        CommandId::MC_AES_GCM_ENCRYPT_UPDATE => CaliptraCommandId::CM_AES_GCM_ENCRYPT_UPDATE,
-        CommandId::MC_AES_GCM_ENCRYPT_FINAL => CaliptraCommandId::CM_AES_GCM_ENCRYPT_FINAL,
-        CommandId::MC_AES_GCM_DECRYPT_INIT => CaliptraCommandId::CM_AES_GCM_DECRYPT_INIT,
-        CommandId::MC_AES_GCM_DECRYPT_UPDATE => CaliptraCommandId::CM_AES_GCM_DECRYPT_UPDATE,
-        CommandId::MC_AES_GCM_DECRYPT_FINAL => CaliptraCommandId::CM_AES_GCM_DECRYPT_FINAL,
-        CommandId::MC_ECDH_GENERATE => CaliptraCommandId::CM_ECDH_GENERATE,
-        CommandId::MC_ECDH_FINISH => CaliptraCommandId::CM_ECDH_FINISH,
-        CommandId::MC_ECDSA_CMK_PUBLIC_KEY => CaliptraCommandId::CM_ECDSA_PUBLIC_KEY,
-        CommandId::MC_ECDSA_CMK_SIGN => CaliptraCommandId::CM_ECDSA_SIGN,
-        CommandId::MC_ECDSA_CMK_VERIFY => CaliptraCommandId::CM_ECDSA_VERIFY,
-        CommandId::MC_MLDSA_CMK_PUBLIC_KEY => CaliptraCommandId::CM_MLDSA_PUBLIC_KEY,
-        CommandId::MC_MLDSA_CMK_SIGN => CaliptraCommandId::CM_MLDSA_SIGN,
-        CommandId::MC_MLDSA_CMK_VERIFY => CaliptraCommandId::CM_MLDSA_VERIFY,
-        CommandId::MC_PROD_DEBUG_UNLOCK_REQ => CaliptraCommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ,
-        CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN => {
-            CaliptraCommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN
-        }
+        CommandId::MC_FIPS_SELF_TEST_START => raw::CMD_SELF_TEST_START,
+        CommandId::MC_FIPS_SELF_TEST_GET_RESULTS => raw::CMD_SELF_TEST_GET_RESULTS,
+        CommandId::MC_SHA_INIT => raw::CMD_CM_SHA_INIT,
+        CommandId::MC_SHA_UPDATE => raw::CMD_CM_SHA_UPDATE,
+        CommandId::MC_SHA_FINAL => raw::CMD_CM_SHA_FINAL,
+        CommandId::MC_HMAC => raw::CMD_CM_HMAC,
+        CommandId::MC_HMAC_KDF_COUNTER => raw::CMD_CM_HMAC_KDF_COUNTER,
+        CommandId::MC_HKDF_EXTRACT => raw::CMD_CM_HKDF_EXTRACT,
+        CommandId::MC_HKDF_EXPAND => raw::CMD_CM_HKDF_EXPAND,
+        CommandId::MC_IMPORT => raw::CMD_CM_IMPORT,
+        CommandId::MC_DELETE => raw::CMD_CM_DELETE,
+        CommandId::MC_CM_STATUS => raw::CMD_CM_STATUS,
+        CommandId::MC_RANDOM_GENERATE => raw::CMD_CM_RANDOM_GENERATE,
+        CommandId::MC_RANDOM_STIR => raw::CMD_CM_RANDOM_STIR,
+        CommandId::MC_AES_ENCRYPT_INIT => raw::CMD_CM_AES_ENCRYPT_INIT,
+        CommandId::MC_AES_ENCRYPT_UPDATE => raw::CMD_CM_AES_ENCRYPT_UPDATE,
+        CommandId::MC_AES_DECRYPT_INIT => raw::CMD_CM_AES_DECRYPT_INIT,
+        CommandId::MC_AES_DECRYPT_UPDATE => raw::CMD_CM_AES_DECRYPT_UPDATE,
+        CommandId::MC_AES_GCM_ENCRYPT_INIT => raw::CMD_CM_AES_GCM_ENCRYPT_INIT,
+        CommandId::MC_AES_GCM_ENCRYPT_UPDATE => raw::CMD_CM_AES_GCM_ENCRYPT_UPDATE,
+        CommandId::MC_AES_GCM_ENCRYPT_FINAL => raw::CMD_CM_AES_GCM_ENCRYPT_FINAL,
+        CommandId::MC_AES_GCM_DECRYPT_INIT => raw::CMD_CM_AES_GCM_DECRYPT_INIT,
+        CommandId::MC_AES_GCM_DECRYPT_UPDATE => raw::CMD_CM_AES_GCM_DECRYPT_UPDATE,
+        CommandId::MC_AES_GCM_DECRYPT_FINAL => raw::CMD_CM_AES_GCM_DECRYPT_FINAL,
+        CommandId::MC_ECDH_GENERATE => raw::CMD_CM_ECDH_GENERATE,
+        CommandId::MC_ECDH_FINISH => raw::CMD_CM_ECDH_FINISH,
+        CommandId::MC_ECDSA_CMK_PUBLIC_KEY => raw::CMD_CM_ECDSA_PUBLIC_KEY,
+        CommandId::MC_ECDSA_CMK_SIGN => raw::CMD_CM_ECDSA_SIGN,
+        CommandId::MC_ECDSA_CMK_VERIFY => raw::CMD_CM_ECDSA_VERIFY,
+        CommandId::MC_MLDSA_CMK_PUBLIC_KEY => raw::CMD_CM_MLDSA_PUBLIC_KEY,
+        CommandId::MC_MLDSA_CMK_SIGN => raw::CMD_CM_MLDSA_SIGN,
+        CommandId::MC_MLDSA_CMK_VERIFY => raw::CMD_CM_MLDSA_VERIFY,
         _ => return None,
     };
-    Some(code.into())
+    Some(code)
+}
+
+fn response_buffer_size(cmd: u32) -> usize {
+    match CommandId::from(cmd) {
+        c if c == CommandId::MC_MLDSA_CMK_VERIFY || c == CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN => {
+            size_of::<MailboxRespHeader>()
+        }
+        _ => size_of::<McuMailboxResp>(),
+    }
+}
+
+fn populate_response_checksum(resp: &mut [u8]) -> McuResult<()> {
+    if resp.len() < size_of::<MailboxRespHeader>() {
+        return Err(errors::INVALID_PARAMS);
+    }
+    let checksum = raw::mailbox_checksum(0, &resp[size_of::<u32>()..]);
+    resp[..size_of::<u32>()].copy_from_slice(&checksum.to_le_bytes());
+    Ok(())
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
@@ -1,16 +1,14 @@
 // Licensed under the Apache-2.0 license
 
-use crate::cmd_interface::CmdInterface;
+use crate::cmd_interface::{CmdInterface, McuMboxScratch};
 use crate::transport::McuMboxTransport;
 use caliptra_mcu_common_commands::{CaliptraCmdHandler, CommandAuthorizer};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
-use caliptra_mcu_mbox_common::messages::{McuMailboxReq, McuMailboxResp};
 use caliptra_mcu_userlog::{log_error, Hex32};
 #[allow(unused_imports)]
 use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
-use embassy_executor::Spawner;
 
 #[derive(Debug)]
 pub enum McuMboxServiceError {
@@ -20,28 +18,36 @@ pub enum McuMboxServiceError {
 
 /// MCU mailbox service.
 ///
-/// Encapsulates the command interface, task spawner, and running state for the MCU mailbox service.
+/// Encapsulates the command interface and running state for the MCU mailbox service.
 ///
 /// Fields:
-/// - `spawner`: Embassy task spawner for running async tasks.
 /// - `cmd_interface`: Handles mailbox commands.
 /// - `running`: Indicates if the service is active.
-pub struct McuMboxService<'a> {
-    spawner: Spawner,
-    cmd_interface: CmdInterface<'a>,
+pub struct McuMboxService<
+    'a,
+    H: CaliptraCmdHandler + 'static,
+    A: CommandAuthorizer + 'static,
+    Alloc: McuMboxScratch + 'static,
+> {
+    cmd_interface: CmdInterface<'a, H, A, Alloc>,
     running: &'static AtomicBool,
 }
 
-impl<'a> McuMboxService<'a> {
+impl<'a, H, A, Alloc> McuMboxService<'a, H, A, Alloc>
+where
+    H: CaliptraCmdHandler + 'static,
+    A: CommandAuthorizer + 'static,
+    Alloc: McuMboxScratch + 'static,
+{
     pub fn init(
-        non_crypto_cmd_handler: &'a dyn CaliptraCmdHandler,
-        cmd_authorizer: &'a mut dyn CommandAuthorizer,
+        non_crypto_cmd_handler: &'a H,
+        cmd_authorizer: &'a mut A,
         transport: &'a mut McuMboxTransport,
-        spawner: Spawner,
+        scratch: &'a Alloc,
     ) -> Self {
-        let cmd_interface = CmdInterface::new(transport, non_crypto_cmd_handler, cmd_authorizer);
+        let cmd_interface =
+            CmdInterface::new(transport, non_crypto_cmd_handler, cmd_authorizer, scratch);
         Self {
-            spawner,
             cmd_interface,
             running: {
                 static RUNNING: AtomicBool = AtomicBool::new(false);
@@ -57,13 +63,7 @@ impl<'a> McuMboxService<'a> {
 
         self.running.store(true, Ordering::SeqCst);
 
-        let cmd_interface: &'static mut CmdInterface<'static> =
-            unsafe { core::mem::transmute(&mut self.cmd_interface) };
-
-        self.spawner
-            .spawn(mcu_mbox_responder_task(cmd_interface, self.running))
-            .unwrap();
-
+        mcu_mbox_responder(&mut self.cmd_interface, self.running).await;
         Ok(())
     }
 
@@ -72,25 +72,16 @@ impl<'a> McuMboxService<'a> {
     }
 }
 
-#[embassy_executor::task]
-pub async fn mcu_mbox_responder_task(
-    cmd_interface: &'static mut CmdInterface<'static>,
+pub async fn mcu_mbox_responder<H, A, Alloc>(
+    cmd_interface: &mut CmdInterface<'_, H, A, Alloc>,
     running: &'static AtomicBool,
-) {
-    mcu_mbox_responder(cmd_interface, running).await;
-}
-
-pub async fn mcu_mbox_responder(
-    cmd_interface: &'static mut CmdInterface<'static>,
-    running: &'static AtomicBool,
-) {
-    let mut req_buf = [0; size_of::<McuMailboxReq>()];
-    let mut resp_buf = [0; size_of::<McuMailboxResp>()];
+) where
+    H: CaliptraCmdHandler,
+    A: CommandAuthorizer,
+    Alloc: McuMboxScratch,
+{
     while running.load(Ordering::SeqCst) {
-        if let Err(e) = cmd_interface
-            .handle_responder_msg(&mut req_buf, &mut resp_buf)
-            .await
-        {
+        if let Err(e) = cmd_interface.handle_responder_msg_from_scratch().await {
             log_error!(
                 Console::<DefaultSyscalls>::writer(),
                 "mcu_mbox_responder error={}",

--- a/runtime/userspace/api/mcu-mbox-lib/src/fips_periodic.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/fips_periodic.rs
@@ -5,9 +5,6 @@
 //! This module provides functionality to run FIPS self-tests periodically
 //! in the background. It can be enabled/disabled via MCU mailbox commands.
 
-use caliptra_api::mailbox::CommandId as CaliptraCommandId;
-use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
-use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_alarm::{Convert, Hz, Milliseconds};
 use caliptra_mcu_libtock_console::Console;
@@ -20,6 +17,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_sync::signal::Signal;
+use mcu_caliptra_api_lite::raw;
 
 /// Periodic FIPS self-test interval in milliseconds.
 /// Default: 60 seconds (60000 ms)
@@ -99,18 +97,13 @@ async fn sleep_ms(ms: u32) {
 /// 1. Sends SELF_TEST_START to Caliptra
 /// 2. Polls SELF_TEST_GET_RESULTS until completion
 /// 3. Returns true on success, false on failure
-async fn run_fips_self_test(caliptra_mbox: &Mailbox) -> bool {
+async fn run_fips_self_test() -> bool {
     // Start the self-test
     let mut req_buf = [0u8; 8]; // Minimal request buffer (just header)
     let mut resp_buf = [0u8; 8]; // Response buffer
 
-    let start_result = execute_mailbox_cmd(
-        caliptra_mbox,
-        CaliptraCommandId::SELF_TEST_START.into(),
-        &mut req_buf,
-        &mut resp_buf,
-    )
-    .await;
+    let start_result =
+        raw::raw_mailbox_execute(raw::CMD_SELF_TEST_START, &mut req_buf, &mut resp_buf).await;
 
     if start_result.is_err() {
         log_error!(
@@ -127,13 +120,9 @@ async fn run_fips_self_test(caliptra_mbox: &Mailbox) -> bool {
         sleep_ms(100).await;
 
         // Get results
-        let get_results = execute_mailbox_cmd(
-            caliptra_mbox,
-            CaliptraCommandId::SELF_TEST_GET_RESULTS.into(),
-            &mut req_buf,
-            &mut resp_buf,
-        )
-        .await;
+        let get_results =
+            raw::raw_mailbox_execute(raw::CMD_SELF_TEST_GET_RESULTS, &mut req_buf, &mut resp_buf)
+                .await;
 
         match get_results {
             Ok(_) => {
@@ -160,8 +149,6 @@ async fn run_fips_self_test(caliptra_mbox: &Mailbox) -> bool {
 /// when enabled.
 #[embassy_executor::task]
 pub async fn fips_periodic_task() {
-    let caliptra_mbox = Mailbox::new();
-
     log_info!(
         Console::<DefaultSyscalls>::writer(),
         "Periodic FIPS self-test task started"
@@ -170,7 +157,7 @@ pub async fn fips_periodic_task() {
     loop {
         if is_enabled() {
             // Run self-test
-            let result = run_fips_self_test(&caliptra_mbox).await;
+            let result = run_fips_self_test().await;
 
             // Update state (load-modify-store since fetch_add not available on riscv32)
             let current = ITERATIONS.load(Ordering::SeqCst);

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
@@ -18,17 +18,34 @@ where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
 {
-    // Decode only the required unlock-level byte. Missing data is an invalid
-    // payload; extra bytes are ignored by the command handler.
-    let Some(&unlock_level) = req.first() else {
+    const REQUEST_LENGTH_DWORDS: u32 = 2;
+    const RESPONSE_LENGTH_DWORDS: u32 = 21;
+
+    let &[length_0, length_1, length_2, length_3, unlock_level, _, _, _] = req else {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
     };
+    let length = u32::from_le_bytes([length_0, length_1, length_2, length_3]);
+    if length != REQUEST_LENGTH_DWORDS {
+        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
+    }
+
     let data = match super::write_success(out) {
         Ok(data) => data,
         Err(code) => return CaliptraVdmCmdResult::Error(code),
     };
-    match cmds.request_debug_unlock(unlock_level, scratch, data).await {
-        Ok(n) => CaliptraVdmCmdResult::Response(1 + n),
+    let Some((length_out, challenge_out)) = data.split_at_mut_checked(core::mem::size_of::<u32>())
+    else {
+        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
+    };
+
+    match cmds
+        .request_debug_unlock(unlock_level, scratch, challenge_out)
+        .await
+    {
+        Ok(n) => {
+            length_out.copy_from_slice(&RESPONSE_LENGTH_DWORDS.to_le_bytes());
+            CaliptraVdmCmdResult::Response(1 + length_out.len() + n)
+        }
         Err(code) => CaliptraVdmCmdResult::Error(code),
     }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -719,45 +719,56 @@ mod tests {
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
+            2,
+            0,
+            0,
+            0,
             7,
+            0,
+            0,
+            0,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
 
         assert_inline(
             response,
-            2 + 1 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
+            2 + 1 + 4 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
         );
         assert_eq!(inline[0], CALIPTRA_VDM_COMMAND_VERSION);
         assert_eq!(inline[1], CaliptraVdmCommand::RequestDebugUnlock as u8);
         assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_eq!(u32::from_le_bytes(inline[3..7].try_into().unwrap()), 21);
         assert_eq!(
-            &inline[3..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+            &inline[7..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
             &[0x11; DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
         );
         assert_eq!(
-            &inline[3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
-                ..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+            &inline[7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
+                ..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
             &[0x22; DEBUG_UNLOCK_CHALLENGE_SIZE]
         );
     }
 
     #[test]
-    fn request_debug_unlock_allows_trailing_payload() {
+    fn request_debug_unlock_rejects_trailing_payload() {
         let cmds = TestCommands::new(0);
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
+            2,
+            0,
+            0,
+            0,
             7,
+            0,
+            0,
+            0,
             0xaa,
-            0xbb,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
 
-        assert_inline(
-            response,
-            2 + 1 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
-        );
-        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
     }
 
     #[test]

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -241,7 +241,6 @@ impl<S: Syscalls> Mailbox<S> {
         response_buffer: &mut [u8],
     ) -> Result<usize, MailboxError> {
         let mutex = MAILBOX_MUTEX.lock().await;
-
         let request_len = header
             .map_or(Some(payload.len()), |h| h.len().checked_add(payload.len()))
             .ok_or(MailboxError::ErrorCode(ErrorCode::Invalid))?;

--- a/tests/integration/src/test_mcu_mbox.rs
+++ b/tests/integration/src/test_mcu_mbox.rs
@@ -2706,9 +2706,14 @@ pub mod test {
             // a valid challenge-response flow. Sending a zeroed token will be
             // rejected, confirming the passthrough dispatch works.
             println!("  Testing prod debug unlock token passthrough...");
-            let mut prod_token_req = McuMailboxReq::ProdDebugUnlockToken(
-                McuProdDebugUnlockTokenReq(ProductionAuthDebugUnlockToken::new_zeroed()),
-            );
+            let mut prod_token_req =
+                McuMailboxReq::ProdDebugUnlockToken(McuProdDebugUnlockTokenReq {
+                    hdr: MailboxReqHeader::default(),
+                    token: ProductionAuthDebugUnlockToken::new_zeroed(),
+                });
+            if let McuMailboxReq::ProdDebugUnlockToken(req) = &mut prod_token_req {
+                req.populate_caliptra_chksum().unwrap();
+            }
             prod_token_req.populate_chksum().unwrap();
 
             let prod_token_resp = self.process_message(
@@ -3006,8 +3011,13 @@ pub mod test {
 
             // Step 5: Send the signed token
             println!("  Sending signed token...");
-            let mut token_req =
-                McuMailboxReq::ProdDebugUnlockToken(McuProdDebugUnlockTokenReq(token));
+            let mut token_req = McuMailboxReq::ProdDebugUnlockToken(McuProdDebugUnlockTokenReq {
+                hdr: MailboxReqHeader::default(),
+                token,
+            });
+            if let McuMailboxReq::ProdDebugUnlockToken(req) = &mut token_req {
+                req.populate_caliptra_chksum().unwrap();
+            }
             token_req.populate_chksum().unwrap();
 
             let token_resp = self


### PR DESCRIPTION
Move the MCU Mailbox to use scratch backed `caliptra-api-lite` APIs.  

`MCU Mailbox` and `SPDM VDM` transports now use the same shared command backend/device operations for `debug unlock, attested CSR export, logging, and FE_PROG` execution. 

Currently, authorization remains transport-specific: MCU Mailbox uses `CommandAuthorizer`, while SPDM VDM retains separate challenge storage and inline HMAC verification. 
