### PR TITLE
mcu-mbox: Remove caliptra-api dependency, part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,8 +1668,8 @@ dependencies = [
 name = "caliptra-mcu-mbox-common"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
  "caliptra-mcu-registers-generated",
+ "mcu-caliptra-api-lite",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ caliptra-mcu-pldm-lib = { path = "runtime/userspace/api/pldm-lib" }
 caliptra-mcu-spdm-traits = { path = "runtime/userspace/api/spdm-lib/traits" }
 caliptra-mcu-spdm-stack = { path = "runtime/userspace/api/spdm-lib/stack" }
 caliptra-mcu-spdm-codec = { path = "runtime/userspace/api/spdm-lib/codec" }
-mcu-caliptra-api-lite = { path = "runtime/userspace/api/caliptra-api-lite" }
+mcu-caliptra-api-lite = { path = "runtime/userspace/api/caliptra-api-lite", default-features = false }
 caliptra-mcu-spdm-transports = { path = "runtime/userspace/api/spdm-lib/transports" }
 caliptra-mcu-spdm-pal = { path = "runtime/userspace/api/spdm-lib/pal" }
 caliptra-mcu-spdm-errors = { path = "runtime/userspace/api/spdm-lib/errors" }

--- a/common/mcu-mbox/Cargo.toml
+++ b/common/mcu-mbox/Cargo.toml
@@ -7,6 +7,6 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-caliptra-api.workspace = true
+mcu-caliptra-api-lite.workspace = true
 zerocopy.workspace = true
 caliptra-mcu-registers-generated.workspace = true

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1,31 +1,30 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::mailbox::CommandId as CaliptraCommandId;
-pub use caliptra_api::mailbox::{
-    CmAesDecryptInitReq, CmAesDecryptUpdateReq, CmAesEncryptInitReq, CmAesEncryptInitResp,
-    CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq, CmAesGcmDecryptFinalReq,
-    CmAesGcmDecryptFinalResp, CmAesGcmDecryptFinalRespHeader, CmAesGcmDecryptInitReq,
-    CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq, CmAesGcmDecryptUpdateResp,
-    CmAesGcmDecryptUpdateRespHeader, CmAesGcmEncryptFinalReq, CmAesGcmEncryptFinalResp,
-    CmAesGcmEncryptFinalRespHeader, CmAesGcmEncryptInitReq, CmAesGcmEncryptInitResp,
-    CmAesGcmEncryptUpdateReq, CmAesGcmEncryptUpdateResp, CmAesGcmEncryptUpdateRespHeader,
-    CmAesMode, CmAesResp, CmAesRespHeader, CmDeleteReq, CmEcdhFinishReq, CmEcdhFinishResp,
-    CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp,
-    CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHkdfExpandReq, CmHkdfExpandResp,
-    CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq, CmHmacKdfCounterResp, CmHmacReq,
-    CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage, CmMldsaPublicKeyReq, CmMldsaPublicKeyResp,
-    CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq, CmRandomGenerateReq, CmRandomGenerateResp,
-    CmRandomStirReq, CmShaFinalReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq,
-    CmStatusResp, Cmk, MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize,
-    ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
-    ProductionAuthDebugUnlockToken, ResponseVarSize, CMB_AES_ENCRYPTED_CONTEXT_SIZE,
-    CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_HMAC_MAX_SIZE,
-    MAX_CMB_DATA_SIZE,
-};
-pub use caliptra_api::{calc_checksum, verify_checksum};
 use caliptra_mcu_registers_generated::fuses::OTP_CPTRA_CORE_VENDOR_PK_HASH_0;
 use core::convert::From;
 use core::num::NonZeroU32;
+use mcu_caliptra_api_lite::mailbox::CommandId as CaliptraCommandId;
+pub use mcu_caliptra_api_lite::mailbox::{
+    calc_checksum, verify_checksum, CmAesDecryptInitReq, CmAesDecryptUpdateReq,
+    CmAesEncryptInitReq, CmAesEncryptInitResp, CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq,
+    CmAesGcmDecryptFinalReq, CmAesGcmDecryptFinalResp, CmAesGcmDecryptFinalRespHeader,
+    CmAesGcmDecryptInitReq, CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq,
+    CmAesGcmDecryptUpdateResp, CmAesGcmDecryptUpdateRespHeader, CmAesGcmEncryptFinalReq,
+    CmAesGcmEncryptFinalResp, CmAesGcmEncryptFinalRespHeader, CmAesGcmEncryptInitReq,
+    CmAesGcmEncryptInitResp, CmAesGcmEncryptUpdateReq, CmAesGcmEncryptUpdateResp,
+    CmAesGcmEncryptUpdateRespHeader, CmAesMode, CmAesResp, CmAesRespHeader, CmDeleteReq,
+    CmEcdhFinishReq, CmEcdhFinishResp, CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq,
+    CmEcdsaPublicKeyResp, CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHkdfExpandReq,
+    CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq,
+    CmHmacKdfCounterResp, CmHmacReq, CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage,
+    CmMldsaPublicKeyReq, CmMldsaPublicKeyResp, CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq,
+    CmRandomGenerateReq, CmRandomGenerateResp, CmRandomStirReq, CmShaFinalReq, CmShaFinalResp,
+    CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmStatusResp, Cmk, MailboxReqHeader,
+    MailboxRespHeader, MailboxRespHeaderVarSize, ProductionAuthDebugUnlockChallenge,
+    ProductionAuthDebugUnlockReq, ProductionAuthDebugUnlockToken, ResponseVarSize,
+    CMB_AES_ENCRYPTED_CONTEXT_SIZE, CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE,
+    CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_HMAC_MAX_SIZE, MAX_CMB_DATA_SIZE,
+};
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 pub const MAX_RESP_DATA_SIZE: usize = 4 * 1024;

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -38,7 +38,7 @@ caliptra-mcu-pldm-common.workspace = true
 caliptra-mcu-pldm-lib.workspace = true
 mcu-error.workspace = true
 caliptra-mcu-romtime.workspace = true
-mcu-caliptra-api-lite.workspace = true
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 caliptra-mcu-spdm-codec.workspace = true
 caliptra-mcu-spdm-pal.workspace = true
 caliptra-mcu-spdm-stack = { workspace = true }

--- a/runtime/userspace/api/caliptra-api-lite/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api-lite/Cargo.toml
@@ -7,7 +7,15 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-mcu-error = { workspace = true }
-caliptra-mcu-libsyscall-caliptra = { workspace = true }
-caliptra-mcu-libtock_platform = { workspace = true }
+mcu-error = { workspace = true, optional = true }
+caliptra-mcu-libsyscall-caliptra = { workspace = true, optional = true }
+caliptra-mcu-libtock_platform = { workspace = true, optional = true }
 zerocopy = { workspace = true }
+
+[features]
+default = ["mailbox-io"]
+mailbox-io = [
+    "dep:mcu-error",
+    "dep:caliptra-mcu-libsyscall-caliptra",
+    "dep:caliptra-mcu-libtock_platform",
+]

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -22,44 +22,71 @@
 #![no_std]
 #![allow(async_fn_in_trait)]
 
+#[cfg(feature = "mailbox-io")]
 mod aes_gcm;
+#[cfg(feature = "mailbox-io")]
 mod alloc;
+#[cfg(feature = "mailbox-io")]
 mod auth_stash;
+#[cfg(feature = "mailbox-io")]
 mod cert;
+#[cfg(feature = "mailbox-io")]
 mod debug_unlock;
+#[cfg(feature = "mailbox-io")]
 mod device_state;
+#[cfg(feature = "mailbox-io")]
 mod dpe;
 pub mod eat;
+#[cfg(feature = "mailbox-io")]
 mod ecdh;
+#[cfg(feature = "mailbox-io")]
 mod fe_prog;
+#[cfg(feature = "mailbox-io")]
 mod fw_info;
+#[cfg(feature = "mailbox-io")]
 mod hmac;
+#[cfg(feature = "mailbox-io")]
 mod import;
+pub mod mailbox;
+#[cfg(feature = "mailbox-io")]
 mod pcr;
+#[cfg(feature = "mailbox-io")]
 pub mod raw;
+#[cfg(feature = "mailbox-io")]
 mod rng;
+#[cfg(feature = "mailbox-io")]
 mod sha;
+#[cfg(feature = "mailbox-io")]
 pub mod signed_eat;
+#[cfg(feature = "mailbox-io")]
 mod slice;
 mod types;
+#[cfg(feature = "mailbox-io")]
 mod wire;
 
+#[cfg(feature = "mailbox-io")]
 pub use aes_gcm::{
     spdm_aes_gcm_decrypt, spdm_aes_gcm_decrypt_final, spdm_aes_gcm_decrypt_init,
     spdm_aes_gcm_decrypt_update, spdm_aes_gcm_encrypt, spdm_aes_gcm_encrypt_final,
     spdm_aes_gcm_encrypt_init, spdm_aes_gcm_encrypt_update, Aes256GcmTag, AesGcmCtx,
 };
+#[cfg(feature = "mailbox-io")]
 pub use alloc::ApiAlloc;
+#[cfg(feature = "mailbox-io")]
 pub use auth_stash::{
     authorize_and_stash, AuthorizeAndStashFlags, AuthorizeAndStashParams, ImageHashSource,
     AUTHORIZE_AND_STASH_CONTEXT_SIZE, AUTHORIZE_AND_STASH_MEASUREMENT_SIZE,
 };
+#[cfg(feature = "mailbox-io")]
 pub use cert::{get_attested_csr_ecc384, get_attested_csr_mldsa87, populate_idev_ecc384_cert};
+#[cfg(feature = "mailbox-io")]
 pub use debug_unlock::{
     request_debug_unlock_challenge, DEBUG_UNLOCK_CHALLENGE_LEN,
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
+#[cfg(feature = "mailbox-io")]
 pub use device_state::{get_pcr_value, pcr_quote_ecc384, PCR_QUOTE_ECC384_LEN};
+#[cfg(feature = "mailbox-io")]
 pub use dpe::{
     dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
     dpe_derive_context, dpe_get_cert_chain_chunk, dpe_rotate_context_default, dpe_sign_ecc_p384,
@@ -67,18 +94,27 @@ pub use dpe::{
     DpeDeriveContextParams, DpeDeriveContextResult, DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN,
     DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE, DPE_TCI_MEASUREMENT_SIZE,
 };
+#[cfg(feature = "mailbox-io")]
 pub use ecdh::{
     ecdh_finish, ecdh_generate, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,
 };
+#[cfg(feature = "mailbox-io")]
 pub use fe_prog::fe_prog;
+#[cfg(feature = "mailbox-io")]
 pub use fw_info::{fw_info, FwInfo};
+#[cfg(feature = "mailbox-io")]
 pub use hmac::{cm_hmac, hkdf_expand, hkdf_extract, HkdfSalt, CMB_HMAC_MAX_SIZE};
+#[cfg(feature = "mailbox-io")]
 pub use import::{cm_delete, cm_import};
+#[cfg(feature = "mailbox-io")]
 pub use pcr::{extend_pcr31, PCR31_INDEX, PCR31_MEASUREMENT_SIZE};
+#[cfg(feature = "mailbox-io")]
 pub use rng::rng_generate;
+#[cfg(feature = "mailbox-io")]
 pub use sha::{
     sha_finish, sha_init, sha_update, HashAlgo, HashState, SHA_CHUNK_SIZE, SHA_CONTEXT_SIZE,
 };
 pub use types::{CmKeyUsage, Cmk, CMK_SIZE};
 
+#[cfg(feature = "mailbox-io")]
 pub use mcu_error::{McuErrorCode, McuResult};

--- a/runtime/userspace/api/caliptra-api-lite/src/mailbox.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/mailbox.rs
@@ -1,0 +1,1728 @@
+// Licensed under the Apache-2.0 license
+
+//! Caliptra mailbox wire definitions needed by MCU mailbox transports.
+//!
+//! These definitions mirror the pinned `caliptra-api::mailbox` wire layout
+//! for the Caliptra cryptographic-manager and debug-unlock commands used by
+//! `caliptra-mcu-mbox-common`, without depending on the external
+//! `caliptra-api` crate.
+
+use core::mem::size_of;
+
+pub use crate::types::{CmKeyUsage, Cmk, CMK_SIZE as CMK_SIZE_BYTES};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+pub const MAX_CMB_DATA_SIZE: usize = 4096;
+pub const MAILBOX_SIZE: usize = 256 * 1024;
+pub const MAX_CM_SHA_INPUT_SIZE: usize = MAILBOX_SIZE - 12;
+pub const MAX_CMB_AES_GCM_OUTPUT_SIZE: usize = MAX_CMB_DATA_SIZE + 16;
+pub const CMB_SHA_CONTEXT_SIZE: usize = 200;
+pub const MAX_RESP_DATA_SIZE: usize = 9216;
+pub const _CMB_AES_CONTEXT_SIZE: usize = 128;
+pub const CMB_AES_ENCRYPTED_CONTEXT_SIZE: usize = 156;
+const _: () = assert!(_CMB_AES_CONTEXT_SIZE + 12 + 16 == CMB_AES_ENCRYPTED_CONTEXT_SIZE);
+pub const CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE: usize = 128;
+pub const CMB_ECDH_CONTEXT_SIZE: usize = 48;
+pub const CMB_ECDH_ENCRYPTED_CONTEXT_SIZE: usize = 76;
+const _: () = assert!(CMB_ECDH_CONTEXT_SIZE + 12 + 16 == CMB_ECDH_ENCRYPTED_CONTEXT_SIZE);
+pub const CMB_ECDH_EXCHANGE_DATA_MAX_SIZE: usize = 96;
+const _: () = assert!(CMB_ECDH_CONTEXT_SIZE * 2 == CMB_ECDH_EXCHANGE_DATA_MAX_SIZE);
+pub const CMB_HMAC_MAX_SIZE: usize = 64;
+pub const CMK_MAX_KEY_SIZE_BITS: usize = 512;
+
+pub const ECC384_SCALAR_BYTE_SIZE: usize = 48;
+pub const SHA512_DIGEST_BYTE_SIZE: usize = 64;
+pub const MLDSA87_PUB_KEY_BYTE_SIZE: usize = 2592;
+pub const MLDSA87_SIGNATURE_BYTE_SIZE: usize = 4628;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MailboxWireError {
+    RequestDataLenTooLarge,
+    ResponseDataLenTooLarge,
+}
+
+pub type MailboxWireResult<T> = Result<T, MailboxWireError>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CommandId(pub u32);
+
+impl CommandId {
+    pub const CM_IMPORT: Self = Self(0x434D_494D); // "CMIM"
+    pub const CM_DELETE: Self = Self(0x434D_444C); // "CMDL"
+    pub const CM_CLEAR: Self = Self(0x434D_434C); // "CMCL"
+    pub const CM_STATUS: Self = Self(0x434D_5354); // "CMST"
+    pub const CM_SHA_INIT: Self = Self(0x434D_5349); // "CMSI"
+    pub const CM_SHA_UPDATE: Self = Self(0x434D_5355); // "CMSU"
+    pub const CM_SHA_FINAL: Self = Self(0x434D_5346); // "CMSF"
+    pub const CM_RANDOM_GENERATE: Self = Self(0x434D_5247); // "CMRG"
+    pub const CM_RANDOM_STIR: Self = Self(0x434D_5253); // "CMRS"
+    pub const CM_AES_ENCRYPT_INIT: Self = Self(0x434D_4149); // "CMAI"
+    pub const CM_AES_ENCRYPT_UPDATE: Self = Self(0x434D_4155); // "CMAU"
+    pub const CM_AES_DECRYPT_INIT: Self = Self(0x434D_414A); // "CMAJ"
+    pub const CM_AES_DECRYPT_UPDATE: Self = Self(0x434D_4156); // "CMAV"
+    pub const CM_AES_GCM_ENCRYPT_INIT: Self = Self(0x434D_4749); // "CMGI"
+    pub const CM_AES_GCM_SPDM_ENCRYPT_INIT: Self = Self(0x434D_5345); // "CMSE"
+    pub const CM_AES_GCM_ENCRYPT_UPDATE: Self = Self(0x434D_4755); // "CMGU"
+    pub const CM_AES_GCM_ENCRYPT_FINAL: Self = Self(0x434D_4746); // "CMGF"
+    pub const CM_AES_GCM_DECRYPT_INIT: Self = Self(0x434D_4449); // "CMDI"
+    pub const CM_AES_GCM_SPDM_DECRYPT_INIT: Self = Self(0x434D_5344); // "CMSD"
+    pub const CM_AES_GCM_DECRYPT_UPDATE: Self = Self(0x434D_4455); // "CMDU"
+    pub const CM_AES_GCM_DECRYPT_FINAL: Self = Self(0x434D_4446); // "CMDF"
+    pub const CM_ECDH_GENERATE: Self = Self(0x434D_4547); // "CMEG"
+    pub const CM_ECDH_FINISH: Self = Self(0x434D_4546); // "CMEF"
+    pub const CM_HMAC: Self = Self(0x434D_484D); // "CMHM"
+    pub const CM_HMAC_KDF_COUNTER: Self = Self(0x434D_4B43); // "CMKC"
+    pub const CM_HKDF_EXTRACT: Self = Self(0x434D_4B54); // "CMKT"
+    pub const CM_HKDF_EXPAND: Self = Self(0x434D_4B50); // "CMKP"
+    pub const CM_MLDSA_PUBLIC_KEY: Self = Self(0x434D_4D50); // "CMMP"
+    pub const CM_MLDSA_SIGN: Self = Self(0x434D_4D53); // "CMMS"
+    pub const CM_MLDSA_VERIFY: Self = Self(0x434D_4D56); // "CMMV"
+    pub const CM_ECDSA_PUBLIC_KEY: Self = Self(0x434D_4550); // "CMEP"
+    pub const CM_ECDSA_SIGN: Self = Self(0x434D_4553); // "CMES"
+    pub const CM_ECDSA_VERIFY: Self = Self(0x434D_4556); // "CMEV"
+    pub const PRODUCTION_AUTH_DEBUG_UNLOCK_REQ: Self = Self(0x5044_5552); // "PDUR"
+    pub const PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN: Self = Self(0x5044_5554); // "PDUT"
+}
+
+impl From<u32> for CommandId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CommandId> for u32 {
+    fn from(value: CommandId) -> Self {
+        value.0
+    }
+}
+
+pub trait Request: IntoBytes + FromBytes + Immutable + KnownLayout {
+    const ID: CommandId;
+    type Resp: Response;
+}
+
+pub trait Response: IntoBytes + FromBytes
+where
+    Self: Sized,
+{
+    const MIN_SIZE: usize = core::mem::size_of::<Self>();
+}
+
+#[repr(C)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct MailboxReqHeader {
+    pub chksum: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Clone)]
+pub struct MailboxRespHeader {
+    pub chksum: u32,
+    pub fips_status: u32,
+}
+
+impl MailboxRespHeader {
+    pub const FIPS_STATUS_APPROVED: u32 = 0;
+    pub const FIPS_STATUS_NON_ZEROIZABLE_KEY: u32 = 0x4241_444B; // "BADK"
+    pub const FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST: u32 = 0x5553_5244; // "USRD"
+}
+
+impl Default for MailboxRespHeader {
+    fn default() -> Self {
+        Self {
+            chksum: 0,
+            fips_status: Self::FIPS_STATUS_APPROVED,
+        }
+    }
+}
+
+impl Response for MailboxRespHeader {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, Default, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct MailboxRespHeaderVarSize {
+    pub hdr: MailboxRespHeader,
+    pub data_len: u32,
+}
+
+pub trait ResponseVarSize: IntoBytes + FromBytes + Immutable + KnownLayout {
+    fn data(&self) -> MailboxWireResult<&[u8]> {
+        let (hdr, data) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| MailboxWireError::ResponseDataLenTooLarge)?;
+        data.get(..hdr.data_len as usize)
+            .ok_or(MailboxWireError::ResponseDataLenTooLarge)
+    }
+
+    fn partial_len(&self) -> MailboxWireResult<usize> {
+        let (hdr, _) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| MailboxWireError::ResponseDataLenTooLarge)?;
+        response_partial_len(
+            size_of::<MailboxRespHeaderVarSize>(),
+            hdr.data_len as usize,
+            self.as_bytes().len(),
+        )
+    }
+
+    fn as_bytes_partial(&self) -> MailboxWireResult<&[u8]> {
+        self.as_bytes()
+            .get(..self.partial_len()?)
+            .ok_or(MailboxWireError::ResponseDataLenTooLarge)
+    }
+
+    fn as_bytes_partial_mut(&mut self) -> MailboxWireResult<&mut [u8]> {
+        let partial_len = self.partial_len()?;
+        self.as_mut_bytes()
+            .get_mut(..partial_len)
+            .ok_or(MailboxWireError::ResponseDataLenTooLarge)
+    }
+}
+
+impl<T: ResponseVarSize> Response for T {
+    const MIN_SIZE: usize = core::mem::size_of::<MailboxRespHeaderVarSize>();
+}
+
+pub fn verify_checksum(checksum: u32, cmd: u32, data: &[u8]) -> bool {
+    calc_checksum(cmd, data) == checksum
+}
+
+pub fn calc_checksum(cmd: u32, data: &[u8]) -> u32 {
+    let mut checksum = 0u32;
+    for c in cmd.to_le_bytes().iter() {
+        checksum = checksum.wrapping_add(*c as u32);
+    }
+    for d in data {
+        checksum = checksum.wrapping_add(*d as u32);
+    }
+    0u32.wrapping_sub(checksum)
+}
+
+fn request_partial_len(
+    total_len: usize,
+    max_data_len: usize,
+    data_len: usize,
+) -> MailboxWireResult<usize> {
+    if data_len > max_data_len {
+        return Err(MailboxWireError::RequestDataLenTooLarge);
+    }
+    total_len
+        .checked_sub(max_data_len - data_len)
+        .ok_or(MailboxWireError::RequestDataLenTooLarge)
+}
+
+fn response_partial_len(
+    header_len: usize,
+    data_len: usize,
+    total_len: usize,
+) -> MailboxWireResult<usize> {
+    let partial_len = header_len
+        .checked_add(data_len)
+        .ok_or(MailboxWireError::ResponseDataLenTooLarge)?;
+    if partial_len > total_len {
+        return Err(MailboxWireError::ResponseDataLenTooLarge);
+    }
+    Ok(partial_len)
+}
+
+fn response_data(bytes: &[u8], header_len: usize, data_len: usize) -> MailboxWireResult<&[u8]> {
+    let data = bytes
+        .get(header_len..)
+        .ok_or(MailboxWireError::ResponseDataLenTooLarge)?;
+    data.get(..data_len)
+        .ok_or(MailboxWireError::ResponseDataLenTooLarge)
+}
+
+macro_rules! impl_request_var_size {
+    ($ty:ty, $len_field:ident, $max:expr) => {
+        impl $ty {
+            pub fn as_bytes_partial(&self) -> MailboxWireResult<&[u8]> {
+                let partial_len =
+                    request_partial_len(size_of::<Self>(), $max, self.$len_field as usize)?;
+                self.as_bytes()
+                    .get(..partial_len)
+                    .ok_or(MailboxWireError::RequestDataLenTooLarge)
+            }
+
+            pub fn as_bytes_partial_mut(&mut self) -> MailboxWireResult<&mut [u8]> {
+                let partial_len =
+                    request_partial_len(size_of::<Self>(), $max, self.$len_field as usize)?;
+                self.as_mut_bytes()
+                    .get_mut(..partial_len)
+                    .ok_or(MailboxWireError::RequestDataLenTooLarge)
+            }
+        }
+    };
+}
+
+macro_rules! impl_response_var_size_with_header {
+    ($ty:ty, $hdr:ty, $len_field:ident) => {
+        impl ResponseVarSize for $ty {
+            fn data(&self) -> MailboxWireResult<&[u8]> {
+                response_data(
+                    self.as_bytes(),
+                    size_of::<$hdr>(),
+                    self.hdr.$len_field as usize,
+                )
+            }
+
+            fn partial_len(&self) -> MailboxWireResult<usize> {
+                response_partial_len(
+                    size_of::<$hdr>(),
+                    self.hdr.$len_field as usize,
+                    self.as_bytes().len(),
+                )
+            }
+        }
+    };
+}
+
+// PRODUCTION_AUTH_DEBUG_UNLOCK_REQ
+#[repr(C)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq, Default)]
+pub struct ProductionAuthDebugUnlockReq {
+    pub hdr: MailboxReqHeader,
+    pub length: u32,
+    pub unlock_level: u8,
+    pub reserved: [u8; 3],
+}
+
+impl Request for ProductionAuthDebugUnlockReq {
+    const ID: CommandId = CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ;
+    type Resp = ProductionAuthDebugUnlockChallenge;
+}
+
+#[repr(C)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq, Clone)]
+pub struct ProductionAuthDebugUnlockChallenge {
+    pub hdr: MailboxRespHeader,
+    pub length: u32,
+    pub unique_device_identifier: [u8; 32],
+    pub challenge: [u8; 48],
+}
+
+impl Default for ProductionAuthDebugUnlockChallenge {
+    fn default() -> Self {
+        Self {
+            hdr: Default::default(),
+            length: 0,
+            unique_device_identifier: Default::default(),
+            challenge: [0; 48],
+        }
+    }
+}
+
+impl Response for ProductionAuthDebugUnlockChallenge {}
+
+#[repr(C)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq)]
+pub struct ProductionAuthDebugUnlockToken {
+    pub hdr: MailboxReqHeader,
+    pub length: u32,
+    pub unique_device_identifier: [u8; 32],
+    pub unlock_level: u8,
+    pub reserved: [u8; 3],
+    pub challenge: [u8; 48],
+    pub ecc_public_key: [u32; 24],
+    pub mldsa_public_key: [u32; 648],
+    pub ecc_signature: [u32; 24],
+    pub mldsa_signature: [u32; 1157],
+}
+
+impl Default for ProductionAuthDebugUnlockToken {
+    fn default() -> Self {
+        Self {
+            hdr: Default::default(),
+            length: Default::default(),
+            unique_device_identifier: Default::default(),
+            unlock_level: Default::default(),
+            reserved: Default::default(),
+            challenge: [0; 48],
+            ecc_public_key: [0; 24],
+            mldsa_public_key: [0; 648],
+            ecc_signature: [0; 24],
+            mldsa_signature: [0; 1157],
+        }
+    }
+}
+
+impl Request for ProductionAuthDebugUnlockToken {
+    const ID: CommandId = CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN;
+    type Resp = MailboxRespHeader;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmImportReq {
+    pub hdr: MailboxReqHeader,
+    pub key_usage: u32,
+    pub input_size: u32,
+    pub input: [u8; Self::MAX_KEY_SIZE],
+}
+
+impl Default for CmImportReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            key_usage: 0,
+            input_size: 0,
+            input: [0u8; Self::MAX_KEY_SIZE],
+        }
+    }
+}
+
+impl CmImportReq {
+    pub const MAX_KEY_SIZE: usize = CMK_MAX_KEY_SIZE_BITS / 8;
+}
+
+impl_request_var_size!(CmImportReq, input_size, CmImportReq::MAX_KEY_SIZE);
+
+impl Request for CmImportReq {
+    const ID: CommandId = CommandId::CM_IMPORT;
+    type Resp = CmImportResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmImportResp {
+    pub hdr: MailboxRespHeader,
+    pub cmk: Cmk,
+}
+
+impl Response for CmImportResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmDeleteReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+}
+
+impl Request for CmDeleteReq {
+    const ID: CommandId = CommandId::CM_DELETE;
+    type Resp = MailboxRespHeader;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmStatusResp {
+    pub hdr: MailboxRespHeader,
+    pub used_usage_storage: u32,
+    pub total_usage_storage: u32,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CmHashAlgorithm {
+    Reserved = 0,
+    Sha384 = 1,
+    Sha512 = 2,
+}
+
+impl From<u32> for CmHashAlgorithm {
+    fn from(val: u32) -> Self {
+        match val {
+            1 => CmHashAlgorithm::Sha384,
+            2 => CmHashAlgorithm::Sha512,
+            _ => CmHashAlgorithm::Reserved,
+        }
+    }
+}
+
+impl From<CmHashAlgorithm> for u32 {
+    fn from(value: CmHashAlgorithm) -> Self {
+        match value {
+            CmHashAlgorithm::Sha384 => 1,
+            CmHashAlgorithm::Sha512 => 2,
+            CmHashAlgorithm::Reserved => 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmShaInitReq {
+    pub hdr: MailboxReqHeader,
+    pub hash_algorithm: u32,
+    pub input_size: u32,
+    pub input: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmShaInitReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            hash_algorithm: 0,
+            input_size: 0,
+            input: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmShaInitReq, input_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmShaInitReq {
+    const ID: CommandId = CommandId::CM_SHA_INIT;
+    type Resp = CmShaInitResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmShaInitResp {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_SHA_CONTEXT_SIZE],
+}
+
+impl Default for CmShaInitResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_SHA_CONTEXT_SIZE],
+        }
+    }
+}
+
+impl Response for CmShaInitResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmShaUpdateReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_SHA_CONTEXT_SIZE],
+    pub input_size: u32,
+    pub input: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmShaUpdateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_SHA_CONTEXT_SIZE],
+            input_size: 0,
+            input: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmShaUpdateReq, input_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmShaUpdateReq {
+    const ID: CommandId = CommandId::CM_SHA_UPDATE;
+    type Resp = CmShaInitResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmShaFinalReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_SHA_CONTEXT_SIZE],
+    pub input_size: u32,
+    pub input: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmShaFinalReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_SHA_CONTEXT_SIZE],
+            input_size: 0,
+            input: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmShaFinalReq, input_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmShaFinalReq {
+    const ID: CommandId = CommandId::CM_SHA_FINAL;
+    type Resp = CmShaFinalResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmShaFinalResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub hash: [u8; SHA512_DIGEST_BYTE_SIZE],
+}
+
+impl Default for CmShaFinalResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            hash: [0u8; SHA512_DIGEST_BYTE_SIZE],
+        }
+    }
+}
+
+impl ResponseVarSize for CmShaFinalResp {}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CmRandomGenerateReq {
+    pub hdr: MailboxReqHeader,
+    pub size: u32,
+}
+
+impl Request for CmRandomGenerateReq {
+    const ID: CommandId = CommandId::CM_RANDOM_GENERATE;
+    type Resp = CmRandomGenerateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmRandomGenerateResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub data: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmRandomGenerateResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            data: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl ResponseVarSize for CmRandomGenerateResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmRandomStirReq {
+    pub hdr: MailboxReqHeader,
+    pub input_size: u32,
+    pub input: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmRandomStirReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            input_size: 0,
+            input: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmRandomStirReq, input_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmRandomStirReq {
+    const ID: CommandId = CommandId::CM_RANDOM_STIR;
+    type Resp = MailboxRespHeader;
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CmAesMode {
+    Reserved = 0,
+    Cbc = 1,
+    Ctr = 2,
+}
+
+impl From<u32> for CmAesMode {
+    fn from(val: u32) -> Self {
+        match val {
+            1 => CmAesMode::Cbc,
+            2 => CmAesMode::Ctr,
+            _ => CmAesMode::Reserved,
+        }
+    }
+}
+
+impl From<CmAesMode> for u32 {
+    fn from(value: CmAesMode) -> Self {
+        match value {
+            CmAesMode::Cbc => 1,
+            CmAesMode::Ctr => 2,
+            CmAesMode::Reserved => 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesEncryptInitReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub mode: u32,
+    pub plaintext_size: u32,
+    pub plaintext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesEncryptInitReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            mode: CmAesMode::Reserved as u32,
+            plaintext_size: 0,
+            plaintext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesEncryptInitReq, plaintext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesEncryptInitReq {
+    const ID: CommandId = CommandId::CM_AES_ENCRYPT_INIT;
+    type Resp = CmAesEncryptInitResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesEncryptInitResp {
+    pub hdr: CmAesEncryptInitRespHeader,
+    pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesEncryptInitRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+    pub iv: [u8; 16],
+    pub ciphertext_size: u32,
+}
+
+impl Default for CmAesEncryptInitResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesEncryptInitRespHeader::default(),
+            ciphertext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl Default for CmAesEncryptInitRespHeader {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+            iv: [0u8; 16],
+            ciphertext_size: 0,
+        }
+    }
+}
+
+impl_response_var_size_with_header!(
+    CmAesEncryptInitResp,
+    CmAesEncryptInitRespHeader,
+    ciphertext_size
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesEncryptUpdateReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+    pub plaintext_size: u32,
+    pub plaintext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesEncryptUpdateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+            plaintext_size: 0,
+            plaintext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesEncryptUpdateReq, plaintext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesEncryptUpdateReq {
+    const ID: CommandId = CommandId::CM_AES_ENCRYPT_UPDATE;
+    type Resp = CmAesResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesDecryptInitReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub mode: u32,
+    pub iv: [u8; 16],
+    pub ciphertext_size: u32,
+    pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesDecryptInitReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            mode: CmAesMode::Reserved as u32,
+            iv: [0u8; 16],
+            ciphertext_size: 0,
+            ciphertext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesDecryptInitReq, ciphertext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesDecryptInitReq {
+    const ID: CommandId = CommandId::CM_AES_DECRYPT_INIT;
+    type Resp = CmAesResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesDecryptUpdateReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+    pub ciphertext_size: u32,
+    pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesDecryptUpdateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+            ciphertext_size: 0,
+            ciphertext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesDecryptUpdateReq, ciphertext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesDecryptUpdateReq {
+    const ID: CommandId = CommandId::CM_AES_DECRYPT_UPDATE;
+    type Resp = CmAesResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesResp {
+    pub hdr: CmAesRespHeader,
+    pub output: [u8; MAX_CMB_DATA_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+    pub output_size: u32,
+}
+
+impl Default for CmAesResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesRespHeader::default(),
+            output: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl Default for CmAesRespHeader {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_ENCRYPTED_CONTEXT_SIZE],
+            output_size: 0,
+        }
+    }
+}
+
+impl_response_var_size_with_header!(CmAesResp, CmAesRespHeader, output_size);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptInitReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: u32,
+    pub cmk: Cmk,
+    pub aad_size: u32,
+    pub aad: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmEncryptInitReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            flags: 0,
+            cmk: Cmk::default(),
+            aad_size: 0,
+            aad: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmEncryptInitReq, aad_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmEncryptInitReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_ENCRYPT_INIT;
+    type Resp = CmAesGcmEncryptInitResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptInitResp {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub iv: [u8; 12],
+}
+
+impl Default for CmAesGcmEncryptInitResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            iv: [0u8; 12],
+        }
+    }
+}
+
+impl Response for CmAesGcmEncryptInitResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptUpdateReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub plaintext_size: u32,
+    pub plaintext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmEncryptUpdateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            plaintext_size: 0,
+            plaintext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmEncryptUpdateReq, plaintext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmEncryptUpdateReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_ENCRYPT_UPDATE;
+    type Resp = CmAesGcmEncryptUpdateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptUpdateResp {
+    pub hdr: CmAesGcmEncryptUpdateRespHeader,
+    pub ciphertext: [u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptUpdateRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub ciphertext_size: u32,
+}
+
+impl Default for CmAesGcmEncryptUpdateResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesGcmEncryptUpdateRespHeader::default(),
+            ciphertext: [0u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+        }
+    }
+}
+
+impl Default for CmAesGcmEncryptUpdateRespHeader {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            ciphertext_size: 0,
+        }
+    }
+}
+
+impl_response_var_size_with_header!(
+    CmAesGcmEncryptUpdateResp,
+    CmAesGcmEncryptUpdateRespHeader,
+    ciphertext_size
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptFinalReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub plaintext_size: u32,
+    pub plaintext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmEncryptFinalReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            plaintext_size: 0,
+            plaintext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmEncryptFinalReq, plaintext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmEncryptFinalReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_ENCRYPT_FINAL;
+    type Resp = CmAesGcmEncryptFinalResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmEncryptFinalResp {
+    pub hdr: CmAesGcmEncryptFinalRespHeader,
+    pub ciphertext: [u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmAesGcmEncryptFinalRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub tag: [u8; 16],
+    pub ciphertext_size: u32,
+}
+
+impl Default for CmAesGcmEncryptFinalResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesGcmEncryptFinalRespHeader::default(),
+            ciphertext: [0u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+        }
+    }
+}
+
+impl_response_var_size_with_header!(
+    CmAesGcmEncryptFinalResp,
+    CmAesGcmEncryptFinalRespHeader,
+    ciphertext_size
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptInitReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: u32,
+    pub cmk: Cmk,
+    pub iv: [u8; 12],
+    pub aad_size: u32,
+    pub aad: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmDecryptInitReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            flags: 0,
+            cmk: Cmk::default(),
+            iv: [0u8; 12],
+            aad_size: 0,
+            aad: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmDecryptInitReq, aad_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmDecryptInitReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_DECRYPT_INIT;
+    type Resp = CmAesGcmDecryptInitResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptInitResp {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub iv: [u8; 12],
+}
+
+impl Default for CmAesGcmDecryptInitResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            iv: [0u8; 12],
+        }
+    }
+}
+
+impl Response for CmAesGcmDecryptInitResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptUpdateReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub ciphertext_size: u32,
+    pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmDecryptUpdateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            ciphertext_size: 0,
+            ciphertext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmDecryptUpdateReq, ciphertext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmDecryptUpdateReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_DECRYPT_UPDATE;
+    type Resp = CmAesGcmDecryptUpdateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptUpdateResp {
+    pub hdr: CmAesGcmDecryptUpdateRespHeader,
+    pub plaintext: [u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptUpdateRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub plaintext_size: u32,
+}
+
+impl Default for CmAesGcmDecryptUpdateResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesGcmDecryptUpdateRespHeader::default(),
+            plaintext: [0u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+        }
+    }
+}
+
+impl Default for CmAesGcmDecryptUpdateRespHeader {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            plaintext_size: 0,
+        }
+    }
+}
+
+impl_response_var_size_with_header!(
+    CmAesGcmDecryptUpdateResp,
+    CmAesGcmDecryptUpdateRespHeader,
+    plaintext_size
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptFinalReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+    pub tag_len: u32,
+    pub tag: [u8; 16],
+    pub ciphertext_size: u32,
+    pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmAesGcmDecryptFinalReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
+            tag_len: 0,
+            tag: [0u8; 16],
+            ciphertext_size: 0,
+            ciphertext: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmAesGcmDecryptFinalReq, ciphertext_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmAesGcmDecryptFinalReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_DECRYPT_FINAL;
+    type Resp = CmAesGcmDecryptFinalResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptFinalResp {
+    pub hdr: CmAesGcmDecryptFinalRespHeader,
+    pub plaintext: [u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmAesGcmDecryptFinalRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub tag_verified: u32,
+    pub plaintext_size: u32,
+}
+
+impl Default for CmAesGcmDecryptFinalResp {
+    fn default() -> Self {
+        Self {
+            hdr: CmAesGcmDecryptFinalRespHeader::default(),
+            plaintext: [0u8; MAX_CMB_AES_GCM_OUTPUT_SIZE],
+        }
+    }
+}
+
+impl_response_var_size_with_header!(
+    CmAesGcmDecryptFinalResp,
+    CmAesGcmDecryptFinalRespHeader,
+    plaintext_size
+);
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdhGenerateReq {
+    pub hdr: MailboxReqHeader,
+}
+
+impl Request for CmEcdhGenerateReq {
+    const ID: CommandId = CommandId::CM_ECDH_GENERATE;
+    type Resp = CmEcdhGenerateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdhGenerateResp {
+    pub hdr: MailboxRespHeader,
+    pub context: [u8; CMB_ECDH_ENCRYPTED_CONTEXT_SIZE],
+    pub exchange_data: [u8; CMB_ECDH_EXCHANGE_DATA_MAX_SIZE],
+}
+
+impl Default for CmEcdhGenerateResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            context: [0u8; CMB_ECDH_ENCRYPTED_CONTEXT_SIZE],
+            exchange_data: [0u8; CMB_ECDH_EXCHANGE_DATA_MAX_SIZE],
+        }
+    }
+}
+
+impl Response for CmEcdhGenerateResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdhFinishReq {
+    pub hdr: MailboxReqHeader,
+    pub context: [u8; CMB_ECDH_ENCRYPTED_CONTEXT_SIZE],
+    pub key_usage: u32,
+    pub incoming_exchange_data: [u8; CMB_ECDH_EXCHANGE_DATA_MAX_SIZE],
+}
+
+impl Default for CmEcdhFinishReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            context: [0u8; CMB_ECDH_ENCRYPTED_CONTEXT_SIZE],
+            key_usage: 0,
+            incoming_exchange_data: [0u8; CMB_ECDH_EXCHANGE_DATA_MAX_SIZE],
+        }
+    }
+}
+
+impl Request for CmEcdhFinishReq {
+    const ID: CommandId = CommandId::CM_ECDH_FINISH;
+    type Resp = CmEcdhFinishResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdhFinishResp {
+    pub hdr: MailboxRespHeader,
+    pub output: Cmk,
+}
+
+impl Response for CmEcdhFinishResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHmacReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub hash_algorithm: u32,
+    pub data_size: u32,
+    pub data: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmHmacReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            hash_algorithm: 0,
+            data_size: 0,
+            data: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmHmacReq, data_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmHmacReq {
+    const ID: CommandId = CommandId::CM_HMAC;
+    type Resp = CmHmacResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHmacResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub mac: [u8; CMB_HMAC_MAX_SIZE],
+}
+
+impl Default for CmHmacResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            mac: [0u8; CMB_HMAC_MAX_SIZE],
+        }
+    }
+}
+
+impl ResponseVarSize for CmHmacResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHmacKdfCounterReq {
+    pub hdr: MailboxReqHeader,
+    pub kin: Cmk,
+    pub hash_algorithm: u32,
+    pub key_usage: u32,
+    pub key_size: u32,
+    pub label_size: u32,
+    pub label: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmHmacKdfCounterReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            kin: Cmk::default(),
+            hash_algorithm: 0,
+            key_size: 0,
+            key_usage: 0,
+            label_size: 0,
+            label: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmHmacKdfCounterReq, label_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmHmacKdfCounterReq {
+    const ID: CommandId = CommandId::CM_HMAC_KDF_COUNTER;
+    type Resp = CmHmacKdfCounterResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHmacKdfCounterResp {
+    pub hdr: MailboxRespHeader,
+    pub kout: Cmk,
+}
+
+impl Response for CmHmacKdfCounterResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmHkdfExtractReq {
+    pub hdr: MailboxReqHeader,
+    pub hash_algorithm: u32,
+    pub salt: Cmk,
+    pub ikm: Cmk,
+}
+
+impl Request for CmHkdfExtractReq {
+    const ID: CommandId = CommandId::CM_HKDF_EXTRACT;
+    type Resp = CmHkdfExtractResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHkdfExtractResp {
+    pub hdr: MailboxRespHeader,
+    pub prk: Cmk,
+}
+
+impl Response for CmHkdfExtractResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHkdfExpandReq {
+    pub hdr: MailboxReqHeader,
+    pub prk: Cmk,
+    pub hash_algorithm: u32,
+    pub key_usage: u32,
+    pub key_size: u32,
+    pub info_size: u32,
+    pub info: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmHkdfExpandReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            prk: Cmk::default(),
+            hash_algorithm: 0,
+            key_size: 0,
+            key_usage: 0,
+            info_size: 0,
+            info: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmHkdfExpandReq, info_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmHkdfExpandReq {
+    const ID: CommandId = CommandId::CM_HKDF_EXPAND;
+    type Resp = CmHkdfExpandResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHkdfExpandResp {
+    pub hdr: MailboxRespHeader,
+    pub okm: Cmk,
+}
+
+impl Response for CmHkdfExpandResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmMldsaPublicKeyReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+}
+
+impl Request for CmMldsaPublicKeyReq {
+    const ID: CommandId = CommandId::CM_MLDSA_PUBLIC_KEY;
+    type Resp = CmMldsaPublicKeyResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMldsaPublicKeyResp {
+    pub hdr: MailboxRespHeader,
+    pub public_key: [u8; MLDSA87_PUB_KEY_BYTE_SIZE],
+}
+
+impl Default for CmMldsaPublicKeyResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            public_key: [0u8; MLDSA87_PUB_KEY_BYTE_SIZE],
+        }
+    }
+}
+
+impl Response for CmMldsaPublicKeyResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMldsaSignReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub message_size: u32,
+    pub message: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmMldsaSignReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            message_size: 0,
+            message: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmMldsaSignReq, message_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmMldsaSignReq {
+    const ID: CommandId = CommandId::CM_MLDSA_SIGN;
+    type Resp = CmMldsaSignResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMldsaSignResp {
+    pub hdr: MailboxRespHeader,
+    pub signature: [u8; MLDSA87_SIGNATURE_BYTE_SIZE],
+}
+
+impl Default for CmMldsaSignResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            signature: [0u8; MLDSA87_SIGNATURE_BYTE_SIZE],
+        }
+    }
+}
+
+impl Response for CmMldsaSignResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMldsaVerifyReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub signature: [u8; MLDSA87_SIGNATURE_BYTE_SIZE],
+    pub message_size: u32,
+    pub message: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmMldsaVerifyReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            signature: [0u8; MLDSA87_SIGNATURE_BYTE_SIZE],
+            message_size: 0,
+            message: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmMldsaVerifyReq, message_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmMldsaVerifyReq {
+    const ID: CommandId = CommandId::CM_MLDSA_VERIFY;
+    type Resp = MailboxRespHeader;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmEcdsaPublicKeyReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+}
+
+impl Request for CmEcdsaPublicKeyReq {
+    const ID: CommandId = CommandId::CM_ECDSA_PUBLIC_KEY;
+    type Resp = CmEcdsaPublicKeyResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdsaPublicKeyResp {
+    pub hdr: MailboxRespHeader,
+    pub public_key_x: [u8; ECC384_SCALAR_BYTE_SIZE],
+    pub public_key_y: [u8; ECC384_SCALAR_BYTE_SIZE],
+}
+
+impl Default for CmEcdsaPublicKeyResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            public_key_x: [0u8; ECC384_SCALAR_BYTE_SIZE],
+            public_key_y: [0u8; ECC384_SCALAR_BYTE_SIZE],
+        }
+    }
+}
+
+impl Response for CmEcdsaPublicKeyResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdsaSignReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub message_size: u32,
+    pub message: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmEcdsaSignReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            message_size: 0,
+            message: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmEcdsaSignReq, message_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmEcdsaSignReq {
+    const ID: CommandId = CommandId::CM_ECDSA_SIGN;
+    type Resp = CmEcdsaSignResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdsaSignResp {
+    pub hdr: MailboxRespHeader,
+    pub signature_r: [u8; ECC384_SCALAR_BYTE_SIZE],
+    pub signature_s: [u8; ECC384_SCALAR_BYTE_SIZE],
+}
+
+impl Default for CmEcdsaSignResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            signature_r: [0u8; ECC384_SCALAR_BYTE_SIZE],
+            signature_s: [0u8; ECC384_SCALAR_BYTE_SIZE],
+        }
+    }
+}
+
+impl Response for CmEcdsaSignResp {}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmEcdsaVerifyReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub signature_r: [u8; ECC384_SCALAR_BYTE_SIZE],
+    pub signature_s: [u8; ECC384_SCALAR_BYTE_SIZE],
+    pub message_size: u32,
+    pub message: [u8; MAX_CMB_DATA_SIZE],
+}
+
+impl Default for CmEcdsaVerifyReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            signature_r: [0u8; ECC384_SCALAR_BYTE_SIZE],
+            signature_s: [0u8; ECC384_SCALAR_BYTE_SIZE],
+            message_size: 0,
+            message: [0u8; MAX_CMB_DATA_SIZE],
+        }
+    }
+}
+
+impl_request_var_size!(CmEcdsaVerifyReq, message_size, MAX_CMB_DATA_SIZE);
+
+impl Request for CmEcdsaVerifyReq {
+    const ID: CommandId = CommandId::CM_ECDSA_VERIFY;
+    type Resp = MailboxRespHeader;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checksum_matches_caliptra_api_vector() {
+        assert_eq!(calc_checksum(0xe8dc3994, &[0x83, 0xe7, 0x25]), 0xfffffbe0);
+        assert!(verify_checksum(0xfffffbe0, 0xe8dc3994, &[0x83, 0xe7, 0x25]));
+    }
+
+    #[test]
+    fn mailbox_wire_layout_matches_caliptra_api() {
+        assert_eq!(size_of::<MailboxReqHeader>(), 4);
+        assert_eq!(size_of::<MailboxRespHeader>(), 8);
+        assert_eq!(size_of::<MailboxRespHeaderVarSize>(), 12);
+        assert_eq!(size_of::<Cmk>(), 128);
+        assert_eq!(size_of::<ProductionAuthDebugUnlockReq>(), 12);
+        assert_eq!(size_of::<ProductionAuthDebugUnlockChallenge>(), 92);
+        assert_eq!(size_of::<ProductionAuthDebugUnlockToken>(), 7504);
+        assert_eq!(size_of::<CmImportReq>(), 76);
+        assert_eq!(size_of::<CmImportResp>(), 136);
+        assert_eq!(size_of::<CmDeleteReq>(), 132);
+        assert_eq!(size_of::<CmStatusResp>(), 16);
+        assert_eq!(size_of::<CmShaInitReq>(), 4108);
+        assert_eq!(size_of::<CmShaUpdateReq>(), 4304);
+        assert_eq!(size_of::<CmShaFinalReq>(), 4304);
+        assert_eq!(size_of::<CmShaInitResp>(), 208);
+        assert_eq!(size_of::<CmShaFinalResp>(), 76);
+        assert_eq!(size_of::<CmRandomGenerateReq>(), 8);
+        assert_eq!(size_of::<CmRandomGenerateResp>(), 4108);
+        assert_eq!(size_of::<CmRandomStirReq>(), 4104);
+        assert_eq!(size_of::<CmAesEncryptInitReq>(), 4236);
+        assert_eq!(size_of::<CmAesEncryptInitRespHeader>(), 184);
+        assert_eq!(size_of::<CmAesEncryptInitResp>(), 4280);
+        assert_eq!(size_of::<CmAesRespHeader>(), 168);
+        assert_eq!(size_of::<CmAesResp>(), 4264);
+        assert_eq!(size_of::<CmAesGcmEncryptInitReq>(), 4236);
+        assert_eq!(size_of::<CmAesGcmEncryptInitResp>(), 148);
+        assert_eq!(size_of::<CmAesGcmEncryptUpdateRespHeader>(), 140);
+        assert_eq!(size_of::<CmAesGcmEncryptUpdateResp>(), 4252);
+        assert_eq!(size_of::<CmAesGcmEncryptFinalRespHeader>(), 28);
+        assert_eq!(size_of::<CmAesGcmEncryptFinalResp>(), 4140);
+        assert_eq!(size_of::<CmAesGcmDecryptFinalReq>(), 4252);
+        assert_eq!(size_of::<CmAesGcmDecryptFinalRespHeader>(), 16);
+        assert_eq!(size_of::<CmAesGcmDecryptFinalResp>(), 4128);
+        assert_eq!(size_of::<CmEcdhGenerateReq>(), 4);
+        assert_eq!(size_of::<CmEcdhGenerateResp>(), 180);
+        assert_eq!(size_of::<CmEcdhFinishReq>(), 180);
+        assert_eq!(size_of::<CmEcdhFinishResp>(), 136);
+        assert_eq!(size_of::<CmHmacReq>(), 4236);
+        assert_eq!(size_of::<CmHmacResp>(), 76);
+        assert_eq!(size_of::<CmHmacKdfCounterReq>(), 4244);
+        assert_eq!(size_of::<CmHmacKdfCounterResp>(), 136);
+        assert_eq!(size_of::<CmHkdfExtractReq>(), 264);
+        assert_eq!(size_of::<CmHkdfExtractResp>(), 136);
+        assert_eq!(size_of::<CmHkdfExpandReq>(), 4244);
+        assert_eq!(size_of::<CmHkdfExpandResp>(), 136);
+        assert_eq!(size_of::<CmMldsaPublicKeyReq>(), 132);
+        assert_eq!(size_of::<CmMldsaPublicKeyResp>(), 2600);
+        assert_eq!(size_of::<CmMldsaSignReq>(), 4232);
+        assert_eq!(size_of::<CmMldsaSignResp>(), 4636);
+        assert_eq!(size_of::<CmMldsaVerifyReq>(), 8860);
+        assert_eq!(size_of::<CmEcdsaPublicKeyReq>(), 132);
+        assert_eq!(size_of::<CmEcdsaPublicKeyResp>(), 104);
+        assert_eq!(size_of::<CmEcdsaSignReq>(), 4232);
+        assert_eq!(size_of::<CmEcdsaSignResp>(), 104);
+        assert_eq!(size_of::<CmEcdsaVerifyReq>(), 4328);
+    }
+
+    #[test]
+    fn request_partial_len_is_checked() {
+        let mut req = CmShaInitReq {
+            input_size: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            req.as_bytes_partial().unwrap().len(),
+            size_of::<CmShaInitReq>() - MAX_CMB_DATA_SIZE + 3
+        );
+        assert_eq!(
+            req.as_bytes_partial_mut().unwrap().len(),
+            size_of::<CmShaInitReq>() - MAX_CMB_DATA_SIZE + 3
+        );
+
+        req.input_size = (MAX_CMB_DATA_SIZE + 1) as u32;
+        assert_eq!(
+            req.as_bytes_partial().unwrap_err(),
+            MailboxWireError::RequestDataLenTooLarge
+        );
+    }
+
+    #[test]
+    fn response_partial_len_is_checked() {
+        let mut resp = CmAesResp::default();
+        resp.hdr.output_size = 4;
+        assert_eq!(resp.data().unwrap().len(), 4);
+        assert_eq!(
+            resp.as_bytes_partial().unwrap().len(),
+            size_of::<CmAesRespHeader>() + 4
+        );
+        assert_eq!(
+            resp.as_bytes_partial_mut().unwrap().len(),
+            size_of::<CmAesRespHeader>() + 4
+        );
+
+        resp.hdr.output_size = (MAX_CMB_DATA_SIZE + 1) as u32;
+        assert_eq!(
+            resp.as_bytes_partial().unwrap_err(),
+            MailboxWireError::ResponseDataLenTooLarge
+        );
+    }
+}

