### PR TITLE
docs: address VDM command follow-ups

### DIFF
--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -26,7 +26,7 @@ The following table describes the commands defined under this specification. The
 | Device Capabilities             | R   | MCTP VDM, MCI Mailbox | Retrieve device capabilities.                                                                                                        |
 | Get Debug Log                   | R   | MCTP VDM, MCI Mailbox | Retrieve debug log.                                                                                                                  |
 | Clear Debug Log                 | R   | MCTP VDM, MCI Mailbox | Clear debug log.                                                                                                                     |
-| Get Attestation                 | O   | SPDM VDM, MCI Mailbox | Retrieve attestation evidence.                                                                                                       |
+| Get Attestation                 | O   | SPDM VDM              | Retrieve attestation evidence. MCI Mailbox support is TBD.                                                                           |
 | Request Debug Unlock            | O   | SPDM VDM, MCI Mailbox | Request debug unlock in production environment.                                                                                      |
 | Authorize Debug Unlock Token    | O   | SPDM VDM, MCI Mailbox | Send debug unlock token to device for authorization.                                                                                 |
 | Export Attested CSR             | O   | SPDM VDM, MCI Mailbox | Export attested CSR for a Caliptra device identity key (LDevID, FMC Alias, or RT Alias).                                             |
@@ -65,9 +65,9 @@ Retrieves the version of the target firmware.
 
 **Response Payload**:
 
-| Byte(s) | Name            | Type   | Description                             |
-| ------- | --------------- | ------ | --------------------------------------- |
-| 0:31    | version         | u8[32] | Firmware Version Number in ASCII format |
+| Byte(s) | Name    | Type   | Description                             |
+| ------- | ------- | ------ | --------------------------------------- |
+| 0:31    | version | u8[32] | Firmware Version Number in ASCII format |
 
 ### Device Capabilities
 
@@ -75,9 +75,9 @@ Retrieves the version of the target firmware.
 
 **Response Payload**:
 
-| Byte(s) | Name            | Type   | Description                                                                                                                                                                                                                                                                    |
-| ------- | --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 0:31    | caps            | u8[32] | Device Capabilities: <br>- Bytes [0:7]: Reserved for Caliptra RT <br>- Bytes [8:11]: Reserved for Caliptra FMC <br>- Bytes [12:15]: Reserved for Caliptra ROM <br>- Bytes [16:23]: Reserved for MCU RT <br>- Bytes [24:27]: Reserved for MCU ROM <br>- Bytes [28:31]: Reserved |
+| Byte(s) | Name | Type   | Description                                                                                                                                                                                                                                                                    |
+| ------- | ---- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 0:31    | caps | u8[32] | Device Capabilities: <br>- Bytes [0:7]: Reserved for Caliptra RT <br>- Bytes [8:11]: Reserved for Caliptra FMC <br>- Bytes [12:15]: Reserved for Caliptra ROM <br>- Bytes [16:23]: Reserved for MCU RT <br>- Bytes [24:27]: Reserved for MCU ROM <br>- Bytes [28:31]: Reserved |
 
 ### Get Debug Log
 
@@ -87,11 +87,11 @@ Retrieves the debug log for the MCU Runtime.
 
 **Response Payload**:
 
-| Byte(s) | Name            | Type          | Description                         |
-| ------- | --------------- | ------------- | ----------------------------------- |
-| 0:3     | more_data       | u32           | `1` if more log data remains        |
-| 4:7     | data_size       | u32           | Size of the valid log data in bytes |
-| 8:N     | data            | u8[data_size] | Debug log contents                  |
+| Byte(s) | Name      | Type          | Description                         |
+| ------- | --------- | ------------- | ----------------------------------- |
+| 0:3     | more_data | u32           | `1` if more log data remains        |
+| 4:7     | data_size | u32           | Size of the valid log data in bytes |
+| 8:N     | data      | u8[data_size] | Debug log contents                  |
 
 For defmt-based debug logs, the device exposes a sequential drain interface rather than random access to individual log entries. Callers drain the debug log by repeating this command until `more_data` is `0`. Each response contains zero or more complete defmt frames. The host concatenates the returned data and decodes the resulting frame stream using the matching firmware ELF.
 
