### PR TITLE
builder: Use image_id from ImageCfg for SOC image flash TOC identifiers

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -782,6 +782,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             .iter()
             .map(|img| img.path.clone())
             .collect(),
+        effective_soc_images.clone(),
         false, // Base flash image is not for flash-based boot
     )?;
     let pldm_manifest_decoded = match pldm_manifest {
@@ -946,6 +947,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
                 Some(feature_soc_manifest_file.path().to_path_buf()),
                 Some(feature_runtime_file.path().to_path_buf()),
                 feature_soc_images_paths,
+                feature_soc_images.clone(),
                 is_flash_based_boot,
             )?;
 
@@ -961,6 +963,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
                     Some(feature_soc_manifest_file.path().to_path_buf()),
                     Some(feature_runtime_file.path().to_path_buf()),
                     feature_soc_images_paths_clone,
+                    feature_soc_images.clone(),
                     false, // No partition table for update image
                 )?)
             } else {
@@ -1242,6 +1245,7 @@ fn create_flash_image(
     soc_manifest_path: Option<PathBuf>,
     mcu_runtime_path: Option<PathBuf>,
     soc_images_paths: Vec<PathBuf>,
+    soc_images: Option<Vec<ImageCfg>>,
     is_flash_based_boot: bool,
 ) -> Result<PathBuf> {
     let flash_image_path = tempfile::NamedTempFile::new()
@@ -1268,6 +1272,7 @@ fn create_flash_image(
                 .map(|p| p.to_string_lossy().to_string())
                 .collect(),
         ),
+        soc_images,
         offset: flash_offset,
         output_path: Some(flash_image_path.to_string_lossy().to_string()),
         ..Default::default()

--- a/builder/src/flash_image.rs
+++ b/builder/src/flash_image.rs
@@ -234,10 +234,15 @@ pub fn flash_image_create(args: &CaliptraBuildArgs) -> Result<()> {
     }
 
     // Generate FirmwareImage from soc image buffer
-    let mut soc_image_identifer = SOC_IMAGES_BASE_IDENTIFIER;
-    for soc_img in soc_img_buffers.iter() {
-        images.push(FirmwareImage::new(soc_image_identifer, soc_img)?);
-        soc_image_identifer += 1;
+    // Use image_id from soc_images config when available; otherwise fall back to
+    // SOC_IMAGES_BASE_IDENTIFIER + index for backward compatibility.
+    for (i, soc_img) in soc_img_buffers.iter().enumerate() {
+        let identifier = if let Some(ref soc_images) = args.soc_images {
+            soc_images[i].image_id
+        } else {
+            SOC_IMAGES_BASE_IDENTIFIER + i as u32
+        };
+        images.push(FirmwareImage::new(identifier, soc_img)?);
     }
 
     let image_info = generate_image_info(images.clone());
@@ -379,7 +384,7 @@ pub fn write_partition_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PROJECT_ROOT;
+    use crate::{ImageCfg, PROJECT_ROOT};
     use std::fs::{self, File};
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -588,5 +593,66 @@ mod tests {
 
         // Cleanup
         fs::remove_file(image_path).expect("Failed to clean up test file");
+    }
+
+    #[test]
+    fn test_flash_image_uses_image_id_from_config() {
+        // Regression test for #1580: when ImageCfg provides nonsequential image_id
+        // values (e.g. 12 and 6), flash_image_create must use those as the flash
+        // TOC identifiers instead of SOC_IMAGES_BASE_IDENTIFIER + index.
+        let soc_image1_content = b"Soc Image 1 - custom id";
+        let soc_image2_content = b"Soc Image 2 - custom id";
+
+        let soc_image1 = create_temp_file(soc_image1_content).unwrap();
+        let soc_image2 = create_temp_file(soc_image2_content).unwrap();
+
+        let soc_image_paths = Some(vec![
+            soc_image1.path().to_str().unwrap().to_string(),
+            soc_image2.path().to_str().unwrap().to_string(),
+        ]);
+
+        let soc_images = Some(vec![
+            ImageCfg {
+                path: soc_image1.path().to_path_buf(),
+                image_id: 12,
+                ..Default::default()
+            },
+            ImageCfg {
+                path: soc_image2.path().to_path_buf(),
+                image_id: 6,
+                ..Default::default()
+            },
+        ]);
+
+        let output_file = NamedTempFile::new().unwrap();
+        let output_path = output_file.path().to_str().unwrap();
+
+        flash_image_create(&CaliptraBuildArgs {
+            soc_image_paths,
+            soc_images,
+            offset: 0,
+            output_path: Some(output_path.to_string()),
+            ..Default::default()
+        })
+        .expect("Failed to build flash image");
+
+        // Read and verify identifiers
+        let mut file = File::open(output_path).unwrap();
+        let mut data = Vec::new();
+        file.read_to_end(&mut data).unwrap();
+
+        let header =
+            FlashHeader::read_from_bytes(&data[..HEADER_SIZE]).expect("Failed to parse header");
+        assert_eq!(header.image_count, 2);
+
+        // First SOC image should have identifier 12
+        let offset0 = header.image_headers_offset as usize;
+        let img0 = ImageHeader::read_from_bytes(&data[offset0..offset0 + IMAGE_INFO_SIZE]).unwrap();
+        assert_eq!(img0.identifier, 12);
+
+        // Second SOC image should have identifier 6
+        let offset1 = offset0 + IMAGE_INFO_SIZE;
+        let img1 = ImageHeader::read_from_bytes(&data[offset1..offset1 + IMAGE_INFO_SIZE]).unwrap();
+        assert_eq!(img1.identifier, 6);
     }
 }


### PR DESCRIPTION
flash_image_create() was always assigning SOC_IMAGES_BASE_IDENTIFIER + index as the flash TOC identifier for SOC images. However, the auth manifest generated by get_soc_manifest_metadata() uses image_id from ImageCfg as fw_id. This mismatch caused FirmwareUpdater::verify() to fail when image_id differs from SOC_IMAGES_BASE_IDENTIFIER + index, because the flash TOC identifier and manifest fw_id wouldn't match.

Use image_id from args.soc_images when available. Fall back to SOC_IMAGES_BASE_IDENTIFIER + index when only soc_image_paths is provided (no ImageCfg) for backward compatibility.

Fixes: #1580