### PR TITLE
mcu-mbox: Remove caliptra-api dependency, part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,13 +1542,11 @@ name = "caliptra-mcu-libsyscall-caliptra"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "caliptra-api",
  "caliptra-mcu-libtock_console",
  "caliptra-mcu-libtock_platform",
  "caliptra-mcu-libtock_runtime",
  "caliptra-mcu-libtock_unittest",
  "caliptra-mcu-libtockasync",
- "caliptra-mcu-mbox-common",
  "caliptra-mcu-registers-generated",
  "embassy-sync",
  "zerocopy",

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -7,7 +7,7 @@ use caliptra_mcu_common_commands::{
     DeviceInfo, FirmwareVersion, GetLogResult, MAX_UID_LEN,
 };
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
-use caliptra_mcu_libsyscall_caliptra::otp::Otp;
+use caliptra_mcu_libsyscall_caliptra::otp::{Otp, RevokeVendorPubKeyType};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
 use caliptra_mcu_mbox_common::messages::{
@@ -20,8 +20,8 @@ use caliptra_mcu_mbox_common::messages::{
     MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize, McuFeProgReq, McuMailboxReq,
     McuMailboxResp, McuProdDebugUnlockReqReq, McuProdDebugUnlockReqResp,
     McuProdDebugUnlockTokenReq, McuResponseVarSize, ProvisionVendorPkHashReq,
-    ProvisionVendorPkHashResp, RevokeVendorPubKeyType, DEVICE_CAPS_SIZE, MAX_FUSE_DATA_SIZE,
-    MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
+    ProvisionVendorPkHashResp, DEVICE_CAPS_SIZE, MAX_FUSE_DATA_SIZE, MAX_FW_VERSION_STR_LEN,
+    MAX_RESP_DATA_SIZE,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{

--- a/runtime/userspace/syscall/Cargo.toml
+++ b/runtime/userspace/syscall/Cargo.toml
@@ -8,13 +8,11 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-caliptra-api.workspace = true
 embassy-sync.workspace = true
 caliptra-mcu-libtock_console.workspace = true
 caliptra-mcu-libtock_platform.workspace = true
 caliptra-mcu-libtockasync.workspace = true
 caliptra-mcu-libtock_runtime.workspace = true
-caliptra-mcu-mbox-common.workspace = true
 caliptra-mcu-registers-generated.workspace = true
 zerocopy.workspace = true
 

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 use crate::DefaultSyscalls;
 use alloc::boxed::Box;
 use async_trait::async_trait;
-use caliptra_api::mailbox::MailboxReqHeader;
 use caliptra_mcu_libtock_platform::{share, DefaultConfig, ErrorCode, Syscalls};
 use caliptra_mcu_libtockasync::TockSubscribe;
 use core::{hint::black_box, marker::PhantomData};
@@ -14,6 +13,7 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 // Global mutex to ensure that multiple tasks do not overwrite each other's upcall pointers.
 static MAILBOX_MUTEX: Mutex<CriticalSectionRawMutex, u32> = Mutex::new(0);
 const PAYLOAD_CHUNK_SIZE: usize = 256;
+const MAILBOX_REQ_HEADER_SIZE: usize = core::mem::size_of::<u32>();
 
 /// Mailbox interface user interface.
 ///
@@ -32,14 +32,23 @@ impl<S: Syscalls> Default for Mailbox<S> {
 
 // Populate the checksum for a mailbox request.
 pub fn populate_checksum(cmd: u32, data: &mut [u8]) -> Result<(), ErrorCode> {
-    // Calc checksum, use the size override if provided
-    let checksum = caliptra_api::calc_checksum(cmd, data);
-
-    if data.len() < size_of::<MailboxReqHeader>() {
-        Err(ErrorCode::Invalid)?;
-    }
-    data[..size_of::<MailboxReqHeader>()].copy_from_slice(&checksum.to_le_bytes());
+    let checksum = calc_checksum(cmd, data);
+    let Some(checksum_dst) = data.get_mut(..MAILBOX_REQ_HEADER_SIZE) else {
+        return Err(ErrorCode::Invalid);
+    };
+    checksum_dst.copy_from_slice(&checksum.to_le_bytes());
     Ok(())
+}
+
+fn calc_checksum(cmd: u32, data: &[u8]) -> u32 {
+    let mut checksum = 0u32;
+    for c in cmd.to_le_bytes().iter() {
+        checksum = checksum.wrapping_add(*c as u32);
+    }
+    for d in data {
+        checksum = checksum.wrapping_add(*d as u32);
+    }
+    0u32.wrapping_sub(checksum)
 }
 
 impl<S: Syscalls> Mailbox<S> {
@@ -364,4 +373,39 @@ mod mailbox_subscribe {
 pub enum MailboxError {
     ErrorCode(ErrorCode),
     MailboxError(u32),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checksum_matches_caliptra_api_vector() {
+        assert_eq!(calc_checksum(0xe8dc3994, &[0x83, 0xe7, 0x25]), 0xfffffbe0);
+    }
+
+    #[test]
+    fn populate_checksum_writes_header_word() {
+        let mut data = [0, 0, 0, 0, 0x83, 0xe7, 0x25];
+        assert_eq!(populate_checksum(0xe8dc3994, &mut data), Ok(()));
+
+        let expected_checksum = 0xfffffbe0u32.to_le_bytes();
+        assert_eq!(
+            data.get(..MAILBOX_REQ_HEADER_SIZE),
+            Some(expected_checksum.as_slice())
+        );
+        assert_eq!(
+            data.get(MAILBOX_REQ_HEADER_SIZE..),
+            Some([0x83, 0xe7, 0x25].as_slice())
+        );
+    }
+
+    #[test]
+    fn populate_checksum_rejects_short_header() {
+        let mut data = [0; MAILBOX_REQ_HEADER_SIZE - 1];
+        assert_eq!(
+            populate_checksum(0xe8dc3994, &mut data),
+            Err(ErrorCode::Invalid)
+        );
+    }
 }

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -4,7 +4,6 @@
 
 use crate::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
-use caliptra_mcu_mbox_common::messages::RevokeVendorPubKeyType;
 use core::{iter::repeat, marker::PhantomData};
 
 pub const VENDOR_PK_HASH_SIZE: usize =
@@ -13,6 +12,33 @@ pub const MAX_NUM_VENDOR_PK_HASH: usize = 16;
 pub const VENDOR_ECC_MAX_KEY_COUNT: u32 = 4;
 pub const VENDOR_LMS_MAX_KEY_COUNT: u32 = 32;
 pub const VENDOR_MLDSA_MAX_KEY_COUNT: u32 = 4;
+
+#[repr(u32)]
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum RevokeVendorPubKeyType {
+    Ecdsa384 = 0,
+    Lms = 1,
+    Mldsa87 = 2,
+}
+
+impl TryFrom<u32> for RevokeVendorPubKeyType {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Ecdsa384),
+            1 => Ok(Self::Lms),
+            2 => Ok(Self::Mldsa87),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<RevokeVendorPubKeyType> for u32 {
+    fn from(value: RevokeVendorPubKeyType) -> Self {
+        value as u32
+    }
+}
 
 pub struct Otp<S: Syscalls = DefaultSyscalls> {
     syscall: PhantomData<S>,


### PR DESCRIPTION
## Goal

This series removes `caliptra-api` from the `caliptra-mcu-mbox-lib` dependency tree. After all three PRs are stacked, `caliptra-mcu-mbox-lib` should no longer depend on `caliptra-api`.

## This part

Part 1 removes the syscall-layer dependency paths that were pulling `caliptra-api` into the mailbox stack:

- Removes `runtime/userspace/syscall`'s direct dependency on `caliptra-api`.
- Keeps the minimal mailbox checksum/header logic needed at the syscall boundary.
- Removes syscall's dependency on `caliptra-mcu-mbox-common` by keeping the OTP key-revocation type local to the syscall OTP implementation.
- Updates `caliptra-mcu-mbox-lib` to pass the raw key type value into the syscall OTP API.

## Stack

1. `mcu-mbox: Remove caliptra-api dependency, part 1` — syscall dependency cleanup.
2. `mcu-mbox: Remove caliptra-api dependency, part 2` — move mailbox wire definitions to `mcu-caliptra-api-lite` and switch `common/mcu-mbox` to lite definitions.
3. `mcu-mbox: Remove caliptra-api dependency, part 3` — remove the `mcu-mbox-lib -> romtime -> caliptra-api` fuse-helper dependency path.