@@ -111,7 +111,7 @@ Clears the debug log in the MCU Runtime. No authorization is required.
 
 ### Get Attestation
 
-Retrieves attestation evidence. This command is assigned to SPDM VDM IANA. The payload format is TBD.
+Retrieves attestation evidence. This command is assigned to SPDM VDM IANA. MCI Mailbox support and the payload format are TBD.
 
 **Request Payload**: TBD
 
@@ -172,10 +172,10 @@ Exports an attested Certificate Signing Request (CSR) for a specified device key
 
 **Response Payload**:
 
-| Byte(s) | Name            | Type          | Description                              |
-| ------- | --------------- | ------------- | ---------------------------------------- |
-| 0:3     | data_size       | u32           | Length in bytes of the attested CSR data |
-| 4:N     | data            | u8[data_size] | Attested CSR data blob                   |
+| Byte(s) | Name      | Type          | Description                              |
+| ------- | --------- | ------------- | ---------------------------------------- |
+| 0:3     | data_size | u32           | Length in bytes of the attested CSR data |
+| 4:N     | data      | u8[data_size] | Attested CSR data blob                   |
 
 ### Authorization-Gated Subcommand Wrapper
 

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -89,14 +89,14 @@ R = Required, O = Optional
 
 ## Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. `AuthorizedCommand` does not define the authorization mechanism by itself. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. Only subcommands marked Supported are currently dispatched; requests for Planned subcommands return `InvalidParameter`. `AuthorizedCommand` does not define the authorization mechanism by itself. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately.
 
-| Subcommand ID          | Name                       | Description                                        |
-| ---------------------- | -------------------------- | -------------------------------------------------- |
-| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Challenge acquisition for authorization-gated use. |
-| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Provision vendor public key hash.                  |
-| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Increase Caliptra minimum SVN.                     |
-| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Program field entropy.                             |
-| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Revoke vendor public key.                          |
-| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Revoke vendor public key hash.                     |
-| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Lock fuse partition.                               |
+| Subcommand ID          | Name                       | Status        | Description                                        |
+| ---------------------- | -------------------------- | ------------- | -------------------------------------------------- |
+| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Supported     | Challenge acquisition for authorization-gated use. |
+| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Planned (TBD) | Provision vendor public key hash.                  |
+| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Planned (TBD) | Increase Caliptra minimum SVN.                     |
+| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Supported     | Program field entropy.                             |
+| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Planned (TBD) | Revoke vendor public key.                          |
+| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Planned (TBD) | Revoke vendor public key hash.                     |
+| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Planned (TBD) | Lock fuse partition.                               |

