### PR TITLE
[ci]: Prebuild xtask to speed up CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,8 +15,41 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  build-xtask:
+    runs-on: e2-standard-4
+    timeout-minutes: 30
+
+    env:
+      CARGO_INCREMENTAL: 0
+      EXTRA_CARGO_CONFIG: 'target.''cfg(all())''.rustflags = ["-Dwarnings"]'
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install required packages
+        run: |
+          sudo apt-get update -qy && \
+          sudo apt-get install -qy build-essential curl git libclang-dev && \
+          rustup toolchain install -c clippy,rust-src,llvm-tools,rustfmt,rustc-dev
+
+      - name: Prebuild xtask
+        run: |
+          cargo build --package caliptra-mcu-xtask --features parallel-build
+          cp target/debug/caliptra-mcu-xtask /tmp/xtask
+
+      - name: Upload xtask binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/xtask
+          retention-days: 1
+
   precheckin:
-    runs-on: ubuntu-latest
+    runs-on: e2-standard-8
+    needs: [build-xtask]
     timeout-minutes: 30
 
     env:
@@ -39,11 +72,25 @@ jobs:
           sudo apt-get install -qy build-essential curl git && \
           rustup toolchain install -c clippy,rust-src,llvm-tools,rustfmt,rustc-dev
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
+      - name: Install cargo-nextest (prebuilt binary)
+        run: |
+          curl -LsSf https://get.nexte.st/0.9.118/linux | tar zxf - -C ~/.cargo/bin
+
       - name: Run precheckin
-        run: cargo xtask precheckin
+        run: /tmp/xtask precheckin
 
   build-firmware:
     runs-on: e2-standard-16-big-disk
+    needs: [build-xtask]
     timeout-minutes: 90
 
     env:
@@ -94,13 +141,22 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
       - name: Build ROM and runtime binaries
         run: |
           # Build all test runtime features used by integration tests
           # Note: nightly tests (test-*-spdm-*, test-caliptra-util-host-validator) are excluded
           # Note: parallel-build is disabled because it creates separate target dirs
           # per build, which exhausts disk space on the e2-standard-8 runner.
-          cargo run -p caliptra-mcu-xtask -- all-build --platform emulator \
+          /tmp/xtask all-build --platform emulator \
             --rom-features "hw-2-1" \
             --test-rom-features "ocp-lock,stable-owner-key" \
             --separate-runtimes
@@ -108,7 +164,7 @@ jobs:
 
       - name: Build release ROM and runtime binaries
         run: |
-          cargo run -p caliptra-mcu-xtask --features parallel-build -- all-build \
+          /tmp/xtask all-build \
             --platform emulator --separate-runtimes \
             --profile release
           sccache --show-stats
@@ -129,6 +185,7 @@ jobs:
 
   build-emulator:
     runs-on: e2-standard-16
+    needs: [build-xtask]
     timeout-minutes: 60
 
     env:
@@ -179,10 +236,19 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
       - name: Build emulator binary
         run: |
           # Build a single emulator that supports all test features via runtime flags
-          cargo xtask emulator-build
+          /tmp/xtask emulator-build
           sccache --show-stats
 
       - name: Upload emulator bundle
@@ -194,6 +260,7 @@ jobs:
 
   build-tests:
     runs-on: e2-standard-8
+    needs: [build-xtask]
     timeout-minutes: 60
 
     env:
@@ -252,9 +319,18 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
       - name: Build test archive
         run: |
-          cargo --config "$EXTRA_CARGO_CONFIG" xtask test-archive \
+          /tmp/xtask test-archive \
             --archive /tmp/nextest-archive.tar.zst
           sccache --show-stats
 
@@ -267,7 +343,7 @@ jobs:
 
   test_emulator:
     runs-on: e2-standard-4
-    needs: [precheckin, build-firmware, build-emulator, build-tests]
+    needs: [precheckin, build-firmware, build-emulator, build-tests, build-xtask]
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -295,9 +371,18 @@ jobs:
         run: |
           curl -LsSf https://get.nexte.st/0.9.118/linux | tar zxf - -C ~/.cargo/bin
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
       - name: Setup TAP interface for network tests
         run: |
-          cargo xtask network tap setup
+          /tmp/xtask network tap setup
 
       - name: Download firmware bundle
         uses: actions/download-artifact@v4
@@ -330,7 +415,7 @@ jobs:
       #   cargo xtask test --firmware-bundle target/all-fw.zip --emulator-bundle target/emulators.zip
       - name: Run tests (shard ${{ matrix.shard }}/4)
         run: |
-          cargo --config "$EXTRA_CARGO_CONFIG" xtask test \
+          /tmp/xtask test \
             --archive /tmp/nextest-archive.tar.zst \
             --shard hash:${{ matrix.shard }}/4 \
             --firmware-bundle "${PWD}/target/all-fw.zip" \
@@ -346,7 +431,7 @@ jobs:
       - name: Run release tests
         if: matrix.shard == 1
         run: |
-          cargo --config "$EXTRA_CARGO_CONFIG" xtask test \
+          /tmp/xtask test \
             --archive /tmp/nextest-archive.tar.zst \
             --firmware-bundle "${PWD}/target/all-fw-release.zip" \
             --emulator-bundle "${PWD}/target/emulators.zip" \
@@ -398,7 +483,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs: [precheckin, build-firmware, build-emulator, build-tests]
+    needs: [precheckin, build-firmware, build-emulator, build-tests, build-xtask]
 
     env:
       CARGO_INCREMENTAL: 0
@@ -419,6 +504,15 @@ jobs:
         run: |
           curl -LsSf https://get.nexte.st/0.9.118/linux | tar zxf - -C ~/.cargo/bin
 
+      - name: Download xtask binary
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask-binary
+          path: /tmp/
+
+      - name: Make xtask executable
+        run: chmod +x /tmp/xtask
+
       - name: Download firmware bundle
         uses: actions/download-artifact@v4
         with:
@@ -438,7 +532,7 @@ jobs:
           path: /tmp/
 
       - name: Build ROM ELF for coverage analysis
-        run: cargo xtask rom-build
+        run: /tmp/xtask rom-build
 
       - name: Run tests with coverage collection
         run: |
@@ -454,7 +548,7 @@ jobs:
 
       - name: Analyze coverage
         run: |
-          MCU_COVERAGE_PATH=/tmp/mcu-coverage cargo xtask coverage --analyze-only 2>&1 | tee /tmp/coverage-results.txt
+          MCU_COVERAGE_PATH=/tmp/mcu-coverage /tmp/xtask coverage --analyze-only 2>&1 | tee /tmp/coverage-results.txt
           echo '## Code Coverage' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Image | Metric | Value |' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Each step uses xtask and spends a lot of time building it. Pre-building it before running subsequent steps will save some wall clock time in the CI.