### PR TITLE
update caliptra-sw reference

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -115,6 +115,7 @@ not (
     test(test_firmware_update_flash_invalid_mcu_image) |
     test(test_firmware_update_flash_invalid_manifest) |
     test(test_header_burns_caliptra_runtime_svn) |
-    test(test_mctp_user_loopback)
+    test(test_mctp_user_loopback) |
+    test(test_defmt_logging_release)
 )
 """

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "bitflags 2.13.0",
  "caliptra-api-types",
@@ -399,7 +419,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -407,7 +427,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -423,7 +443,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
@@ -453,7 +473,7 @@ dependencies = [
  "google-cloud-wkt",
  "hex",
  "idna_adapter",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_with",
  "sha2",
@@ -466,7 +486,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -480,12 +500,14 @@ dependencies = [
  "hex",
  "memoffset 0.8.0",
  "once_cell",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2",
  "toml 0.7.8",
  "zerocopy",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -539,7 +561,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a10
 [[package]]
 name = "caliptra-common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
@@ -563,7 +585,7 @@ dependencies = [
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -581,7 +603,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -632,7 +654,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -658,7 +680,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-emu-types",
  "caliptra-ureg",
@@ -668,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -682,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -698,7 +720,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -709,7 +731,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "aes",
  "arrayref",
@@ -738,17 +760,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-common",
 ]
@@ -756,7 +778,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -764,6 +786,7 @@ dependencies = [
  "bitflags 2.13.0",
  "caliptra-api",
  "caliptra-api-types",
+ "caliptra-builder",
  "caliptra-coverage",
  "caliptra-emu-bus",
  "caliptra-emu-cpu",
@@ -774,6 +797,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-registers",
  "caliptra-ureg",
+ "deser-hjson",
  "libc",
  "nix 0.26.4",
  "once_cell",
@@ -794,7 +818,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -803,7 +827,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -823,7 +847,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -834,7 +858,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -845,7 +869,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -862,7 +886,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -878,7 +902,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "bitflags 2.13.0",
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -893,7 +917,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -905,7 +929,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -975,7 +999,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "zerocopy",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -2624,13 +2648,13 @@ dependencies = [
  "uuid",
  "walkdir",
  "zerocopy",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
 name = "caliptra-ocp-eat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "arrayvec",
 ]
@@ -2638,20 +2662,29 @@ dependencies = [
 [[package]]
 name = "caliptra-okref"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-registers-latest",
+ "caliptra-registers-rev-2-1",
 ]
 
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
+dependencies = [
+ "caliptra-ureg",
+]
+
+[[package]]
+name = "caliptra-registers-rev-2-1"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -2659,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -2695,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2739,12 +2772,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 
 [[package]]
 name = "caliptra-util-host-commands"
@@ -2778,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a29882e210df17021240837f47d15d57c5ce5ffd#a29882e210df17021240837f47d15d57c5ce5ffd"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1a674e6821220355d2f3ee06a986f96525331256#1a674e6821220355d2f3ee06a986f96525331256"
 dependencies = [
  "zeroize",
 ]
@@ -3181,6 +3214,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -3602,6 +3641,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "deser-hjson"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d49a923edd92dc1ca5819822f540ea83f094ab5ac6940e4044e03c1d8e6576"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4213,7 +4261,7 @@ dependencies = [
  "hmac",
  "http",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.13.4",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -4269,7 +4317,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-types",
- "reqwest",
+ "reqwest 0.13.4",
  "rustc_version",
  "serde",
  "serde_json",
@@ -4686,6 +4734,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5511,6 +5560,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,6 +5581,18 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "peg"
@@ -6012,6 +6084,46 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -6485,6 +6597,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7700,6 +7823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8146,6 +8278,26 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -8181,4 +8333,33 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,32 +355,32 @@ caliptra-mcu-libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 caliptra-mcu-tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 
 # caliptra-sw dependencies
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
 caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "767d4ef59a106aea683b883c07bd65456fb3ba", default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "767d4ef59a106aea683b883c07bd65456fb3ba"}
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", features = ["ocp-lock"] }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", default-features = false }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", features = ["cfi"] }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
-caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd", default-features = false }
-caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a29882e210df17021240837f47d15d57c5ce5ffd" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", features = ["ocp-lock"] }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", default-features = false }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", features = ["cfi"] }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
+caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256", default-features = false }
+caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1a674e6821220355d2f3ee06a986f96525331256" }
 
 # caliptra-dpe dependencies; keep git revs in sync with version pulled into caliptra-sw
 dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false, features = ["p384"] }

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_builder::FwId;
+use caliptra_builder::{FirmwareType, FwId};
 
 pub mod hw_model_tests {
     use super::*;
@@ -8,61 +8,61 @@ pub mod hw_model_tests {
     pub const MAILBOX_RESPONDER: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-mailbox-responder",
         bin_name: "caliptra-mcu-test-fw-mailbox-responder",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const HITLESS_UPDATE_FLOW: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-hitless-update-flow",
         bin_name: "caliptra-mcu-test-fw-hitless-update-flow",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const AXI_BYPASS: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-axi-bypass",
         bin_name: "caliptra-mcu-test-fw-axi-bypass",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const EXCEPTION_HANDLER: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-exception-handler",
         bin_name: "caliptra-mcu-test-fw-exception-handler",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const USB_RESPONDER: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-usb-responder",
         bin_name: "caliptra-mcu-test-fw-usb-responder",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const USB_OCP_RECOVERY: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-usb-ocp-recovery",
         bin_name: "caliptra-mcu-test-fw-usb-ocp-recovery",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const SW_DIGEST_LOCK: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-sw-digest-lock",
         bin_name: "caliptra-mcu-test-fw-sw-digest-lock",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const OTP_BLANK_CHECK: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-otp-blank-check",
         bin_name: "caliptra-mcu-test-fw-otp-blank-check",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const OTP_SCRAMBLE_CHECK: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-otp-scramble-check",
         bin_name: "caliptra-mcu-test-fw-otp-scramble-check",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const LC_CTRL: FwId = FwId {
         crate_name: "caliptra-mcu-test-fw-lc-ctrl",
         bin_name: "caliptra-mcu-test-fw-lc-ctrl",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 }
 

--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -133,7 +133,7 @@ pub fn test_rom_build(args: &crate::CaliptraBuildArgs) -> Result<String> {
     let platform_bin = format!("mcu-test-rom-{}-{}.bin", fwid.crate_name, fwid.bin_name);
     let rom_binary = common.release_dir().map(|t| t.join(&platform_bin))?;
 
-    let mut features = fwid.features.to_vec();
+    let mut features = fwid.features().to_vec();
     if !features.contains(&"riscv") {
         features.push("riscv");
     }

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -252,9 +252,6 @@ pub struct InitParams<'a> {
     /// When true, set secrets_valid so DOE reads UDS/FE from strap registers
     /// for deterministic IDevID on FPGA (needed for attestation tests).
     pub use_strap_secrets: bool,
-
-    /// When true, do not provision default LC tokens or other fuses.
-    pub skip_otp_provisioning: bool,
 }
 
 impl InitParams<'_> {
@@ -336,7 +333,6 @@ impl Default for InitParams<'_> {
             active_i3c1: false,
             vendor_test_partition: None,
             use_strap_secrets: false,
-            skip_otp_provisioning: false,
         }
     }
 }

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -453,6 +453,7 @@ impl McuHwModel for ModelFpgaRealtime {
             uds_fuse_row_granularity_64: !params.uds_granularity_32,
             otp_dai_idle_bit_offset: params.otp_dai_idle_bit_offset,
             otp_direct_access_cmd_reg_offset: params.otp_direct_access_cmd_reg_offset,
+            otp_status_reg_offset: 0x10,
             prod_dbg_unlock_keypairs: params.prod_dbg_unlock_keypairs,
             debug_intent: params.debug_intent,
             bootfsm_break: params.bootfsm_break,
@@ -479,7 +480,6 @@ impl McuHwModel for ModelFpgaRealtime {
                     .lifecycle_controller_state
                     .map(|s| caliptra_hw_model::LifecycleControllerState::from(u8::from(s))),
                 use_strap_secrets: params.use_strap_secrets,
-                skip_otp_provisioning: params.skip_otp_provisioning,
                 ..Default::default()
             },
         };

--- a/tests/integration/src/jtag/test_provisioning.rs
+++ b/tests/integration/src/jtag/test_provisioning.rs
@@ -24,7 +24,6 @@ mod test {
             debug_intent: true,
             bootfsm_break: false,
             enable_mcu_uart_log: true,
-            skip_otp_provisioning: true,
             ..Default::default()
         };
 


### PR DESCRIPTION
pulls in several changes. Of particular interest to provisioning is a change that allows specfication of a particular lifecycle target for test OTP provisioning, but also contains some builder fixes that correspond to https://github.com/chipsalliance/caliptra-sw/pull/3999