### PR TITLE
fix(pldm): propagate image authorization failure to PLDM Update Agent

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -48,6 +48,15 @@ use caliptra_mcu_measurement_api::{ImageHashSource, ImageMetadata};
     feature = "test-pldm-fw-update-e2e",
     feature = "test-pldm-streaming-boot"
 ))]
+use caliptra_mcu_pldm_common::message::firmware_update::verify_complete::VerifyResult;
+#[allow(unused)]
+#[cfg(any(
+    feature = "streaming-boot",
+    feature = "test-pldm-discovery",
+    feature = "test-pldm-fw-update",
+    feature = "test-pldm-fw-update-e2e",
+    feature = "test-pldm-streaming-boot"
+))]
 use caliptra_mcu_pldm_lib::daemon::PldmService;
 #[cfg(any(feature = "streaming-boot", feature = "flash-boot"))]
 use caliptra_mcu_spdm_pal::{BitmapAllocator, BITMAP_SLOT_SIZE};
@@ -199,9 +208,14 @@ async fn image_loading<D: DMAMapping>(
         };
         let pldm_image_loader =
             PldmImageLoader::new(&fw_params, EXECUTOR.get().spawner(), dma_mapping);
-        load_soc_images(&pldm_image_loader, soc_image_load_list, false).await?;
-        // Close the PLDM session
-        pldm_image_loader.finalize()?;
+        load_soc_images(&pldm_image_loader, soc_image_load_list, false)
+            .await
+            .inspect_err(|_e| {
+                // Report load/authorization failure to the PLDM Update Agent
+                let _ = pldm_image_loader.finalize(VerifyResult::VerifyFailedFdSecurityChecks);
+            })?;
+        // Close the PLDM session on success
+        pldm_image_loader.finalize(VerifyResult::VerifySuccess)?;
         // Wait for the PLDM service to fully complete the protocol before proceeding
         pldm_image_loader.wait_for_service_stopped().await;
         // Activate the SoC Images (set FW_EXEC_CTRL bit of the corresponding SoC)

--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -171,8 +171,8 @@ impl<'a, D: DMAMapping + 'static> PldmImageLoader<'a, D> {
             dma_mapping,
         }
     }
-    pub fn finalize(&self) -> Result<(), ErrorCode> {
-        pldm_client::finalize(VerifyResult::VerifySuccess)
+    pub fn finalize(&self, verify_result: VerifyResult) -> Result<(), ErrorCode> {
+        pldm_client::finalize(verify_result)
     }
 
     /// Wait for the PLDM service to fully stop (protocol complete, tasks exited).
@@ -208,10 +208,7 @@ impl<D: DMAMapping + 'static> ImageLoader for PldmImageLoader<'_, D> {
         };
         match result {
             Ok(loaded) => Ok(loaded),
-            Err(_) => {
-                self.finalize()?;
-                Err(ErrorCode::Fail)
-            }
+            Err(_) => Err(ErrorCode::Fail),
         }
     }
 }

--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -251,7 +251,7 @@ impl<'a> CmdInterface<'a> {
                     .fd_ctx
                     .cancel_update_component_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Complete)),
                 FwUpdateCmd::CancelUpdate => self
                     .fd_ctx
                     .cancel_update_rsp(payload)


### PR DESCRIPTION
When AUTHORIZE_AND_STASH rejects an image during streaming boot, the VerifyResult reported to the PLDM Update Agent (UA) was always VerifySuccess, because finalize() was hardcoded to that value.

This change:
- Makes PldmImageLoader::finalize() accept a VerifyResult parameter instead of hardcoding VerifySuccess.
- On the authorization failure path in load_and_authorize(), passes VerifyResult::VerifyFailedFdSecurityChecks so the UA receives the correct failure code in the VerifyComplete message.
- Restructures the user-app streaming boot flow so that wait_for_service_stopped() is always called (via async block), ensuring the PLDM service has time to send VerifyComplete before the process exits.
- Changes CancelUpdateComponent responder action to Complete so the PLDM service properly shuts down after the UA cancels a failed component (prevents wait_for_service_stopped() from hanging).

Fixes #1636