--- a/docs/src/unified_caliptra_command_handling.md
+++ b/docs/src/unified_caliptra_command_handling.md
@@ -16,7 +16,7 @@ The Caliptra MCU firmware provides three external command interfaces: [MCTP VDM 
 | Authorize Debug Unlock Token | SPDM VDM          | MC_PROD_DEBUG_UNLOCK_TOKEN | Sends the debug unlock token for authorization.    |
 | Export Attested CSR          | SPDM VDM          | MC_EXPORT_ATTESTED_CSR     | Exports attested CSR for a specified device key.   |
 
-To ensure consistent command behavior and maximize code reuse, we define a protocol-agnostic command handler trait (`CaliptraCmdHandler`) with unified input/output types in the `caliptra-mcu-common-commands` crate. Both protocol frontends parse their respective protocol, then call the same backend handler, ensuring code reuse and consistent behavior.
+To ensure consistent command behavior and maximize code reuse, we define a protocol-agnostic command handler trait (`CaliptraCmdHandler`) with unified input/output types in the `caliptra-mcu-common-commands` crate. All protocol frontends parse their respective protocol, then call the same backend handler, ensuring code reuse and consistent behavior.
 
 - **Architecture**
 ```mermaid

--- a/docs/src/unified_caliptra_command_handling.md
+++ b/docs/src/unified_caliptra_command_handling.md
@@ -1,22 +1,20 @@
 ## Unified Handling of External Commands
 
-The Caliptra MCU firmware provides two external command interfaces: [SPDM VDM over MCTP (out-of-band)](caliptra_spdm_vdm_cmds.md) and [MCI Mailbox (in-band)](external_mailbox_cmds.md). Although these interfaces operate over different protocols, they deliver overlapping functionality to external clients.
+The Caliptra MCU firmware provides three external command interfaces: [MCTP VDM (out-of-band)](external_mctp_vdm_cmds.md), [SPDM VDM over MCTP (out-of-band)](caliptra_spdm_vdm_cmds.md), and [MCI Mailbox (in-band)](external_mailbox_cmds.md). Although these interfaces operate over different protocols, they deliver overlapping functionality to external clients.
 
 <span style="font-size: 0.9em;">
-<em>Table: Overlapping commands between SPDM VDM (OOB) and MCI Mailbox (IB)</em>
+<em>Table: Overlapping commands between VDM transports (OOB) and MCI Mailbox (IB)</em>
 </span>
 
-| **SPDM VDM Command**         | **MCI Mailbox Command**          | **Description**                                    |
-| ---------------------------- | -------------------------------- | -------------------------------------------------- |
-| Firmware Version             | MC_FIRMWARE_VERSION              | Retrieves the version of the firmware.             |
-| Device Capabilities          | MC_DEVICE_CAPABILITIES           | Retrieves device capabilities.                     |
-| Export CSR                   | MC_EXPORT_IDEV_CSR               | Exports the IDEVID CSR.                            |
-| Import Certificate           | MC_IMPORT_IDEV_CERT              | Imports the IDevID certificate.                    |
-| Get Log                      | MC_GET_LOG                       | Retrieves the internal log.                        |
-| Clear Log                    | MC_CLEAR_LOG                     | Clears the log in the RoT subsystem.               |
-| Request Debug Unlock         | MC_PRODUCTION_DEBUG_UNLOCK_REQ   | Requests debug unlock in a production environment. |
-| Authorize Debug Unlock Token | MC_PRODUCTION_DEBUG_UNLOCK_TOKEN | Sends the debug unlock token for authorization.    |
-| Export Attested CSR          | MC_EXPORT_ATTESTED_CSR           | Exports attested CSR for a specified device key.   |
+| **Common Command**           | **OOB Transport** | **MCI Mailbox Command**    | **Description**                                    |
+| ---------------------------- | ----------------- | -------------------------- | -------------------------------------------------- |
+| Firmware Version             | MCTP VDM          | MC_FIRMWARE_VERSION        | Retrieves the version of the firmware.             |
+| Device Capabilities          | MCTP VDM          | MC_DEVICE_CAPABILITIES     | Retrieves device capabilities.                     |
+| Get Debug Log                | MCTP VDM          | MC_GET_LOG                 | Retrieves the MCU Runtime debug log.               |
+| Clear Debug Log              | MCTP VDM          | MC_CLEAR_LOG               | Clears the MCU Runtime debug log.                  |
+| Request Debug Unlock         | SPDM VDM          | MC_PROD_DEBUG_UNLOCK_REQ   | Requests debug unlock in a production environment. |
+| Authorize Debug Unlock Token | SPDM VDM          | MC_PROD_DEBUG_UNLOCK_TOKEN | Sends the debug unlock token for authorization.    |
+| Export Attested CSR          | SPDM VDM          | MC_EXPORT_ATTESTED_CSR     | Exports attested CSR for a specified device key.   |
 
 To ensure consistent command behavior and maximize code reuse, we define a protocol-agnostic command handler trait (`CaliptraCmdHandler`) with unified input/output types in the `caliptra-mcu-common-commands` crate. Both protocol frontends parse their respective protocol, then call the same backend handler, ensuring code reuse and consistent behavior.
 


### PR DESCRIPTION
Follow-up to #1661 addressing the three remaining review comments.

- Mark unsupported SPDM authorization-gated subcommands as planned/TBD.
- Document Get Attestation as SPDM VDM only, with MCI Mailbox support TBD.
- Refresh the unified command inventory with current MCTP/SPDM assignments and mailbox command names.
