### PR TITLE
Measurement API authorize_and_stash component update

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -74,6 +74,20 @@ default-filter = """
 #     poisoned-lock cascade in Drop) when run after the lifecycle tests;
 #     tracked upstream. Still runs on the emulator profile.
 
+[[profile.nightly-ci.overrides]]
+filter = "package(caliptra-mcu-tests-integration) and test(test_firmware_update_streaming_fpga)"
+# FPGA PLDM firmware-update streaming transfers are slow and now also cover
+# Measurement API auth-manifest validation before activation. Keep this timeout
+# scoped to the single FPGA streaming test instead of relaxing the full profile.
+slow-timeout = { period = "5m", terminate-after = 9 }
+
+[[profile.nightly-ci.overrides]]
+filter = "package(caliptra-mcu-tests-integration) and test(test_firmware_activate_fpga)"
+# This test performs the flash-backed activation path on FPGA hardware. W7 adds
+# auth-manifest validation before activation, which can exceed the profile's
+# default slow-test timeout while streaming mailbox payloads on real hardware.
+slow-timeout = { period = "5m", terminate-after = 9 }
+
 [profile.nightly-release]
 inherits = "nightly-emulator"
 default-filter = """

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -91,6 +91,7 @@ const FEATURES_REQUIRING_SOC_IMAGES: &[&str] = &[
     "test-streaming-boot-flash-write-back",
     "test-mctp-spdm-attestation",
     "test-mctp-spdm-attestation-pcr-quote",
+    "test-firmware-v2",
 ];
 
 /// Features that require flash-based boot (partition table at offset 0)

--- a/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
@@ -24,7 +24,10 @@ use caliptra_mcu_libtock_platform::ErrorCode;
 const RESET_REASON_FW_HITLESS_UPD_RESET_MASK: u32 = 0x1;
 
 #[allow(dead_code)]
-pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), ErrorCode> {
+pub async fn firmware_update<D: DMAMapping>(
+    dma_mapping: &D,
+    soc_image_load_list: &'static [u32],
+) -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
     let reset_reason = get_reset_reason()?;
 
@@ -51,6 +54,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         let mut updater = FirmwareUpdater::new(
             staging_memory,
             &fw_params,
+            soc_image_load_list,
             dma_mapping,
             EXECUTOR.get().spawner(),
             None,
@@ -115,6 +119,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         let mut updater = FirmwareUpdater::new(
             staging_memory,
             &fw_params,
+            soc_image_load_list,
             dma_mapping,
             EXECUTOR.get().spawner(),
             Some(&hooks),
@@ -134,6 +139,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         let mut updater = FirmwareUpdater::new(
             staging_memory,
             &fw_params,
+            soc_image_load_list,
             dma_mapping,
             EXECUTOR.get().spawner(),
             None,
@@ -171,6 +177,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         let mut updater = FirmwareUpdater::new(
             staging_memory,
             &fw_params,
+            soc_image_load_list,
             dma_mapping,
             EXECUTOR.get().spawner(),
             None,

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -245,8 +245,9 @@ async fn image_loading<D: DMAMapping>(
             FlashReaderDma::new(SpiFlash::new(load_partition.1.driver_num), dma_mapping);
         let flash_syscall = SpiFlash::new(load_partition.1.driver_num);
         let flash_image_loader = FlashImageLoader::new(flash_syscall, &buffered_dma);
+        let component_update = pending.is_some() && mcu_fw_hitless_update_reset;
 
-        if pending.is_some() {
+        if pending.is_some() && !mcu_fw_hitless_update_reset {
             // In the full MCU firmware-update hitless path, FirmwareUpdater already
             // sets the auth manifest before reset. Keep this call for direct
             // pending-partition boot and future SoC-only update paths until the
@@ -257,7 +258,6 @@ async fn image_loading<D: DMAMapping>(
             flash_image_loader.set_auth_manifest().await?;
         }
 
-        let component_update = pending.is_some() && mcu_fw_hitless_update_reset;
         load_soc_images(&flash_image_loader, soc_image_load_list, component_update).await?;
         boot_config
             .set_partition_status(load_partition.0, PartitionStatus::BootSuccessful)

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -39,7 +39,7 @@ use caliptra_mcu_libsyscall_caliptra::system::System;
 use caliptra_mcu_libtock_console::Console;
 use caliptra_mcu_libtock_platform::ErrorCode;
 #[cfg(any(feature = "streaming-boot", feature = "flash-boot"))]
-use caliptra_mcu_measurement_api::ImageMetadata;
+use caliptra_mcu_measurement_api::{ImageHashSource, ImageMetadata};
 #[allow(unused)]
 #[cfg(any(
     feature = "streaming-boot",
@@ -108,9 +108,9 @@ pub async fn image_loading_task(soc_image_load_list: &'static [u32]) {
     );
     let mci = MciSyscall::<DefaultSyscalls>::new();
     let reset_reason = mci.read(RESET_REASON, 0).unwrap();
-    if reset_reason & RESET_REASON_FW_HITLESS_UPD_RESET_MASK
-        == RESET_REASON_FW_HITLESS_UPD_RESET_MASK
-    {
+    let mcu_fw_hitless_update_reset = reset_reason & RESET_REASON_FW_HITLESS_UPD_RESET_MASK
+        == RESET_REASON_FW_HITLESS_UPD_RESET_MASK;
+    if mcu_fw_hitless_update_reset {
         // Device rebooted due to firmware update
         // MCU SRAM lock is acquired prior to rebooting the device
         // The lock is needed so that Caliptra can write the updated firmware from MCU MBOX SRAM to MCU SRAM
@@ -132,7 +132,13 @@ pub async fn image_loading_task(soc_image_load_list: &'static [u32]) {
             mbox_sram.release_lock().unwrap();
             mbox_sram.acquire_lock().unwrap();
         }
-        match image_loading(&EMULATED_DMA_MAPPING, soc_image_load_list).await {
+        match image_loading(
+            &EMULATED_DMA_MAPPING,
+            soc_image_load_list,
+            mcu_fw_hitless_update_reset,
+        )
+        .await
+        {
             Ok(_) => {}
             Err(_) => System::exit(1),
         }
@@ -150,7 +156,8 @@ pub async fn image_loading_task(soc_image_load_list: &'static [u32]) {
             mbox_sram.release_lock().unwrap();
             mbox_sram.acquire_lock().unwrap();
         }
-        match crate::firmware_update::firmware_update(&FPGA_DMA_MAPPING).await {
+        match crate::firmware_update::firmware_update(&FPGA_DMA_MAPPING, soc_image_load_list).await
+        {
             Ok(_) => System::exit(0),
             Err(_) => System::exit(1),
         }
@@ -165,7 +172,9 @@ pub async fn image_loading_task(soc_image_load_list: &'static [u32]) {
             mbox_sram.release_lock().unwrap();
             mbox_sram.acquire_lock().unwrap();
         }
-        match crate::firmware_update::firmware_update(&EMULATED_DMA_MAPPING).await {
+        match crate::firmware_update::firmware_update(&EMULATED_DMA_MAPPING, soc_image_load_list)
+            .await
+        {
             Ok(_) => System::exit(0),
             Err(_) => System::exit(1),
         }
@@ -178,6 +187,7 @@ pub async fn image_loading_task(soc_image_load_list: &'static [u32]) {
 async fn image_loading<D: DMAMapping>(
     dma_mapping: &'static D,
     soc_image_load_list: &'static [u32],
+    mcu_fw_hitless_update_reset: bool,
 ) -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
     crate::log_info!(console_writer, "IMAGE_LOADER_APP: Hello async world!");
@@ -189,7 +199,7 @@ async fn image_loading<D: DMAMapping>(
         };
         let pldm_image_loader =
             PldmImageLoader::new(&fw_params, EXECUTOR.get().spawner(), dma_mapping);
-        load_soc_images(&pldm_image_loader, soc_image_load_list).await?;
+        load_soc_images(&pldm_image_loader, soc_image_load_list, false).await?;
         // Close the PLDM session
         pldm_image_loader.finalize()?;
         // Wait for the PLDM service to fully complete the protocol before proceeding
@@ -236,12 +246,19 @@ async fn image_loading<D: DMAMapping>(
         let flash_syscall = SpiFlash::new(load_partition.1.driver_num);
         let flash_image_loader = FlashImageLoader::new(flash_syscall, &buffered_dma);
 
-        if let Some(pending) = pending {
-            // Set the new Auth Manifest from the pending partition
+        if pending.is_some() {
+            // In the full MCU firmware-update hitless path, FirmwareUpdater already
+            // sets the auth manifest before reset. Keep this call for direct
+            // pending-partition boot and future SoC-only update paths until the
+            // platform owns an explicit "auth manifest already set" signal.
+            // Depending on whether the SoC manifest preamble DPE contexts are
+            // updated during hitless update, setting the manifest here may also
+            // create mismatched journey measurements.
             flash_image_loader.set_auth_manifest().await?;
         }
 
-        load_soc_images(&flash_image_loader, soc_image_load_list).await?;
+        let component_update = pending.is_some() && mcu_fw_hitless_update_reset;
+        load_soc_images(&flash_image_loader, soc_image_load_list, component_update).await?;
         boot_config
             .set_partition_status(load_partition.0, PartitionStatus::BootSuccessful)
             .await
@@ -281,6 +298,7 @@ async fn image_loading<D: DMAMapping>(
 async fn load_soc_images(
     loader: &impl ImageLoader,
     soc_image_load_list: &'static [u32],
+    component_update: bool,
 ) -> Result<(), ErrorCode> {
     let mut scratch = Vec::new();
     scratch
@@ -301,8 +319,17 @@ async fn load_soc_images(
 
     for fw_id in soc_image_load_list {
         let loaded = loader.load(*fw_id).await?;
-        let metadata =
-            ImageMetadata::initial_load_from_load_address(loaded.image_size, loaded.measurement);
+        let metadata = if component_update {
+            ImageMetadata::component_update(
+                ImageHashSource::LoadAddress,
+                loaded.image_size,
+                loaded.measurement,
+                0,
+                0,
+            )
+        } else {
+            ImageMetadata::initial_load_from_load_address(loaded.image_size, loaded.measurement)
+        };
         caliptra_mcu_measurement_api::authorize_and_stash(&allocator, *fw_id, metadata)
             .await
             .map_err(|_| ErrorCode::Fail)?;

--- a/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
@@ -19,8 +19,8 @@ use crate::slice::{checked_slice_mut, copy_bytes, internal_slice};
 use crate::wire::{
     calc_checksum, mbox_execute, populate_checksum, CMD_CERTIFY_KEY_CHUNKS, CMD_DPE_TAG_TCI,
     CMD_INVOKE_DPE, DPE_CMD_DERIVE_CONTEXT, DPE_CMD_GET_CERTIFICATE_CHAIN,
-    DPE_CMD_ROTATE_CONTEXT_HANDLE, DPE_CMD_SIGN, DPE_COMMAND_MAGIC, DPE_PROFILE_P384_SHA384,
-    DPE_RESPONSE_MAGIC, MBOX_RESP_HEADER_SIZE,
+    DPE_CMD_ROTATE_CONTEXT_HANDLE, DPE_CMD_SIGN, DPE_CMD_UPDATE_CONTEXT_MEASUREMENT,
+    DPE_COMMAND_MAGIC, DPE_PROFILE_P384_SHA384, DPE_RESPONSE_MAGIC, MBOX_RESP_HEADER_SIZE,
 };
 use crate::ApiAlloc;
 
@@ -109,6 +109,17 @@ struct DeriveContextCmd {
     svn: U32,
 }
 
+/// `dpe::commands::UpdateContextMeasurementCmd`.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct UpdateContextMeasurementCmd {
+    parent_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    data: [u8; DPE_TCI_MEASUREMENT_SIZE],
+    reserved: U32,
+    tci_type: U32,
+    reserved_svn: U32,
+}
+
 /// `dpe::response::SignP384Resp`.
 #[repr(C)]
 #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
@@ -168,6 +179,15 @@ struct DeriveContextRespBody {
     parent_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
 }
 
+/// `dpe::response::UpdateContextMeasurementResp`.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct UpdateContextMeasurementRespBody {
+    _resp_hdr: [u8; 12],
+    new_context_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    new_parent_context_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+}
+
 /// Caliptra `TagTciReq`: `chksum(4) + handle(16) + tag(4)`. The
 /// `DPE_TAG_TCI` response carries no command-specific output.
 #[repr(C)]
@@ -193,6 +213,11 @@ const DERIVE_CONTEXT_REQ_LEN: usize =
     size_of::<InvokeDpeReqPrefix>() + size_of::<DpeCommandHdr>() + size_of::<DeriveContextCmd>();
 const DERIVE_CONTEXT_DPE_PAYLOAD_LEN: u32 =
     (size_of::<DpeCommandHdr>() + size_of::<DeriveContextCmd>()) as u32;
+const UPDATE_CONTEXT_MEASUREMENT_REQ_LEN: usize = size_of::<InvokeDpeReqPrefix>()
+    + size_of::<DpeCommandHdr>()
+    + size_of::<UpdateContextMeasurementCmd>();
+const UPDATE_CONTEXT_MEASUREMENT_DPE_PAYLOAD_LEN: u32 =
+    (size_of::<DpeCommandHdr>() + size_of::<UpdateContextMeasurementCmd>()) as u32;
 const CERTIFY_KEY_P384_RESP_PREFIX_LEN: usize = 12 + DPE_CONTEXT_HANDLE_SIZE + 48 + 48 + 4;
 const CERTIFY_KEY_CHUNKS_REQ_LEN: usize =
     4 + 4 + 4 + 4 + 4 + CERTIFY_KEY_CHUNKS_CERTIFY_KEY_REQ_SIZE;
@@ -224,14 +249,21 @@ const _: () = assert!(size_of::<SignP384Cmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 +
 const _: () = assert!(size_of::<SignP384RespBody>() == 12 + DPE_CONTEXT_HANDLE_SIZE + 48 + 48);
 const _: () =
     assert!(size_of::<DeriveContextCmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 4 + 4 + 4);
+const _: () =
+    assert!(size_of::<UpdateContextMeasurementCmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 4 + 4);
 const _: () = assert!(
     size_of::<DeriveContextRespBody>() == 12 + DPE_CONTEXT_HANDLE_SIZE + DPE_CONTEXT_HANDLE_SIZE
+);
+const _: () = assert!(
+    size_of::<UpdateContextMeasurementRespBody>()
+        == 12 + DPE_CONTEXT_HANDLE_SIZE + DPE_CONTEXT_HANDLE_SIZE
 );
 const _: () = assert!(size_of::<InvokeDpeRespPrefix>() == 12);
 const _: () = assert!(size_of::<DpeResponseHdr>() == 12);
 const _: () = assert!(GET_CERT_CHAIN_REQ_LEN == 28);
 const _: () = assert!(SIGN_REQ_LEN == 8 + 12 + 116);
 const _: () = assert!(DERIVE_CONTEXT_REQ_LEN == 8 + 12 + 80);
+const _: () = assert!(UPDATE_CONTEXT_MEASUREMENT_REQ_LEN == 8 + 12 + 76);
 const _: () =
     assert!(CERTIFY_KEY_CHUNKS_CERTIFY_KEY_REQ_SIZE == DPE_CONTEXT_HANDLE_SIZE + 4 + 4 + 48);
 const _: () = assert!(CERTIFY_KEY_P384_RESP_PREFIX_LEN == 128);
@@ -282,6 +314,23 @@ pub struct DpeDeriveContextResult {
     pub parent_handle: DpeContextHandle,
 }
 
+/// Parameters for one DPE `UpdateContextMeasurement` command.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct DpeUpdateContextMeasurementParams {
+    pub parent_handle: DpeContextHandle,
+    pub measurement: [u8; DPE_TCI_MEASUREMENT_SIZE],
+    pub tci_type: u32,
+}
+
+/// Handles returned by one DPE `UpdateContextMeasurement` command.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct DpeUpdateContextMeasurementResult {
+    /// Rotated component context handle.
+    pub component_handle: DpeContextHandle,
+    /// Rotated parent context handle.
+    pub parent_handle: DpeContextHandle,
+}
+
 /// Invoke DPE `DeriveContext`, returning the child handle and rotated parent handle.
 #[inline(never)]
 pub async fn dpe_derive_context<A: ApiAlloc>(
@@ -301,28 +350,11 @@ fn build_derive_context_req<'a, A: ApiAlloc>(
 ) -> McuResult<A::Buf<'a>> {
     let mut req = alloc.alloc(DERIVE_CONTEXT_REQ_LEN)?;
     req.fill(0);
-    {
-        let prefix = InvokeDpeReqPrefix::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            0,
-            size_of::<InvokeDpeReqPrefix>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        prefix.data_size = U32::new(DERIVE_CONTEXT_DPE_PAYLOAD_LEN);
-    }
-    let mut cur = size_of::<InvokeDpeReqPrefix>();
-    {
-        let hdr = DpeCommandHdr::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            cur,
-            size_of::<DpeCommandHdr>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
-        hdr.cmd_id = U32::new(DPE_CMD_DERIVE_CONTEXT);
-        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
-    }
-    cur += size_of::<DpeCommandHdr>();
+    let cur = build_invoke_dpe_header(
+        &mut req,
+        DERIVE_CONTEXT_DPE_PAYLOAD_LEN,
+        DPE_CMD_DERIVE_CONTEXT,
+    )?;
     {
         let cmd = DeriveContextCmd::mut_from_bytes(checked_slice_mut(
             &mut req,
@@ -368,6 +400,75 @@ fn parse_derive_context_response(rsp: &[u8], rsp_len: usize) -> McuResult<DpeDer
     })
 }
 
+/// Invoke DPE `UpdateContextMeasurement`, returning the rotated component and parent handles.
+#[inline(never)]
+pub async fn dpe_update_context_measurement<A: ApiAlloc>(
+    alloc: &A,
+    params: &DpeUpdateContextMeasurementParams,
+) -> McuResult<DpeUpdateContextMeasurementResult> {
+    let req = build_update_context_measurement_req(alloc, params)?;
+    let mut rsp = alloc
+        .alloc(size_of::<InvokeDpeRespPrefix>() + size_of::<UpdateContextMeasurementRespBody>())?;
+    let rsp_len = mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
+    parse_update_context_measurement_response(&rsp, rsp_len)
+}
+
+fn build_update_context_measurement_req<'a, A: ApiAlloc>(
+    alloc: &'a A,
+    params: &DpeUpdateContextMeasurementParams,
+) -> McuResult<A::Buf<'a>> {
+    let mut req = alloc.alloc(UPDATE_CONTEXT_MEASUREMENT_REQ_LEN)?;
+    req.fill(0);
+    let cur = build_invoke_dpe_header(
+        &mut req,
+        UPDATE_CONTEXT_MEASUREMENT_DPE_PAYLOAD_LEN,
+        DPE_CMD_UPDATE_CONTEXT_MEASUREMENT,
+    )?;
+    {
+        let cmd = UpdateContextMeasurementCmd::mut_from_bytes(checked_slice_mut(
+            &mut req,
+            cur,
+            size_of::<UpdateContextMeasurementCmd>(),
+        )?)
+        .map_err(|_| INVARIANT)?;
+        cmd.parent_handle = params.parent_handle;
+        cmd.data = params.measurement;
+        cmd.tci_type = U32::new(params.tci_type);
+    }
+    let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
+    Ok(req)
+}
+
+fn parse_update_context_measurement_response(
+    rsp: &[u8],
+    rsp_len: usize,
+) -> McuResult<DpeUpdateContextMeasurementResult> {
+    let resp_body_off = size_of::<InvokeDpeRespPrefix>();
+    if rsp_len < resp_body_off + size_of::<UpdateContextMeasurementRespBody>() {
+        return Err(INTERNAL_BUG);
+    }
+    let dpe_hdr = DpeResponseHdr::ref_from_bytes(internal_slice(
+        rsp,
+        resp_body_off,
+        size_of::<DpeResponseHdr>(),
+    )?)
+    .map_err(|_| INTERNAL_BUG)?;
+    if dpe_hdr.magic.get() != DPE_RESPONSE_MAGIC || dpe_hdr.status.get() != 0 {
+        return Err(INTERNAL_BUG);
+    }
+    let body = UpdateContextMeasurementRespBody::ref_from_bytes(internal_slice(
+        rsp,
+        resp_body_off,
+        size_of::<UpdateContextMeasurementRespBody>(),
+    )?)
+    .map_err(|_| INTERNAL_BUG)?;
+    Ok(DpeUpdateContextMeasurementResult {
+        component_handle: body.new_context_handle,
+        parent_handle: body.new_parent_context_handle,
+    })
+}
+
 /// Fetch a chunk of the Caliptra-managed DPE certificate chain via
 /// the `INVOKE_DPE / GetCertificateChain` mailbox command.
 ///
@@ -389,28 +490,11 @@ pub async fn dpe_get_cert_chain_chunk<A: ApiAlloc>(
     // Build request: prefix + DPE command header + GetCertChain body.
     let mut req = alloc.alloc(GET_CERT_CHAIN_REQ_LEN)?;
     req.fill(0);
-    {
-        let prefix = InvokeDpeReqPrefix::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            0,
-            size_of::<InvokeDpeReqPrefix>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        prefix.data_size = U32::new(GET_CERT_CHAIN_DPE_PAYLOAD_LEN);
-    }
-    let mut cur = size_of::<InvokeDpeReqPrefix>();
-    {
-        let hdr = DpeCommandHdr::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            cur,
-            size_of::<DpeCommandHdr>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
-        hdr.cmd_id = U32::new(DPE_CMD_GET_CERTIFICATE_CHAIN);
-        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
-    }
-    cur += size_of::<DpeCommandHdr>();
+    let cur = build_invoke_dpe_header(
+        &mut req,
+        GET_CERT_CHAIN_DPE_PAYLOAD_LEN,
+        DPE_CMD_GET_CERTIFICATE_CHAIN,
+    )?;
     {
         let cmd = GetCertChainCmd::mut_from_bytes(checked_slice_mut(
             &mut req,
@@ -676,6 +760,30 @@ fn build_certify_key_chunks_req<'a, A: ApiAlloc>(
     Ok(req)
 }
 
+fn build_invoke_dpe_header(req: &mut [u8], dpe_payload_len: u32, cmd_id: u32) -> McuResult<usize> {
+    {
+        let prefix = InvokeDpeReqPrefix::mut_from_bytes(checked_slice_mut(
+            req,
+            0,
+            size_of::<InvokeDpeReqPrefix>(),
+        )?)
+        .map_err(|_| INVARIANT)?;
+        prefix.data_size = U32::new(dpe_payload_len);
+    }
+
+    let cur = size_of::<InvokeDpeReqPrefix>();
+    {
+        let hdr =
+            DpeCommandHdr::mut_from_bytes(checked_slice_mut(req, cur, size_of::<DpeCommandHdr>())?)
+                .map_err(|_| INVARIANT)?;
+        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
+        hdr.cmd_id = U32::new(cmd_id);
+        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
+    }
+
+    Ok(cur + size_of::<DpeCommandHdr>())
+}
+
 #[inline]
 fn write_fixed(dst: &mut [u8], offset: usize, src: &[u8]) -> McuResult<()> {
     let end = offset.checked_add(src.len()).ok_or(INVARIANT)?;
@@ -768,28 +876,7 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
 
     let mut req = alloc.alloc(SIGN_REQ_LEN)?;
     req.fill(0);
-    {
-        let prefix = InvokeDpeReqPrefix::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            0,
-            size_of::<InvokeDpeReqPrefix>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        prefix.data_size = U32::new(SIGN_DPE_PAYLOAD_LEN);
-    }
-    let mut cur = size_of::<InvokeDpeReqPrefix>();
-    {
-        let hdr = DpeCommandHdr::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            cur,
-            size_of::<DpeCommandHdr>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
-        hdr.cmd_id = U32::new(DPE_CMD_SIGN);
-        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
-    }
-    cur += size_of::<DpeCommandHdr>();
+    let cur = build_invoke_dpe_header(&mut req, SIGN_DPE_PAYLOAD_LEN, DPE_CMD_SIGN)?;
     {
         let cmd = SignP384Cmd::mut_from_bytes(checked_slice_mut(
             &mut req,
@@ -853,28 +940,11 @@ pub async fn dpe_rotate_context_default<A: ApiAlloc>(
     // Build request: prefix + DPE command header + RotateCtx body.
     let mut req = alloc.alloc(ROTATE_CTX_REQ_LEN)?;
     req.fill(0);
-    {
-        let prefix = InvokeDpeReqPrefix::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            0,
-            size_of::<InvokeDpeReqPrefix>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        prefix.data_size = U32::new(ROTATE_CTX_DPE_PAYLOAD_LEN);
-    }
-    let mut cur = size_of::<InvokeDpeReqPrefix>();
-    {
-        let hdr = DpeCommandHdr::mut_from_bytes(checked_slice_mut(
-            &mut req,
-            cur,
-            size_of::<DpeCommandHdr>(),
-        )?)
-        .map_err(|_| INVARIANT)?;
-        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
-        hdr.cmd_id = U32::new(DPE_CMD_ROTATE_CONTEXT_HANDLE);
-        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
-    }
-    cur += size_of::<DpeCommandHdr>();
+    let cur = build_invoke_dpe_header(
+        &mut req,
+        ROTATE_CTX_DPE_PAYLOAD_LEN,
+        DPE_CMD_ROTATE_CONTEXT_HANDLE,
+    )?;
     {
         // `handle` stays the default (all-zero) context handle from the zeroed
         // request buffer; empty `flags` request a freshly generated handle.
@@ -1002,6 +1072,21 @@ mod tests {
     }
 
     #[test]
+    fn update_context_measurement_wire_layout() {
+        assert_eq!(DPE_CMD_UPDATE_CONTEXT_MEASUREMENT, 0x8000_0000);
+        assert_eq!(
+            size_of::<UpdateContextMeasurementCmd>(),
+            DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 4 + 4
+        );
+        assert_eq!(
+            size_of::<UpdateContextMeasurementRespBody>(),
+            12 + DPE_CONTEXT_HANDLE_SIZE * 2
+        );
+        assert_eq!(UPDATE_CONTEXT_MEASUREMENT_REQ_LEN, 8 + 12 + 76);
+        assert_eq!(UPDATE_CONTEXT_MEASUREMENT_DPE_PAYLOAD_LEN, (12 + 76) as u32);
+    }
+
+    #[test]
     fn tag_tci_wire_layout() {
         assert_eq!(CMD_DPE_TAG_TCI, 0x5451_4754);
         assert_eq!(TAG_TCI_REQ_LEN, 4 + DPE_CONTEXT_HANDLE_SIZE + 4);
@@ -1051,6 +1136,30 @@ mod tests {
     }
 
     #[test]
+    fn update_context_measurement_request_preserves_fields() {
+        let alloc = TestAlloc;
+        let params = DpeUpdateContextMeasurementParams {
+            parent_handle: [0xa5u8; DPE_CONTEXT_HANDLE_SIZE],
+            measurement: [0x5au8; DPE_TCI_MEASUREMENT_SIZE],
+            tci_type: 0x1122_3344,
+        };
+
+        let req = build_update_context_measurement_req(&alloc, &params).unwrap();
+        let payload_len =
+            u32::from_le_bytes(*req.get(4..8).and_then(|s| s.first_chunk::<4>()).unwrap());
+        let hdr = DpeCommandHdr::ref_from_bytes(&req[8..20]).unwrap();
+        let cmd = UpdateContextMeasurementCmd::ref_from_bytes(&req[20..96]).unwrap();
+
+        assert_eq!(payload_len, UPDATE_CONTEXT_MEASUREMENT_DPE_PAYLOAD_LEN);
+        assert_eq!(hdr.cmd_id.get(), DPE_CMD_UPDATE_CONTEXT_MEASUREMENT);
+        assert_eq!(cmd.parent_handle, params.parent_handle);
+        assert_eq!(cmd.data, params.measurement);
+        assert_eq!(cmd.reserved.get(), 0);
+        assert_eq!(cmd.tci_type.get(), params.tci_type);
+        assert_eq!(cmd.reserved_svn.get(), 0);
+    }
+
+    #[test]
     fn none_handle_maps_to_default_handle() {
         assert_eq!(dpe_handle_or_default(None), &DEFAULT_DPE_CONTEXT_HANDLE);
     }
@@ -1091,5 +1200,41 @@ mod tests {
                 parent_handle
             }
         );
+    }
+
+    #[test]
+    fn update_context_measurement_reads_component_and_parent_handles() {
+        let component_handle = [0x3cu8; DPE_CONTEXT_HANDLE_SIZE];
+        let parent_handle = [0xc3u8; DPE_CONTEXT_HANDLE_SIZE];
+        let mut rsp = [0u8; 12 + 12 + DPE_CONTEXT_HANDLE_SIZE * 2];
+        let resp_body_off = size_of::<InvokeDpeRespPrefix>();
+        rsp[resp_body_off..resp_body_off + 4].copy_from_slice(&DPE_RESPONSE_MAGIC.to_le_bytes());
+        rsp[resp_body_off + 8..resp_body_off + 12]
+            .copy_from_slice(&DPE_PROFILE_P384_SHA384.to_le_bytes());
+        rsp[resp_body_off + 12..resp_body_off + 12 + DPE_CONTEXT_HANDLE_SIZE]
+            .copy_from_slice(&component_handle);
+        rsp[resp_body_off + 12 + DPE_CONTEXT_HANDLE_SIZE
+            ..resp_body_off + 12 + DPE_CONTEXT_HANDLE_SIZE * 2]
+            .copy_from_slice(&parent_handle);
+
+        assert_eq!(
+            parse_update_context_measurement_response(&rsp, rsp.len()).unwrap(),
+            DpeUpdateContextMeasurementResult {
+                component_handle,
+                parent_handle
+            }
+        );
+    }
+
+    #[test]
+    fn update_context_measurement_rejects_dpe_error_status() {
+        let mut rsp = [0u8; 12 + 12 + DPE_CONTEXT_HANDLE_SIZE * 2];
+        let resp_body_off = size_of::<InvokeDpeRespPrefix>();
+        rsp[resp_body_off..resp_body_off + 4].copy_from_slice(&DPE_RESPONSE_MAGIC.to_le_bytes());
+        rsp[resp_body_off + 4..resp_body_off + 8].copy_from_slice(&1u32.to_le_bytes());
+        rsp[resp_body_off + 8..resp_body_off + 12]
+            .copy_from_slice(&DPE_PROFILE_P384_SHA384.to_le_bytes());
+
+        assert!(parse_update_context_measurement_response(&rsp, rsp.len()).is_err());
     }
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -63,9 +63,11 @@ pub use device_state::{get_pcr_value, pcr_quote_ecc384, PCR_QUOTE_ECC384_LEN};
 pub use dpe::{
     dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
     dpe_derive_context, dpe_get_cert_chain_chunk, dpe_rotate_context_default, dpe_sign_ecc_p384,
-    dpe_tag_tci, walk_dpe_chain, DpeChainSink, DpeContextHandle, DpeDeriveContextFlags,
-    DpeDeriveContextParams, DpeDeriveContextResult, DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN,
-    DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE, DPE_TCI_MEASUREMENT_SIZE,
+    dpe_tag_tci, dpe_update_context_measurement, walk_dpe_chain, DpeChainSink, DpeContextHandle,
+    DpeDeriveContextFlags, DpeDeriveContextParams, DpeDeriveContextResult,
+    DpeUpdateContextMeasurementParams, DpeUpdateContextMeasurementResult, DPE_CONTEXT_HANDLE_SIZE,
+    DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE,
+    DPE_TCI_MEASUREMENT_SIZE,
 };
 pub use ecdh::{
     ecdh_finish, ecdh_generate, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,

--- a/runtime/userspace/api/caliptra-api-lite/src/wire.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/wire.rs
@@ -68,6 +68,9 @@ pub(crate) const DPE_PROFILE_P384_SHA384: u32 = 4;
 /// DPE `DeriveContext` command ID (`dpe::commands::Command::DERIVE_CONTEXT`).
 pub(crate) const DPE_CMD_DERIVE_CONTEXT: u32 = 0x08;
 
+/// DPE vendor `UpdateContextMeasurement` command ID.
+pub(crate) const DPE_CMD_UPDATE_CONTEXT_MEASUREMENT: u32 = 0x8000_0000;
+
 /// DPE `GetCertificateChain` command ID
 /// (`dpe::commands::Command::GET_CERTIFICATE_CHAIN`).
 pub(crate) const DPE_CMD_GET_CERTIFICATE_CHAIN: u32 = 0x10;

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -51,6 +51,7 @@ pub struct FirmwareUpdater<'a, D: DMAMapping> {
     staging_memory: &'static dyn StagingMemory,
     mailbox: Mailbox,
     params: &'a PldmFirmwareDeviceParams,
+    soc_image_load_fw_ids: &'a [u32],
     dma_mapping: &'a D,
     spawner: Spawner,
     skip_activation: bool,
@@ -74,6 +75,7 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
     pub fn new(
         staging_memory: &'static dyn StagingMemory,
         params: &'a PldmFirmwareDeviceParams,
+        soc_image_load_fw_ids: &'a [u32],
         dma_mapping: &'a D,
         spawner: Spawner,
         hooks: Option<&'a dyn FirmwareUpdateHooks>,
@@ -82,6 +84,7 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             staging_memory,
             mailbox: Mailbox::new(),
             params,
+            soc_image_load_fw_ids,
             dma_mapping,
             spawner,
             skip_activation: false,
@@ -258,6 +261,8 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             )
             .await
             .map_err(|_| ErrorCode::Fail)?;
+        self.validate_auth_manifest_soc_fw_id_set(manifest_offset, manifest_len)
+            .await?;
 
         let mut req = AuthManifestReqHeader {
             chksum: 0,
@@ -365,6 +370,8 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             .await
             .map_err(|_| ErrorCode::Fail)?;
         self.verify_manifest(manifest_offset, manifest_len).await?;
+        self.validate_auth_manifest_soc_fw_id_set(manifest_offset, manifest_len)
+            .await?;
 
         for i in 0..flash_header.image_count as usize {
             let image_header = self
@@ -550,38 +557,14 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         manifest_size: usize,
         image_id: u32,
     ) -> Result<AuthManifestImageMetadata, ErrorCode> {
-        let entry_count_offset = manifest_staging_mem_offset
-            + offset_of!(AuthorizationManifest, image_metadata_col)
-            + offset_of!(AuthManifestImageMetadataCollection, entry_count);
-        if entry_count_offset + 4 > manifest_staging_mem_offset + manifest_size {
-            return Err(ErrorCode::Fail);
-        }
-
-        // Read the entry count from staging memory
-        let mut entry_count = [0u8; 4];
-        self.staging_memory
-            .read(entry_count_offset, &mut entry_count)
+        let entry_count = self
+            .get_image_metadata_entry_count(manifest_staging_mem_offset, manifest_size)
             .await?;
-        let entry_count = u32::from_le_bytes(entry_count);
-
-        let image_metadata_collection_offset = manifest_staging_mem_offset
-            + offset_of!(AuthorizationManifest, image_metadata_col)
-            + offset_of!(AuthManifestImageMetadataCollection, image_metadata_list);
 
         for i in 0..entry_count as usize {
-            let metadata_offset = image_metadata_collection_offset
-                + i * core::mem::size_of::<AuthManifestImageMetadata>();
-            let mut metadata_bytes = [0u8; core::mem::size_of::<AuthManifestImageMetadata>()];
-            if metadata_offset + metadata_bytes.len() > manifest_staging_mem_offset + manifest_size
-            {
-                return Err(ErrorCode::Fail);
-            }
-            self.staging_memory
-                .read(metadata_offset, &mut metadata_bytes)
+            let metadata = self
+                .get_image_metadata_by_index(manifest_staging_mem_offset, manifest_size, i)
                 .await?;
-
-            let (metadata, _) = AuthManifestImageMetadata::read_from_prefix(&metadata_bytes)
-                .map_err(|_| ErrorCode::Fail)?;
 
             if metadata.fw_id == image_id {
                 return Ok(metadata);
@@ -589,6 +572,111 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         }
 
         Err(ErrorCode::Fail)
+    }
+
+    async fn get_image_metadata_entry_count(
+        &self,
+        manifest_staging_mem_offset: usize,
+        manifest_size: usize,
+    ) -> Result<u32, ErrorCode> {
+        let entry_count_offset = manifest_staging_mem_offset
+            + offset_of!(AuthorizationManifest, image_metadata_col)
+            + offset_of!(AuthManifestImageMetadataCollection, entry_count);
+        if entry_count_offset + 4 > manifest_staging_mem_offset + manifest_size {
+            return Err(ErrorCode::Fail);
+        }
+
+        let mut entry_count = [0u8; 4];
+        self.staging_memory
+            .read(entry_count_offset, &mut entry_count)
+            .await?;
+        Ok(u32::from_le_bytes(entry_count))
+    }
+
+    async fn get_image_metadata_by_index(
+        &self,
+        manifest_staging_mem_offset: usize,
+        manifest_size: usize,
+        index: usize,
+    ) -> Result<AuthManifestImageMetadata, ErrorCode> {
+        let image_metadata_collection_offset = manifest_staging_mem_offset
+            + offset_of!(AuthorizationManifest, image_metadata_col)
+            + offset_of!(AuthManifestImageMetadataCollection, image_metadata_list);
+        let metadata_offset = image_metadata_collection_offset
+            + index * core::mem::size_of::<AuthManifestImageMetadata>();
+        let mut metadata_bytes = [0u8; core::mem::size_of::<AuthManifestImageMetadata>()];
+        if metadata_offset + metadata_bytes.len() > manifest_staging_mem_offset + manifest_size {
+            return Err(ErrorCode::Fail);
+        }
+        self.staging_memory
+            .read(metadata_offset, &mut metadata_bytes)
+            .await?;
+
+        let (metadata, _) = AuthManifestImageMetadata::read_from_prefix(&metadata_bytes)
+            .map_err(|_| ErrorCode::Fail)?;
+        Ok(metadata)
+    }
+
+    async fn validate_auth_manifest_soc_fw_id_set(
+        &self,
+        manifest_staging_mem_offset: usize,
+        manifest_size: usize,
+    ) -> Result<(), ErrorCode> {
+        let entry_count = self
+            .get_image_metadata_entry_count(manifest_staging_mem_offset, manifest_size)
+            .await?;
+        let mut manifest_soc_fw_id_count = 0usize;
+        for i in 0..entry_count as usize {
+            let metadata = self
+                .get_image_metadata_by_index(manifest_staging_mem_offset, manifest_size, i)
+                .await?;
+            if metadata.fw_id != MCU_RT_IDENTIFIER {
+                manifest_soc_fw_id_count = manifest_soc_fw_id_count
+                    .checked_add(1)
+                    .ok_or(ErrorCode::Fail)?;
+                if !self.soc_image_load_fw_ids.contains(&metadata.fw_id) {
+                    return Err(ErrorCode::Fail);
+                }
+            }
+        }
+
+        if manifest_soc_fw_id_count != self.soc_image_load_fw_ids.len() {
+            return Err(ErrorCode::Fail);
+        }
+
+        for expected_fw_id in self.soc_image_load_fw_ids.iter().copied() {
+            if !self
+                .auth_manifest_contains_fw_id(
+                    manifest_staging_mem_offset,
+                    manifest_size,
+                    entry_count,
+                    expected_fw_id,
+                )
+                .await?
+            {
+                return Err(ErrorCode::Fail);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn auth_manifest_contains_fw_id(
+        &self,
+        manifest_staging_mem_offset: usize,
+        manifest_size: usize,
+        entry_count: u32,
+        fw_id: u32,
+    ) -> Result<bool, ErrorCode> {
+        for i in 0..entry_count as usize {
+            let metadata = self
+                .get_image_metadata_by_index(manifest_staging_mem_offset, manifest_size, i)
+                .await?;
+            if metadata.fw_id == fw_id {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     async fn process_caliptra_fw(
@@ -1072,4 +1160,69 @@ impl PayloadStream for MailboxPayloadStream {
 pub struct AuthManifestReqHeader {
     pub chksum: u32,
     pub manifest_size: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: u32 = 0x1000;
+    const B: u32 = 0x2000;
+    const C: u32 = 0x3000;
+    const D: u32 = 0x4000;
+
+    fn validate_soc_fw_id_same_set(
+        cold_boot_soc_fw_ids: &[u32],
+        manifest_soc_fw_ids: &[u32],
+    ) -> Result<(), ErrorCode> {
+        if cold_boot_soc_fw_ids.len() != manifest_soc_fw_ids.len() {
+            return Err(ErrorCode::Fail);
+        }
+
+        for (index, fw_id) in manifest_soc_fw_ids.iter().copied().enumerate() {
+            if manifest_soc_fw_ids
+                .iter()
+                .take(index)
+                .any(|existing| *existing == fw_id)
+            {
+                return Err(ErrorCode::Fail);
+            }
+            if !cold_boot_soc_fw_ids.contains(&fw_id) {
+                return Err(ErrorCode::Fail);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn validate_soc_fw_id_same_set_accepts_matching_sets() {
+        for (cold_boot, manifest) in [
+            (&[][..], &[][..]),
+            (&[A][..], &[A][..]),
+            (&[A, B][..], &[A, B][..]),
+            (&[A, B][..], &[B, A][..]),
+            (&[A, B, C][..], &[C, A, B][..]),
+        ] {
+            assert!(validate_soc_fw_id_same_set(cold_boot, manifest).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_soc_fw_id_same_set_rejects_mismatched_sets() {
+        for (cold_boot, manifest) in [
+            (&[][..], &[A][..]),
+            (&[A][..], &[][..]),
+            (&[A, B][..], &[A][..]),
+            (&[A, B][..], &[A, B, C][..]),
+            (&[A, B][..], &[A, C][..]),
+            (&[A, B][..], &[C, A][..]),
+            (&[A, B][..], &[A, A][..]),
+            (&[A, B][..], &[B, B][..]),
+            (&[A, B, C][..], &[A, B, B][..]),
+            (&[A, B, C][..], &[A, B, D][..]),
+        ] {
+            assert!(validate_soc_fw_id_same_set(cold_boot, manifest).is_err());
+        }
+    }
 }

--- a/runtime/userspace/api/measurement-api/src/api/component_update.rs
+++ b/runtime/userspace/api/measurement-api/src/api/component_update.rs
@@ -1,0 +1,265 @@
+// Licensed under the Apache-2.0 license
+
+//! Component-update `authorize_and_stash` implementation details.
+
+use caliptra_mcu_libsyscall_caliptra::dpe_handle_store::{
+    DpeHandleRecord, DpeHandleStore, DPE_HANDLE_STORE_DRIVER_NUM,
+};
+use caliptra_mcu_libsyscall_caliptra::soft_pcr_store::{
+    MeasurementRecord, SoftwarePcrStore, SOFT_PCR_STORE_DRIVER_NUM,
+};
+use caliptra_mcu_libtock_platform::Syscalls;
+use mcu_caliptra_api_lite::{
+    authorize_and_stash as caliptra_authorize, dpe_update_context_measurement, extend_pcr31,
+    sha_finish, sha_init, sha_update, ApiAlloc, DpeUpdateContextMeasurementParams,
+    DpeUpdateContextMeasurementResult, HashAlgo, SHA_CONTEXT_SIZE,
+};
+
+use super::{caliptra_authorize_params, MeasurementApi};
+use crate::attestation_manifest::AttestationManifestEntry;
+use crate::errors::{MeasurementApiError, MeasurementApiResult};
+use crate::ImageMetadata;
+
+pub(super) async fn authorize_and_stash<S: Syscalls, A: ApiAlloc>(
+    api: &mut MeasurementApi<'_, S>,
+    alloc: &A,
+    fw_id: u32,
+    metadata: ImageMetadata,
+) -> MeasurementApiResult {
+    api.attestation_state_active()?;
+    let entry = api
+        .manifest
+        .lookup(fw_id)
+        .map_err(|_| MeasurementApiError::UnknownFwId)?;
+
+    let params = caliptra_authorize_params(fw_id, metadata);
+    caliptra_authorize(alloc, &params)
+        .await
+        .map_err(|_| MeasurementApiError::ImageAuthorizationFailed)?;
+
+    if entry.is_tcb() {
+        update_tcb_context(api, alloc, entry, metadata).await?;
+    } else {
+        update_software_pcr(api, alloc, entry, metadata).await?;
+    }
+
+    extend_pcr31(&metadata.measurement)
+        .await
+        .map_err(|_| api.enter_error_state(MeasurementApiError::PcrExtendFailed))
+}
+
+async fn update_tcb_context<S: Syscalls, A: ApiAlloc>(
+    api: &mut MeasurementApi<'_, S>,
+    alloc: &A,
+    entry: AttestationManifestEntry,
+    metadata: ImageMetadata,
+) -> MeasurementApiResult {
+    let dpe_store = DpeHandleStore::<S>::new(DPE_HANDLE_STORE_DRIVER_NUM);
+
+    let mut component = DpeHandleRecord::default();
+    dpe_store
+        .read_record(entry.fw_id, &mut component)
+        .map_err(|_| MeasurementApiError::InvalidDpeHandleStoreState)?;
+    let parent_fw_id = component
+        .parent_fw_id
+        .ok_or(MeasurementApiError::InvalidDpeHandleStoreState)?;
+    if component.fw_id != entry.fw_id {
+        return Err(MeasurementApiError::InvalidDpeHandleStoreState);
+    }
+
+    let mut parent = DpeHandleRecord::default();
+    dpe_store
+        .read_record(parent_fw_id, &mut parent)
+        .map_err(|_| MeasurementApiError::InvalidDpeHandleStoreState)?;
+    if parent.fw_id != parent_fw_id {
+        return Err(MeasurementApiError::InvalidDpeHandleStoreState);
+    }
+
+    let updated = dpe_update_context_measurement(
+        alloc,
+        &DpeUpdateContextMeasurementParams {
+            parent_handle: parent.context_handle,
+            measurement: metadata.measurement,
+            tci_type: entry.fw_id,
+        },
+    )
+    .await
+    .map_err(|_| MeasurementApiError::DpeCommandFailed)?;
+
+    let (parent, component) = tcb_records_with_updated_handles(parent, component, updated);
+    dpe_store
+        .write_record(parent.fw_id, &parent)
+        .map_err(|_| api.enter_error_state(MeasurementApiError::StoreFailed))?;
+    dpe_store
+        .write_record(component.fw_id, &component)
+        .map_err(|_| api.enter_error_state(MeasurementApiError::StoreFailed))
+}
+
+async fn update_software_pcr<S: Syscalls, A: ApiAlloc>(
+    api: &mut MeasurementApi<'_, S>,
+    alloc: &A,
+    entry: AttestationManifestEntry,
+    metadata: ImageMetadata,
+) -> MeasurementApiResult {
+    let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
+
+    let (previous_journey_digest, reserved) = {
+        let mut record = MeasurementRecord::default();
+        pcr_store
+            .read_measurement(entry.fw_id, &mut record)
+            .map_err(|_| MeasurementApiError::InvalidSoftwarePcrStoreState)?;
+        if record.fw_id != entry.fw_id {
+            return Err(MeasurementApiError::InvalidSoftwarePcrStoreState);
+        }
+        (record.journey_digest, record.reserved)
+    };
+
+    let mut journey_digest = [0u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
+    software_pcr_extend_digest(
+        alloc,
+        &previous_journey_digest,
+        &metadata.measurement,
+        &mut journey_digest,
+    )
+    .await?;
+    let record = software_pcr_update_record(
+        entry.fw_id,
+        reserved,
+        metadata.measurement,
+        journey_digest,
+        metadata,
+    );
+
+    pcr_store
+        .update_measurement(entry.fw_id, &record)
+        .map_err(|_| api.enter_error_state(MeasurementApiError::StoreFailed))
+}
+
+fn tcb_records_with_updated_handles(
+    mut parent: DpeHandleRecord,
+    mut component: DpeHandleRecord,
+    updated: DpeUpdateContextMeasurementResult,
+) -> (DpeHandleRecord, DpeHandleRecord) {
+    parent.context_handle = updated.parent_handle;
+    component.context_handle = updated.component_handle;
+    (parent, component)
+}
+
+async fn software_pcr_extend_digest<A: ApiAlloc>(
+    alloc: &A,
+    previous_digest: &[u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+    measurement: &[u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+    digest: &mut [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+) -> MeasurementApiResult {
+    let ctx = alloc
+        .alloc(SHA_CONTEXT_SIZE)
+        .map_err(|_| MeasurementApiError::DigestFailed)?;
+    let mut state = sha_init(alloc, ctx, HashAlgo::Sha384, previous_digest)
+        .await
+        .map_err(|_| MeasurementApiError::DigestFailed)?;
+    sha_update(alloc, &mut state, measurement)
+        .await
+        .map_err(|_| MeasurementApiError::DigestFailed)?;
+    sha_finish(alloc, &mut state, digest)
+        .await
+        .map_err(|_| MeasurementApiError::DigestFailed)
+}
+
+fn software_pcr_update_record(
+    fw_id: u32,
+    reserved: [u8; 4],
+    current_digest: [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+    journey_digest: [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+    metadata: ImageMetadata,
+) -> MeasurementRecord {
+    MeasurementRecord {
+        fw_id,
+        current_digest,
+        journey_digest,
+        svn: metadata.svn,
+        version: metadata.version,
+        reserved,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tcb_update_records_preserve_topology_and_replace_only_handles() {
+        let parent = DpeHandleRecord {
+            fw_id: 0x1000,
+            parent_fw_id: Some(0x2),
+            context_handle: [0x11; 16],
+            tci_tag: 0x1000,
+            flags: 0xaa,
+        };
+        let component = DpeHandleRecord {
+            fw_id: 0x2000,
+            parent_fw_id: Some(0x1000),
+            context_handle: [0x22; 16],
+            tci_tag: 0x2000,
+            flags: 0xbb,
+        };
+        let updated = DpeUpdateContextMeasurementResult {
+            component_handle: [0xcc; 16],
+            parent_handle: [0xdd; 16],
+        };
+
+        let (updated_parent, updated_component) =
+            tcb_records_with_updated_handles(parent, component, updated);
+
+        assert_eq!(updated_parent.context_handle, updated.parent_handle);
+        assert_eq!(updated_component.context_handle, updated.component_handle);
+        assert_eq!(updated_parent.fw_id, parent.fw_id);
+        assert_eq!(updated_parent.parent_fw_id, parent.parent_fw_id);
+        assert_eq!(updated_parent.tci_tag, parent.tci_tag);
+        assert_eq!(updated_parent.flags, parent.flags);
+        assert_eq!(updated_component.fw_id, component.fw_id);
+        assert_eq!(updated_component.parent_fw_id, component.parent_fw_id);
+        assert_eq!(updated_component.tci_tag, component.tci_tag);
+        assert_eq!(updated_component.flags, component.flags);
+    }
+
+    #[test]
+    fn software_pcr_update_record_uses_raw_current_and_extended_journey() {
+        let record = MeasurementRecord {
+            fw_id: 0x3000,
+            current_digest: [0x11; 48],
+            journey_digest: [0x22; 48],
+            svn: 3,
+            version: 4,
+            reserved: [0xa5; 4],
+        };
+        let current_digest = [0x33; 48];
+        let journey_digest = [0x44; 48];
+        let metadata = ImageMetadata {
+            svn: 7,
+            version: 9,
+            ..ImageMetadata::component_update(
+                crate::ImageHashSource::InRequest,
+                0x1234,
+                [0x55; 48],
+                7,
+                9,
+            )
+        };
+
+        let updated = software_pcr_update_record(
+            record.fw_id,
+            record.reserved,
+            current_digest,
+            journey_digest,
+            metadata,
+        );
+
+        assert_eq!(updated.fw_id, record.fw_id);
+        assert_eq!(updated.current_digest, current_digest);
+        assert_eq!(updated.journey_digest, journey_digest);
+        assert_ne!(updated.current_digest, updated.journey_digest);
+        assert_eq!(updated.svn, metadata.svn);
+        assert_eq!(updated.version, metadata.version);
+        assert_eq!(updated.reserved, record.reserved);
+    }
+}

--- a/runtime/userspace/api/measurement-api/src/api/initial_load.rs
+++ b/runtime/userspace/api/measurement-api/src/api/initial_load.rs
@@ -11,11 +11,11 @@ use caliptra_mcu_libsyscall_caliptra::soft_pcr_store::{
 use caliptra_mcu_libtock_platform::Syscalls;
 use mcu_caliptra_api_lite::{
     authorize_and_stash as caliptra_authorize, dpe_derive_context, dpe_tag_tci, extend_pcr31,
-    sha_finish, sha_init, sha_update, ApiAlloc, AuthorizeAndStashFlags, AuthorizeAndStashParams,
-    DpeContextHandle, DpeDeriveContextFlags, DpeDeriveContextParams, HashAlgo, SHA_CONTEXT_SIZE,
+    sha_finish, sha_init, sha_update, ApiAlloc, DpeContextHandle, DpeDeriveContextFlags,
+    DpeDeriveContextParams, HashAlgo, SHA_CONTEXT_SIZE,
 };
 
-use super::MeasurementApi;
+use super::{caliptra_authorize_params, MeasurementApi};
 use crate::attestation_manifest::AttestationManifestEntry;
 use crate::errors::{MeasurementApiError, MeasurementApiResult};
 use crate::ImageMetadata;
@@ -108,8 +108,9 @@ async fn create_software_pcr_record<S: Syscalls, A: ApiAlloc>(
     let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
     reject_existing_measurement_record(&pcr_store, entry.fw_id)?;
 
-    let digest = initial_software_pcr_digest(alloc, &metadata.measurement).await?;
-    let record = software_pcr_initial_load_record(entry.fw_id, digest, metadata);
+    let mut journey_digest = [0u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
+    initial_software_pcr_journey_digest(alloc, &metadata.measurement, &mut journey_digest).await?;
+    let record = software_pcr_initial_load_record(entry.fw_id, journey_digest, metadata);
     pcr_store
         .create_measurement(entry.fw_id, &record)
         .map_err(|_| api.enter_error_state(MeasurementApiError::StoreFailed))
@@ -139,12 +140,12 @@ fn reject_existing_measurement_record<S: Syscalls>(
     Ok(())
 }
 
-async fn initial_software_pcr_digest<A: ApiAlloc>(
+async fn initial_software_pcr_journey_digest<A: ApiAlloc>(
     alloc: &A,
     measurement: &[u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
-) -> MeasurementApiResult<[u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE]> {
+    journey_digest: &mut [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+) -> MeasurementApiResult {
     let zero_digest = [0u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
-    let mut digest = [0u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
     let ctx = alloc
         .alloc(SHA_CONTEXT_SIZE)
         .map_err(|_| MeasurementApiError::DigestFailed)?;
@@ -154,21 +155,20 @@ async fn initial_software_pcr_digest<A: ApiAlloc>(
     sha_update(alloc, &mut state, measurement)
         .await
         .map_err(|_| MeasurementApiError::DigestFailed)?;
-    sha_finish(alloc, &mut state, &mut digest)
+    sha_finish(alloc, &mut state, journey_digest)
         .await
-        .map_err(|_| MeasurementApiError::DigestFailed)?;
-    Ok(digest)
+        .map_err(|_| MeasurementApiError::DigestFailed)
 }
 
 fn software_pcr_initial_load_record(
     fw_id: u32,
-    digest: [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
+    journey_digest: [u8; crate::IMAGE_MEASUREMENT_DIGEST_SIZE],
     metadata: ImageMetadata,
 ) -> MeasurementRecord {
     MeasurementRecord {
         fw_id,
-        current_digest: digest,
-        journey_digest: digest,
+        current_digest: metadata.measurement,
+        journey_digest,
         svn: metadata.svn,
         version: metadata.version,
         reserved: [0u8; 4],
@@ -189,24 +189,13 @@ fn tcb_child_record(
     }
 }
 
-fn caliptra_authorize_params(fw_id: u32, metadata: ImageMetadata) -> AuthorizeAndStashParams {
-    AuthorizeAndStashParams {
-        fw_id,
-        measurement: metadata.measurement,
-        context: [0u8; 48],
-        svn: metadata.svn,
-        flags: AuthorizeAndStashFlags::SKIP_STASH,
-        source: metadata.source,
-        image_size: metadata.image_size,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     extern crate std;
 
     use super::*;
     use crate::attestation_manifest::MCU_RT_FW_ID;
+    use mcu_caliptra_api_lite::AuthorizeAndStashFlags;
 
     #[test]
     fn caliptra_authorize_params_force_skip_stash_for_initial_load() {
@@ -234,19 +223,20 @@ mod tests {
     }
 
     #[test]
-    fn software_pcr_initial_load_record_uses_current_and_journey_digest() {
-        let digest = [0x5a; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
+    fn software_pcr_initial_load_record_uses_raw_current_and_journey_digest() {
+        let journey_digest = [0x5a; crate::IMAGE_MEASUREMENT_DIGEST_SIZE];
         let metadata = ImageMetadata {
             svn: 7,
             version: 9,
             ..ImageMetadata::initial_load_from_load_address(0x1234, [0xa5; 48])
         };
 
-        let record = software_pcr_initial_load_record(0x1000, digest, metadata);
+        let record = software_pcr_initial_load_record(0x1000, journey_digest, metadata);
 
         assert_eq!(record.fw_id, 0x1000);
-        assert_eq!(record.current_digest, digest);
-        assert_eq!(record.journey_digest, digest);
+        assert_eq!(record.current_digest, metadata.measurement);
+        assert_eq!(record.journey_digest, journey_digest);
+        assert_ne!(record.current_digest, record.journey_digest);
         assert_eq!(record.svn, 7);
         assert_eq!(record.version, 9);
         assert_eq!(record.reserved, [0u8; 4]);

--- a/runtime/userspace/api/measurement-api/src/api/mod.rs
+++ b/runtime/userspace/api/measurement-api/src/api/mod.rs
@@ -8,6 +8,7 @@
 //! rather than stored. Boot initialization is performed by
 //! `measurement_boot_init`.
 
+mod component_update;
 mod initial_load;
 
 use caliptra_mcu_libsyscall_caliptra::dpe_handle_store::{
@@ -22,12 +23,13 @@ use core::marker::PhantomData;
 use mcu_caliptra_api_lite::{
     dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
     dpe_rotate_context_default, dpe_sign_ecc_p384, dpe_tag_tci, sha_finish, sha_init, sha_update,
-    ApiAlloc, DpeContextHandle, HashAlgo, DPE_LABEL_LEN, SHA_CONTEXT_SIZE,
+    ApiAlloc, AuthorizeAndStashFlags, AuthorizeAndStashParams, DpeContextHandle, HashAlgo,
+    DPE_LABEL_LEN, SHA_CONTEXT_SIZE,
 };
 
 use crate::attestation_manifest::{parse_and_validate, AttestationManifest, MCU_RT_FW_ID};
 use crate::errors::{MeasurementApiError, MeasurementApiResult};
-use crate::{AttestationState, BootKind, ImageMetadata};
+use crate::{AttestationState, BootKind, ImageMetadata, MeasurementOperation};
 
 /// Owns the attestation configuration and attestation boot/error state.
 ///
@@ -38,6 +40,7 @@ use crate::{AttestationState, BootKind, ImageMetadata};
 /// created on demand inside each operation.
 pub(crate) struct MeasurementApi<'a, S: Syscalls = DefaultSyscalls> {
     manifest: AttestationManifest<'a>,
+    soc_image_load_fw_ids: &'a [u32],
     state: AttestationState,
     _syscalls: PhantomData<S>,
 }
@@ -56,18 +59,19 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
         validate_soc_image_load_fw_ids(&manifest, soc_image_load_fw_ids)?;
         Ok(Self {
             manifest,
+            soc_image_load_fw_ids,
             state: AttestationState::Uninitialized,
             _syscalls: PhantomData,
         })
     }
 
-    /// Compute `attestation_policy_digest = SHA384(canonical manifest bytes)`
-    /// using the Caliptra SHA mailbox, writing it into `digest_out`.
+    /// Compute `measurement_policy_digest = SHA384(canonical manifest bytes ||
+    /// ordered SOC_IMAGE_LOAD_LIST bytes)`
     ///
-    /// The digest is taken over the exact canonical manifest bytes, i.e. the
-    /// authenticated integrator static attestation configuration. Any mailbox
-    /// failure is reported as [`MeasurementApiError::DigestFailed`].
-    async fn attestation_policy_digest<A: ApiAlloc>(
+    /// The digest binds the authenticated integrator static attestation
+    /// configuration and the cold-boot SoC load topology. Any mailbox failure
+    /// is reported as [`MeasurementApiError::DigestFailed`].
+    async fn measurement_policy_digest<A: ApiAlloc>(
         &self,
         alloc: &A,
         digest_out: &mut [u8; POLICY_DIGEST_SIZE],
@@ -78,6 +82,11 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
         let mut state = sha_init(alloc, ctx, HashAlgo::Sha384, self.manifest.bytes())
             .await
             .map_err(|_| MeasurementApiError::DigestFailed)?;
+        for fw_id in self.soc_image_load_fw_ids {
+            sha_update(alloc, &mut state, &fw_id.to_le_bytes())
+                .await
+                .map_err(|_| MeasurementApiError::DigestFailed)?;
+        }
         sha_finish(alloc, &mut state, digest_out)
             .await
             .map_err(|_| MeasurementApiError::DigestFailed)?;
@@ -117,7 +126,7 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
         let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
 
         let mut digest = [0u8; POLICY_DIGEST_SIZE];
-        self.attestation_policy_digest(alloc, &mut digest).await?;
+        self.measurement_policy_digest(alloc, &mut digest).await?;
 
         dpe_store
             .initialize_store(&digest)
@@ -162,7 +171,7 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
         let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
 
         let mut digest = [0u8; POLICY_DIGEST_SIZE];
-        self.attestation_policy_digest(alloc, &mut digest).await?;
+        self.measurement_policy_digest(alloc, &mut digest).await?;
 
         // Validate both preserved stores against the policy digest before use;
         // a mismatch means the preserved state belongs to a different policy.
@@ -203,21 +212,26 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
         Ok(())
     }
 
-    /// Authorize one MCU-managed initial-load component through Caliptra.
+    /// Authorize one MCU-managed component through Caliptra.
     ///
     /// Validates Measurement API state and Attestation Manifest membership,
     /// then uses public `AUTHORIZE_AND_STASH` with `SKIP_STASH=true` for
-    /// authorization only. After authorization succeeds, TCB entries derive
-    /// explicit DPE state, non-TCB entries create Software PCR records, and
-    /// PCR31 is extended as the final common step.
+    /// authorization only. Initial-load and component-update callers then
+    /// dispatch to operation-specific Measurement API state updates.
     pub async fn authorize_and_stash<A: ApiAlloc>(
         &mut self,
         alloc: &A,
         fw_id: u32,
         metadata: ImageMetadata,
     ) -> MeasurementApiResult {
-        // TODO: extend this for the update case.
-        initial_load::authorize_and_stash(self, alloc, fw_id, metadata).await
+        match metadata.operation {
+            MeasurementOperation::InitialLoad => {
+                initial_load::authorize_and_stash(self, alloc, fw_id, metadata).await
+            }
+            MeasurementOperation::ComponentUpdate => {
+                component_update::authorize_and_stash(self, alloc, fw_id, metadata).await
+            }
+        }
     }
 
     /// Return the DPE leaf certificate length for the configured attestation
@@ -405,6 +419,18 @@ fn validate_soc_image_load_fw_ids(
     Ok(())
 }
 
+fn caliptra_authorize_params(fw_id: u32, metadata: ImageMetadata) -> AuthorizeAndStashParams {
+    AuthorizeAndStashParams {
+        fw_id,
+        measurement: metadata.measurement,
+        context: [0u8; 48],
+        svn: metadata.svn,
+        flags: AuthorizeAndStashFlags::SKIP_STASH,
+        source: metadata.source,
+        image_size: metadata.image_size,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -515,20 +541,49 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn policy_digest_input_is_exact_canonical_manifest_bytes() {
+    fn reference_measurement_policy_digest(
+        manifest_bytes: &[u8],
+        soc_image_load_fw_ids: &[u32],
+    ) -> [u8; POLICY_DIGEST_SIZE] {
         use sha2::{Digest, Sha384};
 
-        let bytes = valid_empty_manifest();
-        let api = MeasurementApi::<DefaultSyscalls>::new(&bytes, &[]).unwrap();
+        let mut hasher = Sha384::new();
+        hasher.update(manifest_bytes);
+        for fw_id in soc_image_load_fw_ids {
+            hasher.update(fw_id.to_le_bytes());
+        }
+        hasher.finalize().into()
+    }
 
-        // The digest is computed over the exact canonical manifest bytes.
+    #[test]
+    fn policy_digest_reference_binds_manifest_and_ordered_load_list() {
+        let bytes = valid_manifest_with_entries(&[(0x1000, 0), (0x2000, 0)]);
+        let api = MeasurementApi::<DefaultSyscalls>::new(&bytes, &[0x1000, 0x2000]).unwrap();
+
         assert_eq!(api.manifest.bytes(), &bytes[..]);
 
-        // Reference SHA-384 that the mailbox digest path must reproduce.
-        let reference = Sha384::digest(&bytes);
+        let reference =
+            reference_measurement_policy_digest(api.manifest.bytes(), api.soc_image_load_fw_ids);
         assert_eq!(reference.len(), POLICY_DIGEST_SIZE);
-        assert_eq!(&Sha384::digest(api.manifest.bytes())[..], &reference[..]);
+
+        let mut changed_manifest = bytes.clone();
+        changed_manifest[4] ^= 0x01;
+        assert_ne!(
+            reference,
+            reference_measurement_policy_digest(&changed_manifest, &[0x1000, 0x2000])
+        );
+        assert_ne!(
+            reference,
+            reference_measurement_policy_digest(&bytes, &[0x2000, 0x1000])
+        );
+        assert_ne!(
+            reference,
+            reference_measurement_policy_digest(&bytes, &[0x1000])
+        );
+        assert_ne!(
+            reference,
+            reference_measurement_policy_digest(&bytes, &[0x1000, 0x2000, 0x3000])
+        );
     }
 
     #[test]

--- a/runtime/userspace/api/measurement-api/src/errors.rs
+++ b/runtime/userspace/api/measurement-api/src/errors.rs
@@ -43,6 +43,10 @@ pub enum MeasurementApiError {
     PcrExtendFailed = 0x000a,
     /// Measurement state already exists for the requested firmware identifier.
     DuplicateMeasurementRecord = 0x000b,
+    /// Component-update metadata is routed but update mutation is not wired yet.
+    ComponentUpdateUnsupported = 0x000c,
+    /// MCU-side Software PCR Storage state was missing or semantically invalid.
+    InvalidSoftwarePcrStoreState = 0x000d,
 }
 
 /// Convenience alias for a Measurement API operation result. `T` defaults to
@@ -82,6 +86,8 @@ mod tests {
             (MeasurementApiError::ImageAuthorizationFailed, 0x0009),
             (MeasurementApiError::PcrExtendFailed, 0x000a),
             (MeasurementApiError::DuplicateMeasurementRecord, 0x000b),
+            (MeasurementApiError::ComponentUpdateUnsupported, 0x000c),
+            (MeasurementApiError::InvalidSoftwarePcrStoreState, 0x000d),
         ] {
             let mcu: McuErrorCode = err.into();
             assert_eq!(mcu.domain(), domain::ATTESTATION);

--- a/runtime/userspace/api/measurement-api/src/image_metadata.rs
+++ b/runtime/userspace/api/measurement-api/src/image_metadata.rs
@@ -13,6 +13,8 @@ pub const IMAGE_MEASUREMENT_DIGEST_SIZE: usize = 48;
 pub enum MeasurementOperation {
     /// Boot-time SoC image load.
     InitialLoad = 1,
+    /// Hitless SoC component update requested by firmware update logic.
+    ComponentUpdate = 2,
 }
 
 /// Control flags associated with image metadata.
@@ -66,6 +68,25 @@ impl ImageMetadata {
             flags: ImageMetadataFlags::EMPTY,
         }
     }
+
+    /// Build component-update metadata from caller-supplied authorization data.
+    pub const fn component_update(
+        source: ImageHashSource,
+        image_size: u32,
+        measurement: [u8; IMAGE_MEASUREMENT_DIGEST_SIZE],
+        svn: u32,
+        version: u32,
+    ) -> Self {
+        Self {
+            operation: MeasurementOperation::ComponentUpdate,
+            source,
+            image_size,
+            measurement,
+            svn,
+            version,
+            flags: ImageMetadataFlags::EMPTY,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -84,6 +105,22 @@ mod tests {
         assert_eq!(metadata.measurement, measurement);
         assert_eq!(metadata.svn, 0);
         assert_eq!(metadata.version, 0);
+        assert_eq!(metadata.flags.bits(), 0);
+    }
+
+    #[test]
+    fn component_update_metadata_preserves_caller_supplied_values() {
+        let measurement = [0x5a; IMAGE_MEASUREMENT_DIGEST_SIZE];
+
+        let metadata =
+            ImageMetadata::component_update(ImageHashSource::InRequest, 0x2345, measurement, 7, 9);
+
+        assert_eq!(metadata.operation, MeasurementOperation::ComponentUpdate);
+        assert_eq!(metadata.source, ImageHashSource::InRequest);
+        assert_eq!(metadata.image_size, 0x2345);
+        assert_eq!(metadata.measurement, measurement);
+        assert_eq!(metadata.svn, 7);
+        assert_eq!(metadata.version, 9);
         assert_eq!(metadata.flags.bits(), 0);
     }
 }


### PR DESCRIPTION
Add MeasurementOperation::ComponentUpdate and route Measurement API calls through dedicated component-update handling.

Add api-lite support for DPE UpdateContextMeasurement and use it for TCB SoC component updates while preserving DPE topology fields and rotated handles.

Add non-TCB Software PCR update handling with raw current measurements and journey-digest accumulation, plus PCR31 extension after successful state update.

Bind measurement state to the combined attestation policy/topology digest and validate preserved state on hitless update.

Add firmware-update SoC/Auth Manifest same-set validation against the cold-boot SOC_IMAGE_LOAD_LIST before setting the auth manifest.

Fixes #1676 