### PR TITLE
Add erase_size() to FlashStorage trait

### DIFF
--- a/emulator/periph/src/flash_ctrl.rs
+++ b/emulator/periph/src/flash_ctrl.rs
@@ -104,7 +104,7 @@ impl DummyFlashCtrl {
     pub const PAGE_SIZE: usize = 256;
 
     /// Erase sector size. The minimum erase unit on real flash hardware.
-    pub const ERASE_SIZE: usize = 4096;
+    pub const ERASE_SECTOR_SIZE: usize = 4096;
 
     /// Maximum number of pages in the flash storage connected to the controller.
     /// This is a dummy value, the actual value should be set based on the flash storage size.
@@ -366,13 +366,13 @@ impl DummyFlashCtrl {
         }
 
         // Calculate the sector-aligned offset. Real flash hardware erases at
-        // sector (ERASE_SIZE) granularity, so we erase the entire sector
+        // sector (ERASE_SECTOR_SIZE) granularity, so we erase the entire sector
         // containing the given page.
         let byte_offset = (page_num as usize) * Self::PAGE_SIZE;
-        let sector_start = byte_offset - (byte_offset % Self::ERASE_SIZE);
+        let sector_start = byte_offset - (byte_offset % Self::ERASE_SECTOR_SIZE);
         let file = self.file.as_mut().unwrap();
         file.seek(std::io::SeekFrom::Start(sector_start as u64))
-            .and_then(|_| file.write_all(&vec![0xFF; Self::ERASE_SIZE]))
+            .and_then(|_| file.write_all(&vec![0xFF; Self::ERASE_SECTOR_SIZE]))
             .map_err(|_| FlashOpError::EraseError)?;
 
         Ok(())

--- a/emulator/periph/src/flash_ctrl.rs
+++ b/emulator/periph/src/flash_ctrl.rs
@@ -103,6 +103,9 @@ impl DummyFlashCtrl {
     /// Page size for the flash storage connected to the controller.
     pub const PAGE_SIZE: usize = 256;
 
+    /// Erase sector size. The minimum erase unit on real flash hardware.
+    pub const ERASE_SIZE: usize = 4096;
+
     /// Maximum number of pages in the flash storage connected to the controller.
     /// This is a dummy value, the actual value should be set based on the flash storage size.
     pub const MAX_PAGES: u32 = 64 * 1024 * 1024 / Self::PAGE_SIZE as u32;
@@ -362,10 +365,14 @@ impl DummyFlashCtrl {
             return Err(FlashOpError::EraseError);
         }
 
-        let offset = (page_num * Self::PAGE_SIZE as u32) as usize;
+        // Calculate the sector-aligned offset. Real flash hardware erases at
+        // sector (ERASE_SIZE) granularity, so we erase the entire sector
+        // containing the given page.
+        let byte_offset = (page_num as usize) * Self::PAGE_SIZE;
+        let sector_start = byte_offset - (byte_offset % Self::ERASE_SIZE);
         let file = self.file.as_mut().unwrap();
-        file.seek(std::io::SeekFrom::Start(offset as u64))
-            .and_then(|_| file.write_all(&vec![0xFF; Self::PAGE_SIZE]))
+        file.seek(std::io::SeekFrom::Start(sector_start as u64))
+            .and_then(|_| file.write_all(&vec![0xFF; Self::ERASE_SIZE]))
             .map_err(|_| FlashOpError::EraseError)?;
 
         Ok(())

--- a/hw/model/src/flash_ctrl.rs
+++ b/hw/model/src/flash_ctrl.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 const PAGE_SIZE: usize = 256;
+const ERASE_SIZE: usize = 4096;
 const NUM_PAGES: usize = (64 * 1024 * 1024) / PAGE_SIZE;
 const IO_COMPLETION_TIMEOUT_MS: u32 = 200;
 
@@ -136,10 +137,15 @@ impl ImaginaryFlashController {
             }
             FlashOp::Erase => {
                 if page_num < NUM_PAGES as u32 && page_size as usize == PAGE_SIZE {
-                    let erase_buf = vec![0xFFu8; PAGE_SIZE];
+                    // Erase at sector (ERASE_SIZE) granularity, matching real
+                    // flash hardware behavior where the minimum erase unit is
+                    // a sector (4 KiB), not a page (256 B).
+                    let byte_offset = page_num as usize * PAGE_SIZE;
+                    let sector_start = byte_offset - (byte_offset % ERASE_SIZE);
+                    let erase_buf = vec![0xFFu8; ERASE_SIZE];
                     let io_res = {
                         let mut file = self.flash_file.lock().unwrap();
-                        file.seek(std::io::SeekFrom::Start(page_num as u64 * PAGE_SIZE as u64))
+                        file.seek(std::io::SeekFrom::Start(sector_start as u64))
                             .and_then(|_| file.write_all(&erase_buf))
                     };
                     if io_res.is_ok() {

--- a/platforms/emulator/runtime/kernel/drivers/flash_ctrl/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/flash_ctrl/src/lib.rs
@@ -24,7 +24,7 @@ pub const SECONDARY_FLASH_CTRL_BASE: StaticRef<PrimaryFlashCtrl> =
     unsafe { StaticRef::new(SECONDARY_FLASH_CTRL_ADDR as *const PrimaryFlashCtrl) };
 
 pub const PAGE_SIZE: usize = 256;
-pub const ERASE_SIZE: usize = 4096;
+pub const ERASE_SECTOR_SIZE: usize = 4096;
 pub const FLASH_MAX_PAGES: usize = 64 * 1024 * 1024 / PAGE_SIZE;
 
 #[derive(Debug, PartialEq)]

--- a/platforms/emulator/runtime/kernel/drivers/flash_ctrl/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/flash_ctrl/src/lib.rs
@@ -24,6 +24,7 @@ pub const SECONDARY_FLASH_CTRL_BASE: StaticRef<PrimaryFlashCtrl> =
     unsafe { StaticRef::new(SECONDARY_FLASH_CTRL_ADDR as *const PrimaryFlashCtrl) };
 
 pub const PAGE_SIZE: usize = 256;
+pub const ERASE_SIZE: usize = 4096;
 pub const FLASH_MAX_PAGES: usize = 64 * 1024 * 1024 / PAGE_SIZE;
 
 #[derive(Debug, PartialEq)]

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -746,7 +746,7 @@ pub unsafe fn main() {
         board_kernel,
         mux_primary_flash,
         caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl,
-        caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
+        caliptra_mcu_flash_ctrl_emulator::ERASE_SECTOR_SIZE
     );
 
     // Create a mux for the recovery flash controller
@@ -762,7 +762,7 @@ pub unsafe fn main() {
         board_kernel,
         mux_secondary_flash,
         caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl,
-        caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
+        caliptra_mcu_flash_ctrl_emulator::ERASE_SECTOR_SIZE
     );
 
     let mut logging_flash: [Option<
@@ -830,7 +830,7 @@ pub unsafe fn main() {
         caliptra_mcu_flash_driver::flash_storage_to_pages::FlashStorageToPages::new(
             otp_fl_user,
             otp_page_buffer,
-            caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE,
+            caliptra_mcu_flash_ctrl_emulator::ERASE_SECTOR_SIZE,
         )
     );
     kernel::hil::flash::HasClient::set_client(otp_fl_user, otp_fs_to_pages);

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -745,7 +745,8 @@ pub unsafe fn main() {
         flash_partitions,
         board_kernel,
         mux_primary_flash,
-        caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl
+        caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl,
+        caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
     );
 
     // Create a mux for the recovery flash controller
@@ -760,7 +761,8 @@ pub unsafe fn main() {
         flash_partitions,
         board_kernel,
         mux_secondary_flash,
-        caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl
+        caliptra_mcu_flash_ctrl_emulator::EmulatedFlashCtrl,
+        caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
     );
 
     let mut logging_flash: [Option<
@@ -828,6 +830,7 @@ pub unsafe fn main() {
         caliptra_mcu_flash_driver::flash_storage_to_pages::FlashStorageToPages::new(
             otp_fl_user,
             otp_page_buffer,
+            caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE,
         )
     );
     kernel::hil::flash::HasClient::set_client(otp_fl_user, otp_fs_to_pages);

--- a/platforms/emulator/runtime/src/tests/flash_storage_test.rs
+++ b/platforms/emulator/runtime/src/tests/flash_storage_test.rs
@@ -19,7 +19,7 @@ use kernel::{static_buf, static_init};
 ))]
 use crate::board::run_kernel_op;
 
-pub const TEST_BUF_LEN: usize = 2048;
+pub const TEST_BUF_LEN: usize = 8192;
 
 pub struct IoState {
     read_bytes: usize,
@@ -84,7 +84,8 @@ macro_rules! static_init_fs_test {
                 static_init!(
                     caliptra_mcu_flash_ctrl_emulator::EmulatedFlashPage,
                     caliptra_mcu_flash_ctrl_emulator::EmulatedFlashPage::default()
-                )
+                ),
+                caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
             )
         );
 
@@ -115,7 +116,9 @@ fn test_single_flash_storage_erase(
     flash_storage_drv.set_client(test_cb);
 
     {
-        // Erase the entire test range [0..TEST_BUF_LEN)
+        let erase_size = caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE;
+
+        // Erase two sectors [0..TEST_BUF_LEN)
         let erase_len = TEST_BUF_LEN;
         test_cb.reset();
         assert!(flash_storage_drv.erase(0, erase_len).is_ok());
@@ -142,10 +145,10 @@ fn test_single_flash_storage_erase(
 
         test_cb.reset();
 
-        // Test non-page-aligned erase operation.
-        // Make sure it is within the test range of [0..TEST_BUF_LEN) that is written to flash.
-        let length: usize = 1600;
-        let offset: usize = 50;
+        // Test erase-size-aligned erase operation.
+        // Erase the second sector while keeping the first sector intact.
+        let offset: usize = erase_size;
+        let length: usize = erase_size;
 
         assert!(flash_storage_drv.erase(offset, length).is_ok());
 
@@ -154,6 +157,19 @@ fn test_single_flash_storage_erase(
 
         assert_eq!(test_cb.io_state.borrow().erase_bytes, length);
         test_cb.reset();
+
+        // Verify that non-erase-aligned address returns INVAL
+        assert_eq!(
+            flash_storage_drv.erase(50, erase_size),
+            Err(kernel::ErrorCode::INVAL)
+        );
+
+        // Non-aligned length is accepted (rounded up to next erase_size boundary)
+        // but non-aligned address is still rejected.
+        assert_eq!(
+            flash_storage_drv.erase(100, 100),
+            Err(kernel::ErrorCode::INVAL)
+        );
 
         // Read the entire test range to verify data integrity after erase operation.
         let read_in_buf = test_cb.read_in_buf.take().unwrap();

--- a/platforms/emulator/runtime/src/tests/flash_storage_test.rs
+++ b/platforms/emulator/runtime/src/tests/flash_storage_test.rs
@@ -85,7 +85,7 @@ macro_rules! static_init_fs_test {
                     caliptra_mcu_flash_ctrl_emulator::EmulatedFlashPage,
                     caliptra_mcu_flash_ctrl_emulator::EmulatedFlashPage::default()
                 ),
-                caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE
+                caliptra_mcu_flash_ctrl_emulator::ERASE_SECTOR_SIZE
             )
         );
 
@@ -116,7 +116,7 @@ fn test_single_flash_storage_erase(
     flash_storage_drv.set_client(test_cb);
 
     {
-        let erase_size = caliptra_mcu_flash_ctrl_emulator::ERASE_SIZE;
+        let erase_size = caliptra_mcu_flash_ctrl_emulator::ERASE_SECTOR_SIZE;
 
         // Erase two sectors [0..TEST_BUF_LEN)
         let erase_len = TEST_BUF_LEN;

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_flash_io.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_flash_io.rs
@@ -7,6 +7,7 @@ use caliptra_mcu_config_fpga::flash::STAGING_PARTITION;
 use caliptra_mcu_libsyscall_caliptra::flash::{FlashCapacity, SpiFlash};
 
 const BUF_LEN: usize = 1024;
+const ERASE_LEN: usize = 4096;
 const EXPECTED_CHUNK_SIZE: usize = 512;
 
 struct FlashTestConfig<'a> {
@@ -39,7 +40,7 @@ pub async fn test_flash_usermode_emulator() {
         expected_capacity: FlashCapacity(IMAGE_A_PARTITION.size as u32),
         expected_chunk_size: EXPECTED_CHUNK_SIZE,
         e_offset: IMAGE_A_PARTITION.offset,
-        e_len: BUF_LEN,
+        e_len: ERASE_LEN,
         w_offset: IMAGE_A_PARTITION.offset + 20,
         p_offset: IMAGE_A_PARTITION.offset,
         w_len: 1000,
@@ -53,7 +54,7 @@ pub async fn test_flash_usermode_emulator() {
         expected_capacity: FlashCapacity(IMAGE_B_PARTITION.size as u32),
         expected_chunk_size: EXPECTED_CHUNK_SIZE,
         e_offset: IMAGE_B_PARTITION.offset,
-        e_len: BUF_LEN,
+        e_len: ERASE_LEN,
         w_offset: IMAGE_B_PARTITION.offset + 20,
         p_offset: IMAGE_B_PARTITION.offset,
         w_len: 1000,
@@ -80,7 +81,7 @@ pub async fn test_flash_usermode_fpga() {
         expected_capacity: FlashCapacity(STAGING_PARTITION.size as u32),
         expected_chunk_size: EXPECTED_CHUNK_SIZE,
         e_offset: STAGING_PARTITION.offset,
-        e_len: BUF_LEN,
+        e_len: ERASE_LEN,
         w_offset: STAGING_PARTITION.offset + 20,
         p_offset: STAGING_PARTITION.offset,
         w_len: 1000,
@@ -132,13 +133,10 @@ async fn simple_test<'a>(test_cfg: &'a mut FlashTestConfig<'a>) {
     // Reset read buffer
     test_cfg.r_buf.iter_mut().for_each(|x| *x = 0);
 
-    // Read whole test region
+    // Read back a portion of the erased region to verify data integrity
+    let read_len = test_cfg.r_buf.len().min(test_cfg.e_len);
     let ret = flash_par
-        .read(
-            test_cfg.e_offset,
-            test_cfg.e_len,
-            test_cfg.r_buf as &mut [u8],
-        )
+        .read(test_cfg.e_offset, read_len, test_cfg.r_buf as &mut [u8])
         .await;
     assert_eq!(ret, Ok(()));
 
@@ -158,7 +156,7 @@ async fn simple_test<'a>(test_cfg: &'a mut FlashTestConfig<'a>) {
         }
 
         for i in (test_cfg.w_offset - test_cfg.p_offset + test_cfg.w_len).min(test_cfg.r_buf.len())
-            ..test_cfg.e_len.min(test_cfg.r_buf.len())
+            ..read_len.min(test_cfg.r_buf.len())
         {
             assert_eq!(test_cfg.r_buf[i], 0xFF, "data mismatch at {}", i);
         }

--- a/platforms/fpga/runtime/drivers/flash_ctrl/src/lib.rs
+++ b/platforms/fpga/runtime/drivers/flash_ctrl/src/lib.rs
@@ -16,6 +16,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::ErrorCode;
 
 pub const PAGE_SIZE: usize = 256;
+pub const ERASE_SIZE: usize = 4096;
 pub const FLASH_MAX_PAGES: usize = 64 * 1024 * 1024 / PAGE_SIZE;
 const SOC_RECEIVER_AXI_USER: u32 = 1;
 

--- a/platforms/fpga/runtime/drivers/flash_ctrl/src/lib.rs
+++ b/platforms/fpga/runtime/drivers/flash_ctrl/src/lib.rs
@@ -16,7 +16,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::ErrorCode;
 
 pub const PAGE_SIZE: usize = 256;
-pub const ERASE_SIZE: usize = 4096;
+pub const ERASE_SECTOR_SIZE: usize = 4096;
 pub const FLASH_MAX_PAGES: usize = 64 * 1024 * 1024 / PAGE_SIZE;
 const SOC_RECEIVER_AXI_USER: u32 = 1;
 

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -707,7 +707,8 @@ pub unsafe fn main() {
         staging_partition,
         board_kernel,
         mux_mcu_mbox_flash,
-        caliptra_mcu_flash_ctrl_fpga::EmulatedFlashCtrl
+        caliptra_mcu_flash_ctrl_fpga::EmulatedFlashCtrl,
+        caliptra_mcu_flash_ctrl_fpga::ERASE_SIZE
     );
     caliptra_mcu_romtime::println!("[mcu-runtime] Flash partition component initialized");
 
@@ -797,6 +798,7 @@ pub unsafe fn main() {
         caliptra_mcu_flash_driver::flash_storage_to_pages::FlashStorageToPages::new(
             otp_fl_user,
             otp_page_buffer,
+            caliptra_mcu_flash_ctrl_fpga::ERASE_SIZE,
         )
     );
     kernel::hil::flash::HasClient::set_client(otp_fl_user, otp_fs_to_pages);

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -708,7 +708,7 @@ pub unsafe fn main() {
         board_kernel,
         mux_mcu_mbox_flash,
         caliptra_mcu_flash_ctrl_fpga::EmulatedFlashCtrl,
-        caliptra_mcu_flash_ctrl_fpga::ERASE_SIZE
+        caliptra_mcu_flash_ctrl_fpga::ERASE_SECTOR_SIZE
     );
     caliptra_mcu_romtime::println!("[mcu-runtime] Flash partition component initialized");
 
@@ -798,7 +798,7 @@ pub unsafe fn main() {
         caliptra_mcu_flash_driver::flash_storage_to_pages::FlashStorageToPages::new(
             otp_fl_user,
             otp_page_buffer,
-            caliptra_mcu_flash_ctrl_fpga::ERASE_SIZE,
+            caliptra_mcu_flash_ctrl_fpga::ERASE_SECTOR_SIZE,
         )
     );
     kernel::hil::flash::HasClient::set_client(otp_fl_user, otp_fs_to_pages);

--- a/runtime/kernel/capsules/src/flash_partition.rs
+++ b/runtime/kernel/capsules/src/flash_partition.rs
@@ -341,6 +341,7 @@ impl SyscallDriver for FlashPartition<'_> {
     /// - `3`: Start a write
     /// - `4`: Start an erase
     /// - `5`: Return the chunk size for reads and writes
+    /// - `6`: Return the erase size (minimum erase granularity)
     fn command(
         &self,
         command_num: usize,
@@ -404,6 +405,11 @@ impl SyscallDriver for FlashPartition<'_> {
             5 => {
                 // Return the chunk size for reads and writes
                 CommandReturn::success_u32(BUF_LEN as u32)
+            }
+
+            6 => {
+                // Return the erase size (minimum erase granularity)
+                CommandReturn::success_u32(self.driver.erase_size() as u32)
             }
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/runtime/kernel/components/src/flash_partition.rs
+++ b/runtime/kernel/components/src/flash_partition.rs
@@ -16,7 +16,8 @@ macro_rules! instantiate_flash_partitions {
         $flash_partitions:ident,
         $kernel:expr,
         $mux:expr,
-        $flash_ctrl_ty:ty
+        $flash_ctrl_ty:ty,
+        $erase_size:expr
     ) => {{
         macro_rules! assign_partition {
             ($index:tt, $var:ident, $partition:ident) => {
@@ -30,6 +31,7 @@ macro_rules! instantiate_flash_partitions {
                         image_par_fl_user,
                         $partition.offset,
                         $partition.size,
+                        $erase_size,
                     )
                     .finalize(flash_partition_component_static!(
                         virtual_flash::FlashUser<'static, $flash_ctrl_ty>,
@@ -72,6 +74,7 @@ pub struct FlashPartitionComponent<
     flash: &'static F,
     start_address: usize,
     length: usize,
+    erase_size: usize,
 }
 
 impl<
@@ -89,6 +92,7 @@ impl<
         flash: &'static F,
         start_address: usize,
         length: usize,
+        erase_size: usize,
     ) -> Self {
         Self {
             board_kernel,
@@ -96,6 +100,7 @@ impl<
             flash,
             start_address,
             length,
+            erase_size,
         }
     }
 }
@@ -135,6 +140,7 @@ impl<
             caliptra_mcu_flash_driver::flash_storage_to_pages::FlashStorageToPages::new(
                 self.flash,
                 flash_pagebuffer,
+                self.erase_size,
             ),
         );
         hil::flash::HasClient::set_client(self.flash, fs_to_pages);

--- a/runtime/kernel/drivers/flash/src/flash_storage_to_pages.rs
+++ b/runtime/kernel/drivers/flash/src/flash_storage_to_pages.rs
@@ -53,12 +53,16 @@ pub struct FlashStorageToPages<'a, F: hil::flash::Flash + 'static> {
     remaining_length: Cell<usize>,
     /// Position in the user buffer.
     buffer_index: Cell<usize>,
-    /// Flag to indicate if the erase operation is done and write back is pending.
-    partial_erase_wb_pending: Cell<bool>,
+    /// Minimum erase granularity in bytes (e.g., 4096 for a 4 KiB sector).
+    erase_size: usize,
 }
 
 impl<'a, F: hil::flash::Flash> FlashStorageToPages<'a, F> {
-    pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> FlashStorageToPages<'a, F> {
+    pub fn new(
+        driver: &'a F,
+        buffer: &'static mut F::Page,
+        erase_size: usize,
+    ) -> FlashStorageToPages<'a, F> {
         FlashStorageToPages {
             driver,
             client: OptionalCell::empty(),
@@ -69,7 +73,7 @@ impl<'a, F: hil::flash::Flash> FlashStorageToPages<'a, F> {
             length: Cell::new(0),
             remaining_length: Cell::new(0),
             buffer_index: Cell::new(0),
-            partial_erase_wb_pending: Cell::new(false),
+            erase_size,
         }
     }
 }
@@ -178,6 +182,22 @@ impl<'a, F: hil::flash::Flash> crate::hil::FlashStorage<'a> for FlashStorageToPa
             return Err(ErrorCode::BUSY);
         }
 
+        let erase_size = self.erase_size;
+
+        // Validate that the erase address is aligned to the erase size.
+        if address % erase_size != 0 {
+            return Err(ErrorCode::INVAL);
+        }
+
+        // Round length up to the next erase_size boundary. Real flash hardware
+        // cannot erase less than a full sector, so any request that doesn't end
+        // on a sector boundary will erase through the end of the last sector.
+        let aligned_length = if length == 0 {
+            0
+        } else {
+            length.div_ceil(erase_size) * erase_size
+        };
+
         self.page_buffer
             .take()
             .map_or(Err(ErrorCode::RESERVE), move |page_buffer| {
@@ -186,28 +206,28 @@ impl<'a, F: hil::flash::Flash> crate::hil::FlashStorage<'a> for FlashStorageToPa
                 self.state.set(State::Erase);
                 self.length.set(length);
 
-                if address % page_size == 0 && length >= page_size {
-                    // This erase is aligned to a page and we are erasing an entire page.
-                    self.address.set(address + page_size);
-                    self.remaining_length.set(length - page_size);
+                if aligned_length >= erase_size {
+                    // Erase one sector. The underlying driver erases erase_size bytes
+                    // when erase_page is called.
+                    self.address.set(address + erase_size);
+                    self.remaining_length.set(aligned_length - erase_size);
 
                     self.page_buffer.replace(page_buffer);
 
                     self.driver.erase_page(address / page_size)
                 } else {
-                    // This erase is non-page-aligned, so we need to do a read first.
-                    self.address.set(address);
-                    self.remaining_length.set(length);
-
-                    match self.driver.read_page(address / page_size, page_buffer) {
-                        Ok(()) => Ok(()),
-                        Err((error_code, page_buffer)) => {
-                            self.page_buffer.replace(page_buffer);
-                            Err(error_code)
-                        }
-                    }
+                    // Nothing to erase (length == 0).
+                    self.page_buffer.replace(page_buffer);
+                    self.state.set(State::Idle);
+                    self.client
+                        .map(move |client| client.erase_done(self.length.get()));
+                    Ok(())
                 }
             })
+    }
+
+    fn erase_size(&self) -> usize {
+        self.erase_size
     }
 }
 
@@ -287,17 +307,9 @@ impl<F: hil::flash::Flash> hil::flash::Client<F> for FlashStorageToPages<'_, F> 
             }
 
             State::Erase => {
-                // A read was done because the operation is not page aligned on either or both ends.
-                // Perform erase after read.
-                let page_size = page_buffer.as_mut().len();
-                // Which page was read and which is going to be erased
-                let page_number = self.address.get() / page_size;
-
+                // Erase operations are now required to be erase-size-aligned,
+                // so this state should not be reached.
                 self.page_buffer.replace(page_buffer);
-
-                // set a flag write_back pending
-                self.partial_erase_wb_pending.set(true);
-                let _ = self.driver.erase_page(page_number);
             }
             _ => {}
         }
@@ -352,34 +364,9 @@ impl<F: hil::flash::Flash> hil::flash::Client<F> for FlashStorageToPages<'_, F> 
             }
 
             State::Erase => {
-                // After an erase, the operation could be done, need to do another erase, or need to
-                // do a read.
-                let page_size = page_buffer.as_mut().len();
-                if self.remaining_length.get() == 0 {
-                    // Done!
-                    self.page_buffer.replace(page_buffer);
-                    self.state.set(State::Idle);
-                    self.client
-                        .map(move |client| client.erase_done(self.length.get()));
-                } else if self.remaining_length.get() >= page_size {
-                    // Erase another page.
-                    let page_number = self.address.get() / page_size;
-
-                    self.remaining_length.subtract(page_size);
-                    self.address.add(page_size);
-
-                    self.page_buffer.replace(page_buffer);
-
-                    let _ = self.driver.erase_page(page_number);
-                } else {
-                    // Erase a partial page. Do read first.
-                    if let Err((_, page_buffer)) = self
-                        .driver
-                        .read_page(self.address.get() / page_size, page_buffer)
-                    {
-                        self.page_buffer.replace(page_buffer);
-                    }
-                }
+                // Erase operations are now required to be erase-size-aligned,
+                // so write_complete during erase should not occur.
+                self.page_buffer.replace(page_buffer);
             }
             _ => {}
         }
@@ -388,6 +375,7 @@ impl<F: hil::flash::Flash> hil::flash::Client<F> for FlashStorageToPages<'_, F> 
     fn erase_complete(&self, _result: Result<(), hil::flash::Error>) {
         if let Some(page_buffer) = self.page_buffer.take() {
             let page_size = page_buffer.as_mut().len();
+            let erase_size = self.erase_size;
 
             if self.remaining_length.get() == 0 {
                 // Done!
@@ -395,45 +383,23 @@ impl<F: hil::flash::Flash> hil::flash::Client<F> for FlashStorageToPages<'_, F> 
                 self.state.set(State::Idle);
                 self.client
                     .map(move |client| client.erase_done(self.length.get()));
-            } else if self.partial_erase_wb_pending.get() {
-                // Write back the page
-                let page_index = self.address.get() % page_size;
-                // Length is either the rest of the page or how much is left.
-                let len = cmp::min(page_size - page_index, self.remaining_length.get());
-                // Which page was read and which is going to be written back to.
+            } else if self.remaining_length.get() >= erase_size {
+                // Erase another sector
                 let page_number = self.address.get() / page_size;
 
-                self.remaining_length.subtract(len);
-                self.address.add(len);
-
-                // Fill the rest of the page buffer with 0xFF.
-                page_buffer.as_mut()[page_index..(len + page_index)].fill(0xFF);
-
-                // Perform the write.
-                if let Err((_, page_buffer)) = self.driver.write_page(page_number, page_buffer) {
-                    self.page_buffer.replace(page_buffer);
-                }
-
-                // Clear the flag
-                self.partial_erase_wb_pending.set(false);
-            } else if self.remaining_length.get() >= page_size {
-                // Erase another page
-                let page_number = self.address.get() / page_size;
-
-                self.remaining_length.subtract(page_size);
-                self.address.add(page_size);
+                self.remaining_length.subtract(erase_size);
+                self.address.add(erase_size);
 
                 self.page_buffer.replace(page_buffer);
 
                 let _ = self.driver.erase_page(page_number);
             } else {
-                // Erase a partial page. Do read first.
-                if let Err((_, page_buffer)) = self
-                    .driver
-                    .read_page(self.address.get() / page_size, page_buffer)
-                {
-                    self.page_buffer.replace(page_buffer);
-                }
+                // Remaining length is less than erase_size but non-zero.
+                // This should not happen because erase() validates alignment.
+                self.page_buffer.replace(page_buffer);
+                self.state.set(State::Idle);
+                self.client
+                    .map(move |client| client.erase_done(self.length.get()));
             }
         } else {
             panic!("internal page buffer must have been set for erase operation");

--- a/runtime/kernel/drivers/flash/src/hil.rs
+++ b/runtime/kernel/drivers/flash/src/hil.rs
@@ -38,9 +38,21 @@ pub trait FlashStorage<'a> {
         length: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])>;
 
-    /// Erase `length` bytes starting at address `address`. The address must be
-    /// in the address space of the physical storage.
+    /// Erase `length` bytes starting at address `address`. The `address` must
+    /// be aligned to the erase size returned by [`Self::erase_size`]. If
+    /// `length` is not a multiple of the erase size, it is rounded up to the
+    /// next erase boundary (real flash hardware cannot erase partial sectors).
+    /// The address must be in the address space of the physical storage.
     fn erase(&self, address: usize, length: usize) -> Result<(), ErrorCode>;
+
+    /// Returns the minimum erase granularity in bytes.
+    ///
+    /// On real flash hardware, the erase unit (sector) is typically larger than
+    /// the read/write page size. For example, a SPI NOR flash may have a 256-byte
+    /// page size for reads and writes but a 4096-byte (4 KiB) sector size for erases.
+    ///
+    /// Callers should ensure that erase operations are aligned to this size.
+    fn erase_size(&self) -> usize;
 }
 
 /// Client interface for flash storage.

--- a/runtime/userspace/libtock/unittest/src/fake/flash/mod.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/flash/mod.rs
@@ -8,6 +8,7 @@ pub struct FakeFlashDriver {
     exists: RefCell<bool>,
     capacity: RefCell<u32>,
     chunk_size: RefCell<usize>,
+    erase_size: RefCell<usize>,
     read_buffer: RefCell<RwAllowBuffer>,
     write_buffer: RefCell<RoAllowBuffer>,
     share_ref: DriverShareRef,
@@ -25,7 +26,8 @@ impl FakeFlashDriver {
         Self {
             exists: RefCell::new(true),
             capacity: RefCell::new(0),
-            chunk_size: RefCell::new(256), // Default chunk size
+            chunk_size: RefCell::new(256),  // Default chunk size
+            erase_size: RefCell::new(4096), // Default erase size (4 KiB sector)
             read_buffer: Default::default(),
             write_buffer: Default::default(),
             share_ref: Default::default(),
@@ -41,6 +43,11 @@ impl FakeFlashDriver {
     /// Set the chunk size for read/write operations
     pub fn set_chunk_size(&self, chunk_size: usize) {
         *self.chunk_size.borrow_mut() = chunk_size;
+    }
+
+    /// Set the erase size (minimum erase granularity)
+    pub fn set_erase_size(&self, erase_size: usize) {
+        *self.erase_size.borrow_mut() = erase_size;
     }
 
     /// Set the flash content
@@ -104,6 +111,9 @@ impl SyscallDriver for FakeFlashDriver {
                     .expect("Failed to schedule ERASE_DONE upcall");
                 crate::command_return::success()
             }
+            flash_storage_cmd::GET_ERASE_SIZE => {
+                crate::command_return::success_u32(*self.erase_size.borrow() as u32)
+            }
             _ => crate::command_return::failure(ErrorCode::Invalid),
         }
     }
@@ -148,6 +158,7 @@ mod flash_storage_cmd {
     pub const WRITE: u32 = 3;
     pub const ERASE: u32 = 4;
     pub const GET_CHUNK_SIZE: u32 = 5;
+    pub const GET_ERASE_SIZE: u32 = 6;
 }
 
 mod subscribe {

--- a/runtime/userspace/syscall/src/flash.rs
+++ b/runtime/userspace/syscall/src/flash.rs
@@ -69,6 +69,21 @@ impl<S: Syscalls> SpiFlash<S> {
             .map(|x: u32| x as usize)
     }
 
+    /// Gets the minimum erase granularity in bytes.
+    ///
+    /// On real flash hardware, the erase unit (sector) is typically larger than
+    /// the read/write page size. Erase operations must be aligned to this size.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(usize)` with the erase size in bytes.
+    /// * `Err(ErrorCode)` if there is an error.
+    pub fn get_erase_size(&self) -> Result<usize, ErrorCode> {
+        S::command(self.driver_num, flash_storage_cmd::GET_ERASE_SIZE, 0, 0)
+            .to_result()
+            .map(|x: u32| x as usize)
+    }
+
     /// Internal function to read a chunk of data from the flash memory.
     /// Don't use this function directly, use `read` instead.
     async fn read_chunk(
@@ -273,6 +288,7 @@ mod rw_allow {
 /// - `3`: Start a write
 /// - `4`: Start an erase
 /// - `5`: Get the chunk size for read/write operations.
+/// - `6`: Get the erase size (minimum erase granularity).
 mod flash_storage_cmd {
     pub const EXISTS: u32 = 0;
     pub const GET_CAPACITY: u32 = 1;
@@ -280,4 +296,5 @@ mod flash_storage_cmd {
     pub const WRITE: u32 = 3;
     pub const ERASE: u32 = 4;
     pub const GET_CHUNK_SIZE: u32 = 5;
+    pub const GET_ERASE_SIZE: u32 = 6;
 }


### PR DESCRIPTION
Addresses issue #1511 where FlashStorageToPages erases at page granularity (256B) instead of sector granularity (4KB+). On real SPI flash hardware, the minimum erase unit is a sector (typically 4KB), not a page.

Changes:
- Add erase_size() method to FlashStorage<'a> trait returning the minimum erase granularity in bytes
- Update FlashStorageToPages to accept erase_size parameter and use it for erase operations: one erase_page() call per sector instead of per page
- Require erase address alignment to erase_size; non-aligned lengths are rounded up to the next sector boundary (matching real flash behavior)
- Update emulator flash HW model (DummyFlashCtrl) to erase a full 4KB sector per erase_page() call
- Add ERASE_SIZE = 4096 constants to emulator and FPGA flash controllers
- Expose erase_size to userspace via new GET_ERASE_SIZE syscall command (6) in FlashPartition capsule
- Add get_erase_size() to userspace SpiFlash API and FakeFlashDriver
- Update FlashPartitionComponent and instantiate_flash_partitions! macro to propagate erase_size
- Update tests to use erase-aligned operations

Fixes: #1511