### PR TITLE
[build]: Make sure that cargo nextest list always works from root

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,7 +11,6 @@ store-success-output = false
 store-failure-output = true
 
 [profile.nightly-emulator]
-store-success-output = false
 failure-output = "immediate-final"
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 30 }

--- a/network/app/example/Cargo.toml
+++ b/network/app/example/Cargo.toml
@@ -9,6 +9,7 @@ description = "DHCP + TFTP boot example application using lwip-rs"
 [[bin]]
 name = "caliptra-mcu-lwip-rs-example"
 path = "src/main.rs"
+test = false
 
 [dependencies]
 caliptra-mcu-lwip-rs.workspace = true

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-rom-emulator"
+test = false
+
+
 [build-dependencies]
 caliptra-mcu-builder.workspace = true
 caliptra-mcu-config-emulator.workspace = true

--- a/platforms/emulator/runtime/Cargo.toml
+++ b/platforms/emulator/runtime/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-runtime-emulator"
+test = false
+
+
 [dependencies]
 arrayvec.workspace = true
 capsules-core.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-example-app"
+test = false
+
+
 [dependencies]
 async-trait.workspace = true
 caliptra-api.workspace = true

--- a/platforms/fpga/rom/Cargo.toml
+++ b/platforms/fpga/rom/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-rom-fpga"
+test = false
+
+
 [build-dependencies]
 caliptra-mcu-builder.workspace = true
 caliptra-mcu-config-fpga.workspace = true

--- a/platforms/fpga/runtime/Cargo.toml
+++ b/platforms/fpga/runtime/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-runtime-fpga"
+test = false
+
+
 [dependencies]
 arrayvec.workspace = true
 capsules-core.workspace = true

--- a/provisioning/test-unlocked-fw/Cargo.toml
+++ b/provisioning/test-unlocked-fw/Cargo.toml
@@ -6,6 +6,11 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "caliptra-mcu-provisioning-test-unlocked-fw"
+test = false
+
+
 [dependencies]
 caliptra-mcu-bare-metal-io.workspace = true
 caliptra-mcu-romtime.workspace = true

--- a/provisioning/test-unlocked-fw/src/main.rs
+++ b/provisioning/test-unlocked-fw/src/main.rs
@@ -66,4 +66,6 @@ mod riscv {
 
 #[cfg(not(target_arch = "riscv32"))]
 #[no_mangle]
-pub extern "C" fn main() {}
+pub extern "C" fn main() {
+    println!("nop");
+}

--- a/tests/hello/Cargo.toml
+++ b/tests/hello/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 [[bin]]
 name = "hello"
 path = "src/hello.rs"
+test = false

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -11,6 +11,7 @@ pub(crate) fn precheckin(rom_variants: &[RomVariant]) -> Result<()> {
     crate::deps::check()?;
     crate::docs::check_docs()?;
     crate::registers::autogen(true, &[], &[], None, None)?;
+    crate::test::nextest_list()?;
 
     // Default `devel` profile: 1 MB SRAM, no `release` feature, all debug
     // components present.  Catches code that the dev-time build would actually

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -135,6 +135,20 @@ fn cargo_test_archive(archive_file: &str) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn nextest_list() -> Result<()> {
+    println!("Running: cargo nextest list");
+    let status = Command::new("cargo")
+        .current_dir(&*PROJECT_ROOT)
+        .args(["nextest", "list"])
+        .status()?;
+
+    if !status.success() {
+        bail!("cargo nextest list failed");
+    }
+
+    Ok(())
+}
+
 pub(crate) fn e2e_tests() -> Result<()> {
     println!("Running: e2e tests");
 


### PR DESCRIPTION
It's annoying when this is broken.

Enforced by xtask.