### PR TITLE
Advertise MCTP DCR on I3C targets

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -551,12 +551,14 @@ impl BootFlow for ColdBoot {
             i3c1.configure(crate::I3cConfig {
                 static_addr: straps.i3c1_static_addr,
                 recovery_enabled: true,
+                dcr: crate::i3c::MCTP_DCR,
                 timings: params.i3c1_timings.unwrap_or_default(),
             });
         } else {
             i3c.configure(crate::I3cConfig {
                 static_addr: straps.i3c_static_addr,
                 recovery_enabled: true,
+                dcr: crate::i3c::MCTP_DCR,
                 timings: params.i3c_timings.unwrap_or_default(),
             });
         }

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -5,12 +5,15 @@ use caliptra_mcu_registers_generated::i3c;
 use caliptra_mcu_registers_generated::i3c::bits::{
     DeviceStatus0, HcControl, IndirectFifoCtrl0, QueueThldCtrl, RecoveryStatus,
     RingHeadersSectionOffset, StbyCrCapabilities, StbyCrControl, StbyCrDeviceAddr,
-    StbyCrVirtDeviceAddr, TtiQueueThldCtrl,
+    StbyCrDeviceChar, StbyCrVirtDeviceAddr, TtiQueueThldCtrl,
 };
 use caliptra_mcu_romtime::{HexWord, StaticRef};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 use crate::fatal_error;
+
+/// MIPI-assigned Device Characteristic Register value for an MCTP device.
+pub const MCTP_DCR: u8 = 0xCC;
 
 /// I3C bus timing parameters, in clock units.
 ///
@@ -74,6 +77,9 @@ pub struct I3cConfig {
     pub static_addr: u8,
     /// Whether recovery is enabled (also programs the virtual device address).
     pub recovery_enabled: bool,
+    /// Device Characteristic Register (DCR) — distinguishes device type during DAA.
+    /// The virtual target remains at its reset value of 0xBD (OCP Recovery).
+    pub dcr: u8,
     /// Bus timing parameters for this controller.
     pub timings: I3cTimings,
 }
@@ -92,6 +98,7 @@ impl I3c {
         let I3cConfig {
             static_addr: addr,
             recovery_enabled,
+            dcr,
             timings,
         } = config;
         let regs = self.registers;
@@ -163,6 +170,15 @@ impl I3c {
                 + QueueThldCtrl::RespBufThld.val(1)
                 + QueueThldCtrl::IbiStatusThld.val(1),
         );
+
+        // Set the main target's DCR before enabling the standby controller.
+        // Once STBY_CR_ENABLE_INIT is non-zero, the RTL locks DCR read-only.
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom-i3c] Setting main target DCR to {:02x}",
+            dcr
+        );
+        regs.stdby_ctrl_mode_stby_cr_device_char
+            .modify(StbyCrDeviceChar::Dcr.val(dcr as u32));
 
         caliptra_mcu_romtime::println!("[mcu-rom-i3c] Enable the target transaction interface");
         regs.stdby_ctrl_mode_stby_cr_control.modify(

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -173,10 +173,7 @@ impl I3c {
 
         // Set the main target's DCR before enabling the standby controller.
         // Once STBY_CR_ENABLE_INIT is non-zero, the RTL locks DCR read-only.
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom-i3c] Setting main target DCR to {:02x}",
-            dcr
-        );
+        caliptra_mcu_romtime::println!("[mcu-rom-i3c] Setting main target DCR to {:02x}", dcr);
         regs.stdby_ctrl_mode_stby_cr_device_char
             .modify(StbyCrDeviceChar::Dcr.val(dcr as u32));
 

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -39,7 +39,7 @@ pub use rom::*;
 mod rom_env;
 pub use rom_env::*;
 mod i3c;
-pub use i3c::{I3cConfig, I3cTimings};
+pub use i3c::{I3cConfig, I3cTimings, MCTP_DCR};
 mod i3c_mailbox;
 pub use i3c_mailbox::{DotContext, I3cMailboxHandler};
 mod mailbox;

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -22,6 +22,7 @@ mod test_external_otp;
 mod test_firmware_update;
 mod test_fpga_flash_ctrl;
 mod test_i3c_constant_writes;
+mod test_i3c_dcr;
 mod test_i3c_simple;
 mod test_log_flash_usermode;
 mod test_mctp_capsule_loopback;

--- a/tests/integration/src/test_i3c_dcr.rs
+++ b/tests/integration/src/test_i3c_dcr.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_mcu_hw_model::{McuHwModel, McuManager};
+    use caliptra_mcu_rom_common::MCTP_DCR;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_rom_programs_main_i3c_target_mctp_dcr() {
+        let lock = TEST_LOCK.lock().unwrap();
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_only: true,
+            ..Default::default()
+        });
+
+        hw.step_until_output_contains("[mcu-rom-i3c] Enable the target transaction interface")
+            .expect("ROM did not finish configuring the main I3C target DCR");
+        assert_eq!(hw.mci_fw_fatal_error(), None, "ROM hit fatal error");
+
+        let mut mcu = hw.mcu_manager();
+        let i3c = mcu.i3c();
+        assert_eq!(
+            i3c.stdby_ctrl_mode().stby_cr_device_char().read().dcr(),
+            u32::from(MCTP_DCR),
+            "main I3C target must advertise the MCTP DCR"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
Program the DCR before enabling the standby controller, which makes the
register read-only. Add a ROM-only integration test for the main target.

This addresses #1755