### PR TITLE
syscall: Cancel TockSubscribe on erase command failure

### DIFF
--- a/runtime/userspace/syscall/src/flash.rs
+++ b/runtime/userspace/syscall/src/flash.rs
@@ -228,14 +228,19 @@ impl<S: Syscalls> SpiFlash<S> {
     /// * `Ok(())` if the erase operation is successful.
     /// * `Err(ErrorCode)` if there is an error.
     pub async fn erase(&self, address: usize, len: usize) -> Result<(), ErrorCode> {
-        let async_erase_sub = TockSubscribe::subscribe::<S>(self.driver_num, subscribe::ERASE_DONE);
-        S::command(
+        let mut async_erase_sub =
+            TockSubscribe::subscribe::<S>(self.driver_num, subscribe::ERASE_DONE);
+        if let Err(e) = S::command(
             self.driver_num,
             flash_storage_cmd::ERASE,
             address as u32,
             len as u32,
         )
-        .to_result::<(), ErrorCode>()?;
+        .to_result::<(), ErrorCode>()
+        {
+            async_erase_sub.cancel();
+            return Err(e);
+        }
         async_erase_sub.await.map(|_| Ok(()))?
     }
 }


### PR DESCRIPTION
SpiFlash::erase() subscribes to the ERASE_DONE upcall before issuing the erase command. If the command fails (e.g., out-of-bounds address), the early return via ? drops the TockSubscribe future without a result, triggering a panic in TockSubscribe::drop().

Cancel the subscription before returning on error, matching the pattern already used in read_chunk() and write_chunk().

Fixes: #1524