--- a/runtime/userspace/api/caliptra-api-lite/src/types.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/types.rs
@@ -2,6 +2,8 @@
 
 //! Shared types for Caliptra Cryptographic Manager (CM) mailbox commands.
 
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
 /// Size in bytes of a CMK handle.
 pub const CMK_SIZE: usize = 128;
 
@@ -11,7 +13,7 @@ pub const CMK_SIZE: usize = 128;
 /// 128-byte encrypted key material returned by CM mailbox commands and
 /// supplied back to subsequent CM commands.
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq)]
 pub struct Cmk(pub [u8; CMK_SIZE]);
 
 impl Default for Cmk {
@@ -29,4 +31,28 @@ pub enum CmKeyUsage {
     Aes = 2,
     Ecdsa = 3,
     Mldsa = 4,
+}
+
+impl From<u32> for CmKeyUsage {
+    fn from(val: u32) -> Self {
+        match val {
+            1 => CmKeyUsage::Hmac,
+            2 => CmKeyUsage::Aes,
+            3 => CmKeyUsage::Ecdsa,
+            4 => CmKeyUsage::Mldsa,
+            _ => CmKeyUsage::Reserved,
+        }
+    }
+}
+
+impl From<CmKeyUsage> for u32 {
+    fn from(value: CmKeyUsage) -> Self {
+        match value {
+            CmKeyUsage::Hmac => 1,
+            CmKeyUsage::Aes => 2,
+            CmKeyUsage::Ecdsa => 3,
+            CmKeyUsage::Mldsa => 4,
+            CmKeyUsage::Reserved => 0,
+        }
+    }
 }

--- a/runtime/userspace/api/caliptra-common-commands/Cargo.toml
+++ b/runtime/userspace/api/caliptra-common-commands/Cargo.toml
@@ -8,5 +8,5 @@ authors.workspace = true
 
 [dependencies]
 caliptra-mcu-mbox-common.workspace = true
-mcu-caliptra-api-lite.workspace = true
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 zerocopy.workspace = true

--- a/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
+++ b/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor.workspace = true
 embassy-sync.workspace = true
 mcu-error.workspace = true
 caliptra-mcu-common-commands.workspace = true
-mcu-caliptra-api-lite.workspace = true
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 caliptra-mcu-libsyscall-caliptra.workspace = true
 caliptra-mcu-libtock_alarm.workspace = true
 caliptra-mcu-libtock_console.workspace = true

--- a/runtime/userspace/api/measurement-api/Cargo.toml
+++ b/runtime/userspace/api/measurement-api/Cargo.toml
@@ -11,7 +11,7 @@ mcu-error = { workspace = true }
 caliptra-mcu-libsyscall-caliptra = { workspace = true }
 caliptra-mcu-libtock_platform = { workspace = true }
 embassy-sync = { workspace = true }
-mcu-caliptra-api-lite = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 
 [dev-dependencies]
 sha2 = { workspace = true }

--- a/runtime/userspace/api/spdm-lib/pal/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/pal/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 caliptra-mcu-spdm-traits = { workspace = true }
 caliptra-mcu-spdm-codec = { workspace = true }
 caliptra-mcu-measurement-api = { workspace = true }
-mcu-caliptra-api-lite = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 mcu-error = { workspace = true }
 caliptra-mcu-libsyscall-caliptra = { workspace = true, optional = true }
 caliptra-mcu-libtock_platform = { workspace = true, optional = true }

--- a/runtime/userspace/api/spdm-lib/stack/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/stack/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 [dependencies]
 caliptra-mcu-spdm-traits = { workspace = true }
 caliptra-mcu-spdm-codec = { workspace = true }
-mcu-caliptra-api-lite = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 caliptra-mcu-spdm-errors = { workspace = true }
 mcu-error = { workspace = true }
 bitfield-struct = { workspace = true }

--- a/runtime/userspace/api/spdm-lib/traits/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/traits/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-mcu-caliptra-api-lite = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
 mcu-error = { workspace = true }
 
 [features]

--- a/runtime/userspace/api/spdm-lib/vdm-handler/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/Cargo.toml
@@ -18,4 +18,4 @@ zerocopy = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
-mcu-caliptra-api-lite = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -1,10 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, bail, Result};
-use caliptra_api::calc_checksum;
-use caliptra_api::mailbox::MailboxReqHeader;
 use caliptra_mcu_hw_model::McuHwModel;
