### PR TITLE
[emulator] add missing debug feature to emulator runtime

### DIFF
--- a/platforms/emulator/runtime/Cargo.toml
+++ b/platforms/emulator/runtime/Cargo.toml
@@ -42,6 +42,7 @@ rv32i.workspace = true
 
 [features]
 default = []
+debug = []
 # Production / minimal-size build.  Strips:
 #   - kernel `debug!()` macro          (via kernel/no_debug_panics)
 #   - romtime `print!`/`println!`      (via caliptra-mcu-romtime/no-print)


### PR DESCRIPTION
Adds the missing `debug = []` feature to `[features]` in platforms/emulator/runtime/Cargo.toml. Without this feature, `cargo xtask runtime` fails when xtask passes `--features debug` to the emulator package.