-use caliptra_mcu_mbox_common::messages::GetAuthCmdChallengeReq;
+use caliptra_mcu_mbox_common::messages::{calc_checksum, GetAuthCmdChallengeReq, MailboxReqHeader};
 use core::mem::size_of;
 use hmac::{Hmac, Mac};
 use sha2::Sha384;

--- a/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
+++ b/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
@@ -5,12 +5,12 @@ use crate::{
     test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, TestParams},
 };
 use anyhow::Result;
-use caliptra_api::{error::CaliptraError, mailbox::MailboxReqHeader, SocManager};
+use caliptra_api::{error::CaliptraError, SocManager};
 use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
 use caliptra_mcu_hw_model::{LifecycleControllerState, McuHwModel};
 use caliptra_mcu_mbox_common::messages::{
-    FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq, ProvisionVendorPkHashReq,
-    RevokeVendorPubKeyType,
+    FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq, MailboxReqHeader,
+    ProvisionVendorPkHashReq, RevokeVendorPubKeyType,
 };
 use caliptra_mcu_romtime::McuBootMilestones;
 


### PR DESCRIPTION
Goal
This series removes caliptra-api from the caliptra-mcu-mbox-lib dependency tree. After all three PRs are stacked, caliptra-mcu-mbox-lib should no longer depend on caliptra-api.

This part
Part 2 removes the common/mcu-mbox -> caliptra-api dependency path.

Moves the Caliptra mailbox wire definitions used by common/mcu-mbox into mcu-caliptra-api-lite.
Switches common/mcu-mbox from caliptra-api reexports to mcu-caliptra-api-lite mailbox definitions.
Removes common/mcu-mbox's direct dependency on caliptra-api.
Keeps common/mcu-mbox as a wire-only lite consumer with default-features disabled.
Keeps existing mcu-caliptra-api-lite users on the default mailbox-io behavior while gating syscall-backed lite APIs behind that feature.
Adds wire layout and checksum tests for the copied mailbox definitions.

Stack
mcu-mbox: Remove caliptra-api dependency, part 1 — syscall dependency cleanup.
mcu-mbox: Remove caliptra-api dependency, part 2 — move mailbox wire definitions to mcu-caliptra-api-lite and switch common/mcu-mbox to lite definitions.
mcu-mbox: Remove caliptra-api dependency, part 3 — remove the mcu-mbox-lib -> romtime -> caliptra-api fuse-helper dependency path.