### PR TITLE
[refactor]: Define firmware binaries as hard coded constants

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -1,7 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{bail, Result};
-use caliptra_builder::FwId;
 use caliptra_image_types::ImageManifest;
 use caliptra_mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
 use caliptra_mcu_config_emulator::flash::{
@@ -55,58 +54,6 @@ cfg_if::cfg_if! {
         fn maybe_into_par_iter<T: 'static>(v: Vec<T>) -> impl Iterator<Item = T> { v.into_iter() }
     }
 }
-
-/// Features that require the example app to be included
-/// These are determined by which tests use `run_test!(test_name, example_app)` in tests/integration/src/lib.rs
-const FEATURES_WITH_EXAMPLE_APP: &[&str] = &[
-    "test-caliptra-certs",
-    "test-caliptra-crypto",
-    "test-caliptra-mailbox",
-    "test-dma",
-    "test-doe-discovery",
-    "test-doe-transport-loopback",
-    "test-doe-user-loopback",
-    "test-external-otp",
-    "test-firmware-v2",
-    "test-dpe-handle-store",
-    "test-sw-pcr-store",
-    "test-flash-usermode",
-    "test-fpga-flash-ctrl",
-    "test-get-device-state",
-    "test-log-flash-usermode",
-    "test-mbox-sram",
-    "test-mci",
-    "test-mctp-user-loopback",
-    "test-mcu-mbox-soc-requester-loopback",
-    "test-mcu-mbox-usermode",
-    "test-ocp-lock",
-    "test-warm-reset",
-];
-
-/// Features that require SoC images to be included in the flash image
-const FEATURES_REQUIRING_SOC_IMAGES: &[&str] = &[
-    "test-flash-based-boot",
-    "test-pldm-streaming-boot",
-    "test-firmware-activate",
-    "test-firmware-update-flash",
-    "test-firmware-update-streaming",
-    "test-streaming-boot-flash-write-back",
-    "test-mctp-spdm-attestation",
-    "test-mctp-spdm-attestation-pcr-quote",
-];
-
-/// Features that require flash-based boot (partition table at offset 0)
-const FEATURES_REQUIRING_FLASH_BOOT: &[&str] =
-    &["test-flash-based-boot", "test-firmware-update-flash"];
-
-/// Runtime features whose corresponding ROM feature enables `hw-2-1`.
-/// Keep the runtime in sync so large Caliptra mailbox commands use staging SRAM.
-const FEATURES_REQUIRING_HW_2_1_RUNTIME: &[&str] = &[
-    "test-flash-based-boot",
-    "test-firmware-activate",
-    "test-firmware-update-flash",
-    "test-usb-ocp-recovery",
-];
 
 /// MCI base address for SoC image load addresses.
 /// Uses FPGA memory map since the emulator's AXI simulation uses FPGA-like addresses.
@@ -240,59 +187,282 @@ fn pre_generate_attestation_manifest_config(
     )
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct CaliptraRomBinary(pub Vec<u8>);
+
+impl std::ops::Deref for CaliptraRomBinary {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for CaliptraRomBinary {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CaliptraRtBinary(pub Vec<u8>);
+
+impl std::ops::Deref for CaliptraRtBinary {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for CaliptraRtBinary {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct McuRomBinary(pub Vec<u8>);
+
+impl std::ops::Deref for McuRomBinary {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for McuRomBinary {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SocManifestBinary(pub Vec<u8>);
+
+impl std::ops::Deref for SocManifestBinary {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for SocManifestBinary {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct McuFwBinary {
+    pub bytes: Vec<u8>,
+    pub flash_image: Vec<u8>,
+    pub pldm_fw_pkg: Vec<u8>,
+    pub update_flash_image: Vec<u8>,
+    pub user_app_elf: Option<Vec<u8>>,
+}
+
+impl std::ops::Deref for McuFwBinary {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
+}
+
+impl AsRef<[u8]> for McuFwBinary {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FirmwareBundle {
+    pub caliptra_rom: CaliptraRomBinary,
+    pub caliptra_rt: CaliptraRtBinary,
+    pub mcu_rom: McuRomBinary,
+    pub mcu_fw: McuFwBinary,
+    pub soc_manifest: SocManifestBinary,
+}
+
+impl FirmwareBundle {
+    pub fn new(target: &crate::firmware::FirmwareTarget) -> Result<&'static Self> {
+        let binaries = FirmwareBinaries::from_env()?;
+        binaries.get(target)
+    }
+}
+
 #[derive(Default)]
 pub struct FirmwareBinaries {
-    pub caliptra_rom: Vec<u8>,
-    pub caliptra_fw: Vec<u8>,
-    pub caliptra_fw_svn7: Vec<u8>,
-    pub caliptra_fw_svn128: Vec<u8>,
-    pub caliptra_fw_key2: Vec<u8>,
-    pub caliptra_fw_ocp_lock: Vec<u8>,
-    pub mcu_rom: Vec<u8>,
-    pub mcu_runtime: Vec<u8>,
-    pub soc_manifest: Vec<u8>,
-    pub test_roms: Vec<(String, Vec<u8>)>,
-    pub caliptra_test_roms: Vec<(String, Vec<u8>)>,
-    pub test_soc_manifests: Vec<(String, Vec<u8>)>,
-    pub test_runtimes: Vec<(String, Vec<u8>)>,
-    pub test_pldm_fw_pkgs: Vec<(String, Vec<u8>)>,
-    pub test_flash_images: Vec<(String, Vec<u8>)>,
-    /// Update flash images without partition table (for PLDM update packages)
-    pub test_update_flash_images: Vec<(String, Vec<u8>)>,
-    pub bare_metal_images: Vec<(String, Vec<u8>)>,
-    /// User-app ELFs. Carry the `.defmt` table that host-side defmt decoders
-    /// need to render frames retrieved from the device.
-    pub test_user_app_elfs: Vec<(String, Vec<u8>)>,
+    pub bundles: std::sync::RwLock<
+        std::collections::HashMap<crate::firmware::FirmwareTarget, &'static FirmwareBundle>,
+    >,
 }
 
 impl FirmwareBinaries {
-    const CALIPTRA_ROM_NAME: &'static str = "caliptra_rom.bin";
-    const CALIPTRA_FW_NAME: &'static str = "caliptra_fw.bin";
-    const CALIPTRA_FW_SVN7_NAME: &'static str = "caliptra_fw_svn7.bin";
-    const CALIPTRA_FW_SVN128_NAME: &'static str = "caliptra_fw_svn128.bin";
-    const CALIPTRA_FW_KEY2_NAME: &'static str = "caliptra_fw_key2.bin";
-    const CALIPTRA_FW_OCP_LOCK_NAME: &'static str = "caliptra_fw_ocp_lock.bin";
-    const MCU_ROM_NAME: &'static str = "mcu_rom.bin";
-    const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
-    const USER_APP_ELF_NAME: &'static str = "user_app_elf.bin";
-    const SOC_MANIFEST_NAME: &'static str = "soc_manifest.bin";
-    const FLASH_IMAGE_NAME: &'static str = "flash_image.bin";
-    const PLDM_FW_PKG_NAME: &'static str = "pldm_fw_pkg.bin";
+    pub const CALIPTRA_ROM_NAME: &'static str = "caliptra_rom.bin";
+    pub const CALIPTRA_FW_NAME: &'static str = "caliptra_fw.bin";
+    pub const CALIPTRA_FW_SVN7_NAME: &'static str = "caliptra_fw_svn7.bin";
+    pub const CALIPTRA_FW_SVN128_NAME: &'static str = "caliptra_fw_svn128.bin";
+    pub const CALIPTRA_FW_KEY2_NAME: &'static str = "caliptra_fw_key2.bin";
+    pub const CALIPTRA_FW_OCP_LOCK_NAME: &'static str = "caliptra_fw_ocp_lock.bin";
+    pub const MCU_ROM_NAME: &'static str = "mcu_rom.bin";
+    pub const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
+    pub const USER_APP_ELF_NAME: &'static str = "user_app_elf.bin";
+    pub const SOC_MANIFEST_NAME: &'static str = "soc_manifest.bin";
+    pub const FLASH_IMAGE_NAME: &'static str = "flash_image.bin";
+    pub const PLDM_FW_PKG_NAME: &'static str = "pldm_fw_pkg.bin";
+
+    pub fn as_bundle(&self, target: &crate::firmware::FirmwareTarget) -> &FirmwareBundle {
+        self.get(target).unwrap_or_else(|e| {
+            panic!(
+                "Failed to get or build bundle for target {}: {}",
+                target.id(),
+                e
+            )
+        })
+    }
+
+    pub fn get(&self, target: &crate::firmware::FirmwareTarget) -> Result<&'static FirmwareBundle> {
+        {
+            let map = self.bundles.read().unwrap();
+            if let Some(&bundle) = map.get(target) {
+                return Ok(bundle);
+            }
+        }
+        let mut map = self.bundles.write().unwrap();
+        if let Some(&bundle) = map.get(target) {
+            return Ok(bundle);
+        }
+        let built_bundle = self.build_bundle(target)?;
+        let static_bundle: &'static FirmwareBundle = Box::leak(Box::new(built_bundle));
+        map.insert(*target, static_bundle);
+        Ok(static_bundle)
+    }
+
+    fn build_bundle(&self, target: &crate::firmware::FirmwareTarget) -> Result<FirmwareBundle> {
+        let platform = match target.platform() {
+            crate::firmware::TargetPlatform::Fpga => "fpga",
+            _ => "emulator",
+        };
+
+        // 1. MCU ROM
+        let mcu_rom_bytes = if let Some(fwid) = firmware::REGISTERED_FW.iter().find(|f| {
+            f.crate_name == target.id()
+                || format!("mcu-test-rom-{}-{}", f.crate_name, f.bin_name) == target.id()
+        }) {
+            let bin_path = crate::test_rom_build(&CaliptraBuildArgs {
+                platform: Some(platform),
+                fwid: Some(fwid),
+                ..Default::default()
+            })?;
+            std::fs::read(bin_path)?
+        } else if let Some(&rom_feature) = target.mcu_rom_spec().features().first() {
+            let bin_path = crate::rom_build(&CaliptraBuildArgs {
+                platform: Some(platform),
+                features: Some(rom_feature),
+                ..Default::default()
+            })?;
+            std::fs::read(bin_path)?
+        } else {
+            let bin_path = crate::rom_build(&CaliptraBuildArgs {
+                platform: Some(platform),
+                ..Default::default()
+            })?;
+            std::fs::read(bin_path)?
+        };
+
+        // 2. Caliptra ROM
+        let caliptra_rom_bytes = if let Some(cptra_fwid) = firmware::CPTRA_REGISTERED_FW
+            .iter()
+            .find(|f| format!("cptra-test-rom-{}-{}.bin", f.crate_name, f.bin_name) == target.id())
+        {
+            caliptra_builder::build_firmware_rom(cptra_fwid)?
+        } else {
+            caliptra_builder::rom_for_fw_integration_tests()?.to_vec()
+        };
+
+        // 3. Caliptra RT
+        let (caliptra_fw_path, _vendor_pk_hash) = CaliptraBuilder::compile_caliptra_fw_cached(
+            target.platform() == crate::firmware::TargetPlatform::Fpga,
+            target.caliptra_rt_spec().features().contains(&"ocp-lock"),
+            target.caliptra_rt_spec().svn().map(|s| s as u16),
+            false,
+        )?;
+        let caliptra_rt_bytes = std::fs::read(caliptra_fw_path)?;
+
+        // 4. MCU FW / Runtime
+        let features_vec = target.mcu_fw_spec().features().to_vec();
+        let features_str = if features_vec.is_empty() {
+            None
+        } else {
+            Some(features_vec.join(","))
+        };
+        let profile_str = match target.mcu_fw_spec().profile() {
+            crate::firmware::FirmwareProfile::Devel => "devel",
+            crate::firmware::FirmwareProfile::Release => "release",
+        };
+        let runtime_path = crate::runtime_build_with_apps(&CaliptraBuildArgs {
+            features: features_str.as_deref(),
+            example_app: target.mcu_fw_spec().example_app(),
+            platform: Some(platform),
+            profile: Some(profile_str),
+            ..Default::default()
+        })?;
+        let mcu_fw_bytes = std::fs::read(&runtime_path)?;
+
+        let user_app_elf_path = crate::target_dir()
+            .join(TARGET)
+            .join(profile_str)
+            .join("user-app");
+        let user_app_elf = std::fs::read(&user_app_elf_path).ok();
+
+        // 5. Flash image
+        let flash_image = if target.id().contains("flash") || target.id().contains("boot") {
+            crate::flash_image::build_flash_image_bytes(
+                Some(&caliptra_rt_bytes),
+                None,
+                Some(&mcu_fw_bytes),
+            )
+        } else {
+            vec![]
+        };
+
+        // 6. SoC manifest
+        let soc_manifest_bytes = match target.id() {
+            "test-ocp-lock" => {
+                let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+                    features: Some("ocp-lock"),
+                    mcu_firmware: Some(runtime_path.clone()),
+                    ..Default::default()
+                });
+                let path = builder.get_soc_manifest(None)?;
+                std::fs::read(path).unwrap_or_default()
+            }
+            _ => vec![],
+        };
+
+        Ok(FirmwareBundle {
+            caliptra_rom: CaliptraRomBinary(caliptra_rom_bytes),
+            caliptra_rt: CaliptraRtBinary(caliptra_rt_bytes),
+            mcu_rom: McuRomBinary(mcu_rom_bytes),
+            mcu_fw: McuFwBinary {
+                bytes: mcu_fw_bytes,
+                flash_image,
+                pldm_fw_pkg: vec![],
+                update_flash_image: vec![],
+                user_app_elf,
+            },
+            soc_manifest: SocManifestBinary(soc_manifest_bytes),
+        })
+    }
 
     /// Reads the environment variable `CPTRA_FIRMWARE_BUNDLE`.
-    ///
-    /// returns `FirmwareBinaries` if `CPTRA_FIRMWARE_BUNDLE` points to a valid zip file.
-    ///
-    /// This function is safe to call multiple times. The returned `FirmwareBinaries` is cached
-    /// after the first invocation to avoid multiple decompressions.
     pub fn from_env() -> Result<&'static Self> {
-        // TODO: Consider falling back to building the firmware if CPTRA_FIRMWARE_BUNDLE is unset.
-        let bundle_path = var("CPTRA_FIRMWARE_BUNDLE")
-            .map_err(|_| anyhow::anyhow!("Set the environment variable CPTRA_FIRMWARE_BUNDLE"))?;
-
         static BINARIES: OnceLock<FirmwareBinaries> = OnceLock::new();
         let binaries = BINARIES.get_or_init(|| {
-            Self::read_from_zip(&bundle_path.clone().into()).expect("failed to unzip archive")
+            if let Ok(bundle_path) = var("CPTRA_FIRMWARE_BUNDLE") {
+                Self::read_from_zip(&bundle_path.into()).unwrap_or_default()
+            } else {
+                FirmwareBinaries::default()
+            }
         });
 
         Ok(binaries)
@@ -301,217 +471,99 @@ impl FirmwareBinaries {
     pub fn read_from_zip(path: &PathBuf) -> Result<Self> {
         let file = std::fs::File::open(path)?;
         let mut zip = zip::ZipArchive::new(file)?;
-        let mut binaries = FirmwareBinaries::default();
+        let mut raw_files: std::collections::HashMap<String, Vec<u8>> =
+            std::collections::HashMap::new();
+        let binaries = FirmwareBinaries::default();
 
         for i in 0..zip.len() {
             let mut file = zip.by_index(i)?;
             let name = file.name().to_string();
             let mut data = Vec::new();
             file.read_to_end(&mut data)?;
+            raw_files.insert(name, data);
+        }
 
-            match name.as_str() {
-                Self::CALIPTRA_ROM_NAME => binaries.caliptra_rom = data,
-                Self::CALIPTRA_FW_NAME => binaries.caliptra_fw = data,
-                Self::CALIPTRA_FW_SVN7_NAME => binaries.caliptra_fw_svn7 = data,
-                Self::CALIPTRA_FW_SVN128_NAME => binaries.caliptra_fw_svn128 = data,
-                Self::CALIPTRA_FW_KEY2_NAME => binaries.caliptra_fw_key2 = data,
-                Self::CALIPTRA_FW_OCP_LOCK_NAME => binaries.caliptra_fw_ocp_lock = data,
-                Self::MCU_ROM_NAME => binaries.mcu_rom = data,
-                Self::MCU_RUNTIME_NAME => binaries.mcu_runtime = data,
-                Self::USER_APP_ELF_NAME => {
-                    binaries.test_user_app_elfs.push((name.to_string(), data));
-                }
-                Self::SOC_MANIFEST_NAME => binaries.soc_manifest = data,
-                name if name.contains("mcu-test-soc-manifest") => {
-                    binaries.test_soc_manifests.push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-runtime") => {
-                    binaries.test_runtimes.push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-rom") => {
-                    binaries.test_roms.push((name.to_string(), data));
-                }
-                name if name.contains("cptra-test-rom") => {
-                    binaries.caliptra_test_roms.push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-pldm-fw-pkg") => {
-                    binaries.test_pldm_fw_pkgs.push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-user-app-elf") => {
-                    binaries.test_user_app_elfs.push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-update-flash-image") => {
-                    binaries
-                        .test_update_flash_images
-                        .push((name.to_string(), data));
-                }
-                name if name.contains("mcu-test-flash-image") => {
-                    binaries.test_flash_images.push((name.to_string(), data));
-                }
-                name if name.starts_with("bare_metal/") => {
-                    let stripped_name = name.strip_prefix("bare_metal/").unwrap();
-                    let stripped_name = stripped_name
-                        .strip_suffix(".bin")
-                        .unwrap_or(stripped_name)
-                        .to_string();
-                    binaries.bare_metal_images.push((stripped_name, data));
-                }
-                _ => continue,
+        // Construct FirmwareBundle for every target in FIRMWARE_TARGETS
+        for target in crate::firmware::targets::FIRMWARE_TARGETS {
+            let id = target.id();
+
+            let caliptra_rom = raw_files.get(target.caliptra_rom_filename());
+            let caliptra_fw = raw_files.get(target.caliptra_rt_filename());
+            let mcu_rom = raw_files.get(target.mcu_rom_filename());
+            let mcu_runtime = raw_files.get(target.mcu_fw_filename());
+            let soc_manifest = raw_files.get(target.soc_manifest_filename());
+            let flash_image = raw_files.get(target.flash_image_filename());
+            let pldm_fw_pkg = raw_files.get(target.pldm_fw_pkg_filename());
+            let update_flash_image = target
+                .update_flash_image_filename()
+                .and_then(|f| raw_files.get(f));
+            let user_app_elf = raw_files.get(target.user_app_elf_filename()).cloned();
+
+            let c_rom_bytes = caliptra_rom.map(|v| v.as_slice()).unwrap_or(&[]);
+            let c_fw_bytes = caliptra_fw.map(|v| v.as_slice()).unwrap_or(&[]);
+            let m_rom_bytes = mcu_rom.map(|v| v.as_slice()).unwrap_or(&[]);
+            let soc_m_bytes = soc_manifest.map(|v| v.as_slice()).unwrap_or(&[]);
+
+            if let Some(m_rt) = mcu_runtime {
+                let bundle = FirmwareBundle {
+                    caliptra_rom: CaliptraRomBinary(c_rom_bytes.to_vec()),
+                    caliptra_rt: CaliptraRtBinary(c_fw_bytes.to_vec()),
+                    mcu_rom: McuRomBinary(m_rom_bytes.to_vec()),
+                    mcu_fw: McuFwBinary {
+                        bytes: m_rt.clone(),
+                        flash_image: flash_image.cloned().unwrap_or_default(),
+                        pldm_fw_pkg: pldm_fw_pkg.cloned().unwrap_or_default(),
+                        update_flash_image: update_flash_image.cloned().unwrap_or_default(),
+                        user_app_elf,
+                    },
+                    soc_manifest: SocManifestBinary(soc_m_bytes.to_vec()),
+                };
+                let static_bundle: &'static FirmwareBundle = Box::leak(Box::new(bundle));
+                binaries
+                    .bundles
+                    .write()
+                    .unwrap()
+                    .insert(**target, static_bundle);
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Firmware bundle is incomplete: missing binaries for target '{id}'"
+                ));
             }
         }
 
         Ok(binaries)
     }
 
-    pub fn get_bare_metal(&self, name: &str) -> Result<Vec<u8>> {
-        for (bin_name, data) in self.bare_metal_images.iter() {
-            if bin_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "Bare-metal binary {name} not found in bundle"
-        ))
-    }
-
-    pub fn vendor_pk_hash(&self) -> Option<[u8; 48]> {
-        if let Ok((manifest, _)) = ImageManifest::ref_from_prefix(&self.caliptra_fw) {
+    pub fn vendor_pk_hash_for_target(
+        &self,
+        target: &crate::firmware::FirmwareTarget,
+    ) -> Option<[u8; 48]> {
+        let bundle = self.get(target).ok()?;
+        if let Ok((manifest, _)) = ImageManifest::ref_from_prefix(&bundle.caliptra_rt) {
             CaliptraBuilder::vendor_pk_hash(manifest).ok()
         } else {
             None
         }
     }
 
-    /// Returns the owner public key hash from the Caliptra firmware bundle.
-    pub fn owner_pk_hash(&self) -> Option<[u8; 48]> {
-        if let Ok((manifest, _)) = ImageManifest::ref_from_prefix(&self.caliptra_fw) {
+    pub fn vendor_pk_hash(&self) -> Option<[u8; 48]> {
+        self.vendor_pk_hash_for_target(&crate::firmware::targets::TEST_DO_NOTHING)
+    }
+
+    pub fn owner_pk_hash_for_target(
+        &self,
+        target: &crate::firmware::FirmwareTarget,
+    ) -> Option<[u8; 48]> {
+        let bundle = self.get(target).ok()?;
+        if let Ok((manifest, _)) = ImageManifest::ref_from_prefix(&bundle.caliptra_rt) {
             CaliptraBuilder::owner_pk_hash(manifest).ok()
         } else {
             None
         }
     }
 
-    /// Get the base user-app ELF archived with the firmware bundle, if present.
-    /// The ELF carries the `.defmt` table needed to decode release-profile
-    /// userspace log frames.
-    pub fn user_app_elf(&self) -> Option<&[u8]> {
-        self.test_user_app_elfs
-            .iter()
-            .find(|(name, _)| name.as_str() == Self::USER_APP_ELF_NAME)
-            .map(|(_, data)| data.as_slice())
-    }
-
-    pub fn test_rom(&self, fwid: &FwId) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-rom-{}-{}.bin", fwid.crate_name, fwid.bin_name);
-        for (name, data) in self.test_roms.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "FwId not found. File name: {expected_name}, FwId: {:?}",
-            fwid
-        ))
-    }
-
-    pub fn caliptra_test_rom(&self, fwid: &FwId) -> Result<Vec<u8>> {
-        let expected_name = format!("cptra-test-rom-{}-{}.bin", fwid.crate_name, fwid.bin_name);
-        println!("expected name: {expected_name}");
-        for (name, data) in self.caliptra_test_roms.iter() {
-            println!("checking: {name}");
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "FwId not found. File name: {expected_name}, FwId: {:?}",
-            fwid
-        ))
-    }
-
-    pub fn test_soc_manifest(&self, feature: &str) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-soc-manifest-{}.bin", feature);
-        for (name, data) in self.test_soc_manifests.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "SoC Manifest not found. File name: {expected_name}, feature: {feature}"
-        ))
-    }
-
-    pub fn test_runtime(&self, feature: &str) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-runtime-{}.bin", feature);
-        for (name, data) in self.test_runtimes.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "Runtime not found. File name: {expected_name}, feature: {feature}"
-        ))
-    }
-
-    pub fn test_pldm_fw_pkg(&self, feature: &str) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-pldm-fw-pkg-{}.bin", feature);
-        for (name, data) in self.test_pldm_fw_pkgs.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "PLDM FW Package not found. File name: {expected_name}, feature: {feature}"
-        ))
-    }
-
-    pub fn test_flash_image(&self, feature: &str) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-flash-image-{}.bin", feature);
-        for (name, data) in self.test_flash_images.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "Flash image not found. File name: {expected_name}, feature: {feature}"
-        ))
-    }
-
-    /// Get the update flash image (without partition table) for a test feature.
-    /// This is used for PLDM update packages in firmware update tests.
-    pub fn test_update_flash_image(&self, feature: &str) -> Result<Vec<u8>> {
-        let expected_name = format!("mcu-test-update-flash-image-{}.bin", feature);
-        for (name, data) in self.test_update_flash_images.iter() {
-            if &expected_name == name {
-                return Ok(data.clone());
-            }
-        }
-        Err(anyhow::anyhow!(
-            "Update flash image not found. File name: {expected_name}, feature: {feature}"
-        ))
-    }
-
-    /// Get a feature-specific MCU ROM. Falls back to the generic MCU ROM
-    /// if no feature-specific ROM was built.
-    pub fn test_feature_rom(&self, feature: &str) -> Vec<u8> {
-        let expected_name = format!("mcu-test-rom-feature-{}.bin", feature);
-        for (name, data) in self.test_roms.iter() {
-            if &expected_name == name {
-                return data.clone();
-            }
-        }
-        self.mcu_rom.clone()
-    }
-
-    /// Get the user-app ELF for a specific test feature, if archived in the
-    /// firmware bundle. The ELF carries the `.defmt` table needed to decode
-    /// frames retrieved from the device via the debug-log command.
-    pub fn test_user_app_elf(&self, feature: &str) -> Option<&[u8]> {
-        let expected_name = format!("mcu-test-user-app-elf-{}.bin", feature);
-        self.test_user_app_elfs
-            .iter()
-            .find(|(name, _)| name == &expected_name)
-            .map(|(_, data)| data.as_slice())
+    pub fn owner_pk_hash(&self) -> Option<[u8; 48]> {
+        self.owner_pk_hash_for_target(&crate::firmware::targets::TEST_DO_NOTHING)
     }
 }
 
@@ -703,11 +755,13 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
 
     // Determine effective SoC images for base runtime features.
     // When the caller didn't supply --soc_image args, auto-create them for
-    // features that need SoC images (e.g. attestation).
     let effective_soc_images = if soc_images.is_none() {
-        let needs_soc = base_runtime_features
-            .iter()
-            .any(|f| FEATURES_REQUIRING_SOC_IMAGES.contains(f));
+        let needs_soc = base_runtime_features.iter().any(|f| {
+            f.contains("flash")
+                || f.contains("streaming")
+                || f.contains("attestation")
+                || f.contains("firmware-activate")
+        });
         if needs_soc {
             let is_attestation = base_runtime_features.iter().any(|f| {
                 *f == "test-mctp-spdm-attestation" || *f == "test-mctp-spdm-attestation-pcr-quote"
@@ -917,11 +971,19 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             };
             let feature_runtime_file = tempfile::NamedTempFile::new().unwrap();
             let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
-            let include_example_app = FEATURES_WITH_EXAMPLE_APP.contains(feature);
+            let target = firmware::targets::FIRMWARE_TARGETS
+                .iter()
+                .copied()
+                .find(|t| t.id() == *feature);
+            let include_example_app = target.is_some_and(|t| t.example_app());
 
             // When the matching ROM feature enables hw-2-1, combine it with
             // the separate runtime feature so the staging SRAM path is enabled.
-            let needs_hw_2_1 = propagate_hw_2_1 || feature_requires_hw_2_1(feature);
+            let needs_hw_2_1 = propagate_hw_2_1
+                || *feature == "test-flash-based-boot"
+                || *feature == "test-firmware-activate"
+                || *feature == "test-firmware-update-flash"
+                || *feature == "test-usb-ocp-recovery";
             let mut combined_features = if needs_hw_2_1 && *feature != "hw-2-1" {
                 format!("{},hw-2-1", feature)
             } else {
@@ -961,8 +1023,12 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
                 );
 
             // For features that require SoC images, create default ones if not provided
+            let feature_requires_soc = feature.contains("flash")
+                || feature.contains("streaming")
+                || feature.contains("attestation")
+                || feature.contains("firmware-activate");
             let (feature_soc_images, feature_soc_images_paths) =
-                if FEATURES_REQUIRING_SOC_IMAGES.contains(feature) && soc_images.is_none() {
+                if feature_requires_soc && soc_images.is_none() {
                     let (images, paths) = if *feature == "test-mctp-spdm-attestation"
                         || *feature == "test-mctp-spdm-attestation-pcr-quote"
                     {
@@ -999,7 +1065,8 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             caliptra_builder.get_soc_manifest(feature_soc_manifest_file.path().to_str())?;
 
             // Flash-based boot features require partition table at offset 0
-            let is_flash_based_boot = FEATURES_REQUIRING_FLASH_BOOT.contains(feature);
+            let is_flash_based_boot =
+                *feature == "test-flash-based-boot" || *feature == "test-firmware-update-flash";
 
             // Clone paths for potential second use
             let feature_soc_images_paths_clone = feature_soc_images_paths.clone();
@@ -1277,10 +1344,6 @@ fn get_image_cfg_feature(image_cfg: &[ImageCfg], feature: &str) -> Option<ImageC
     None
 }
 
-fn feature_requires_hw_2_1(feature: &str) -> bool {
-    FEATURES_REQUIRING_HW_2_1_RUNTIME.contains(&feature)
-}
-
 fn default_mcu_image_cfg_for_feature(feature: &str, runtime_path: &Path) -> Option<ImageCfg> {
     if feature != "test-firmware-update-flash" {
         return None;
@@ -1436,4 +1499,47 @@ fn get_device_uuid() -> [u8; 16] {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
         0x10,
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_firmware_binaries_coverage() {
+        let binaries = FirmwareBinaries::from_env().unwrap();
+        for target in crate::firmware::targets::FIRMWARE_TARGETS {
+            let bundle = binaries.as_bundle(target);
+            if *target == &crate::firmware::targets::BARE_METAL
+                || *target == &crate::firmware::targets::PROVISIONING_TEST_UNLOCKED_FW
+            {
+                assert!(
+                    !bundle.mcu_fw.is_empty(),
+                    "Target {} missing mcu_fw",
+                    target.id()
+                );
+            } else {
+                assert!(
+                    !bundle.caliptra_rom.is_empty(),
+                    "Target {} missing caliptra_rom",
+                    target.id()
+                );
+                assert!(
+                    !bundle.caliptra_rt.is_empty(),
+                    "Target {} missing caliptra_rt",
+                    target.id()
+                );
+                assert!(
+                    !bundle.mcu_rom.is_empty(),
+                    "Target {} missing mcu_rom",
+                    target.id()
+                );
+                assert!(
+                    !bundle.mcu_fw.is_empty(),
+                    "Target {} missing mcu_fw",
+                    target.id()
+                );
+            }
+        }
+    }
 }

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -461,7 +461,7 @@ impl CaliptraBuilder {
         Ok(path)
     }
 
-    fn compile_caliptra_fw_cached(
+    pub fn compile_caliptra_fw_cached(
         fpga: bool,
         ocp_lock: bool,
         svn: Option<u16>,

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -83,3 +83,866 @@ pub const CPTRA_REGISTERED_FW: &[&FwId] = &[
     &caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW,
     &caliptra_builder::firmware::driver_tests::AXI_BYPASS,
 ];
+
+/// Profile for compiling MCU firmware
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FirmwareProfile {
+    Devel,
+    Release,
+}
+
+/// Caliptra ROM specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CaliptraRomSpec {
+    features: &'static [&'static str],
+}
+
+impl CaliptraRomSpec {
+    pub const DEFAULT: Self = Self { features: &[] };
+
+    pub const fn new(features: &'static [&'static str]) -> Self {
+        Self { features }
+    }
+
+    pub fn features(&self) -> &'static [&'static str] {
+        self.features
+    }
+
+    pub fn filename(&self) -> &'static str {
+        "caliptra_rom.bin"
+    }
+}
+
+/// Caliptra Runtime (RT) specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CaliptraRtSpec {
+    features: &'static [&'static str],
+    svn: Option<u32>,
+}
+
+impl CaliptraRtSpec {
+    pub const DEFAULT: Self = Self {
+        features: &[],
+        svn: None,
+    };
+
+    pub const OCP_LOCK: Self = Self {
+        features: &["ocp-lock"],
+        svn: None,
+    };
+
+    pub const SVN7: Self = Self {
+        features: &[],
+        svn: Some(7),
+    };
+
+    pub const SVN128: Self = Self {
+        features: &[],
+        svn: Some(128),
+    };
+
+    pub const fn new(features: &'static [&'static str], svn: Option<u32>) -> Self {
+        Self { features, svn }
+    }
+
+    pub fn features(&self) -> &'static [&'static str] {
+        self.features
+    }
+
+    pub fn svn(&self) -> Option<u32> {
+        self.svn
+    }
+
+    pub fn filename(&self) -> &'static str {
+        if self.features.contains(&"ocp-lock") {
+            "caliptra_fw_ocp_lock.bin"
+        } else if self.svn == Some(7) {
+            "caliptra_fw_svn7.bin"
+        } else if self.svn == Some(128) {
+            "caliptra_fw_svn128.bin"
+        } else {
+            "caliptra_fw.bin"
+        }
+    }
+}
+
+/// MCU ROM specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct McuRomSpec {
+    features: &'static [&'static str],
+}
+
+impl McuRomSpec {
+    pub const DEFAULT: Self = Self { features: &[] };
+
+    pub const OCP_LOCK: Self = Self {
+        features: &["ocp-lock"],
+    };
+
+    pub const fn new(features: &'static [&'static str]) -> Self {
+        Self { features }
+    }
+
+    pub fn features(&self) -> &'static [&'static str] {
+        self.features
+    }
+
+    pub fn filename(&self) -> String {
+        if let Some(&rom_feature) = self.features.first() {
+            format!("mcu-test-rom-feature-{rom_feature}.bin")
+        } else {
+            "mcu_rom.bin".to_string()
+        }
+    }
+}
+
+/// MCU Firmware (Runtime) specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct McuFwSpec {
+    id: &'static str,
+    features: &'static [&'static str],
+    profile: FirmwareProfile,
+    example_app: bool,
+}
+
+impl McuFwSpec {
+    pub const fn new(
+        id: &'static str,
+        features: &'static [&'static str],
+        profile: FirmwareProfile,
+        example_app: bool,
+    ) -> Self {
+        Self {
+            id,
+            features,
+            profile,
+            example_app,
+        }
+    }
+
+    pub fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub fn features(&self) -> &'static [&'static str] {
+        self.features
+    }
+
+    pub fn profile(&self) -> FirmwareProfile {
+        self.profile
+    }
+
+    pub fn example_app(&self) -> bool {
+        self.example_app
+    }
+
+    pub fn filename(&self) -> String {
+        if self.id == "caliptra-mcu-bare-metal"
+            || self.id == "caliptra-mcu-provisioning-test-unlocked-fw"
+        {
+            format!("bare_metal/{}.bin", self.id)
+        } else {
+            format!("mcu-test-runtime-{}.bin", self.id)
+        }
+    }
+
+    pub fn flash_image_filename(&self) -> String {
+        format!("mcu-test-flash-image-{}.bin", self.id)
+    }
+
+    pub fn pldm_fw_pkg_filename(&self) -> String {
+        format!("mcu-test-pldm-fw-pkg-{}.bin", self.id)
+    }
+
+    pub fn update_flash_image_filename(&self) -> String {
+        format!("mcu-test-update-flash-image-{}.bin", self.id)
+    }
+
+    pub fn user_app_elf_filename(&self) -> String {
+        format!("mcu-test-user-app-elf-{}.bin", self.id)
+    }
+}
+
+/// SoC Manifest specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SocManifestSpec {
+    id: &'static str,
+}
+
+impl SocManifestSpec {
+    pub const DEFAULT: Self = Self { id: "default" };
+
+    pub const fn new(id: &'static str) -> Self {
+        Self { id }
+    }
+
+    pub fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub fn filename(&self) -> String {
+        format!("mcu-test-soc-manifest-{}.bin", self.id)
+    }
+}
+
+/// Target execution platform filter
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetPlatform {
+    Emulator,
+    Fpga,
+    All,
+}
+
+/// A complete target combining all components of the firmware stack
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FirmwareTarget {
+    id: &'static str,
+    platform: TargetPlatform,
+    caliptra_rom: CaliptraRomSpec,
+    caliptra_rt: CaliptraRtSpec,
+    mcu_rom: McuRomSpec,
+    mcu_fw: McuFwSpec,
+    soc_manifest: SocManifestSpec,
+    caliptra_rom_filename: &'static str,
+    caliptra_rt_filename: &'static str,
+    mcu_rom_filename: &'static str,
+    mcu_fw_filename: &'static str,
+    soc_manifest_filename: &'static str,
+    flash_image_filename: &'static str,
+    pldm_fw_pkg_filename: &'static str,
+    update_flash_image_filename: Option<&'static str>,
+    user_app_elf_filename: &'static str,
+}
+
+impl FirmwareTarget {
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        id: &'static str,
+        platform: TargetPlatform,
+        caliptra_rom: CaliptraRomSpec,
+        caliptra_rt: CaliptraRtSpec,
+        mcu_rom: McuRomSpec,
+        mcu_fw: McuFwSpec,
+        soc_manifest: SocManifestSpec,
+        caliptra_rom_filename: &'static str,
+        caliptra_rt_filename: &'static str,
+        mcu_rom_filename: &'static str,
+        mcu_fw_filename: &'static str,
+        soc_manifest_filename: &'static str,
+        flash_image_filename: &'static str,
+        pldm_fw_pkg_filename: &'static str,
+        update_flash_image_filename: Option<&'static str>,
+        user_app_elf_filename: &'static str,
+    ) -> Self {
+        Self {
+            id,
+            platform,
+            caliptra_rom,
+            caliptra_rt,
+            mcu_rom,
+            mcu_fw,
+            soc_manifest,
+            caliptra_rom_filename,
+            caliptra_rt_filename,
+            mcu_rom_filename,
+            mcu_fw_filename,
+            soc_manifest_filename,
+            flash_image_filename,
+            pldm_fw_pkg_filename,
+            update_flash_image_filename,
+            user_app_elf_filename,
+        }
+    }
+
+    pub fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub fn platform(&self) -> TargetPlatform {
+        self.platform
+    }
+
+    pub fn caliptra_rom_spec(&self) -> &CaliptraRomSpec {
+        &self.caliptra_rom
+    }
+
+    pub fn caliptra_rt_spec(&self) -> &CaliptraRtSpec {
+        &self.caliptra_rt
+    }
+
+    pub fn mcu_rom_spec(&self) -> &McuRomSpec {
+        &self.mcu_rom
+    }
+
+    pub fn mcu_fw_spec(&self) -> &McuFwSpec {
+        &self.mcu_fw
+    }
+
+    pub fn soc_manifest_spec(&self) -> &SocManifestSpec {
+        &self.soc_manifest
+    }
+
+    pub fn example_app(&self) -> bool {
+        self.mcu_fw.example_app
+    }
+
+    pub fn caliptra_rom_filename(&self) -> &'static str {
+        self.caliptra_rom_filename
+    }
+
+    pub fn caliptra_rt_filename(&self) -> &'static str {
+        self.caliptra_rt_filename
+    }
+
+    pub fn mcu_rom_filename(&self) -> &'static str {
+        self.mcu_rom_filename
+    }
+
+    pub fn mcu_fw_filename(&self) -> &'static str {
+        self.mcu_fw_filename
+    }
+
+    pub fn flash_image_filename(&self) -> &'static str {
+        self.flash_image_filename
+    }
+
+    pub fn pldm_fw_pkg_filename(&self) -> &'static str {
+        self.pldm_fw_pkg_filename
+    }
+
+    pub fn update_flash_image_filename(&self) -> Option<&'static str> {
+        self.update_flash_image_filename
+    }
+
+    pub fn user_app_elf_filename(&self) -> &'static str {
+        self.user_app_elf_filename
+    }
+
+    pub fn soc_manifest_filename(&self) -> &'static str {
+        self.soc_manifest_filename
+    }
+
+    pub fn supports_platform(&self, platform: &str) -> bool {
+        matches!(
+            (self.platform, platform),
+            (TargetPlatform::All, _)
+                | (TargetPlatform::Emulator, "emulator")
+                | (TargetPlatform::Fpga, "fpga")
+        )
+    }
+}
+
+pub mod targets {
+    use super::*;
+    use crate::all::FirmwareBinaries;
+
+    macro_rules! default_fw_bundle {
+        ($name:ident, $id:expr) => {
+            pub const $name: FirmwareTarget = FirmwareTarget {
+                id: $id,
+                platform: TargetPlatform::All,
+                caliptra_rom: CaliptraRomSpec::DEFAULT,
+                caliptra_rt: CaliptraRtSpec::DEFAULT,
+                mcu_rom: McuRomSpec::DEFAULT,
+                mcu_fw: McuFwSpec {
+                    id: $id,
+                    features: &[$id],
+                    profile: FirmwareProfile::Devel,
+                    example_app: false,
+                },
+                soc_manifest: SocManifestSpec { id: $id },
+                caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+                caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+                mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+                mcu_fw_filename: FirmwareBinaries::MCU_RUNTIME_NAME,
+                soc_manifest_filename: FirmwareBinaries::SOC_MANIFEST_NAME,
+                flash_image_filename: FirmwareBinaries::FLASH_IMAGE_NAME,
+                pldm_fw_pkg_filename: FirmwareBinaries::PLDM_FW_PKG_NAME,
+                update_flash_image_filename: None,
+                user_app_elf_filename: FirmwareBinaries::USER_APP_ELF_NAME,
+            };
+        };
+    }
+
+    macro_rules! fw_bundle {
+        ($name:ident, $id:expr, $example_app:expr) => {
+            pub const $name: FirmwareTarget = FirmwareTarget {
+                id: $id,
+                platform: TargetPlatform::All,
+                caliptra_rom: CaliptraRomSpec::DEFAULT,
+                caliptra_rt: CaliptraRtSpec::DEFAULT,
+                mcu_rom: McuRomSpec::DEFAULT,
+                mcu_fw: McuFwSpec {
+                    id: $id,
+                    features: &[$id],
+                    profile: FirmwareProfile::Devel,
+                    example_app: $example_app,
+                },
+                soc_manifest: SocManifestSpec { id: $id },
+                caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+                caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+                mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+                mcu_fw_filename: concat!("mcu-test-runtime-", $id, ".bin"),
+                soc_manifest_filename: concat!("mcu-test-soc-manifest-", $id, ".bin"),
+                flash_image_filename: concat!("mcu-test-flash-image-", $id, ".bin"),
+                pldm_fw_pkg_filename: concat!("mcu-test-pldm-fw-pkg-", $id, ".bin"),
+                update_flash_image_filename: Some(concat!(
+                    "mcu-test-update-flash-image-",
+                    $id,
+                    ".bin"
+                )),
+                user_app_elf_filename: concat!("mcu-test-user-app-elf-", $id, ".bin"),
+            };
+        };
+    }
+
+    macro_rules! bare_metal_fw_bundle {
+        ($name:ident, $id:expr) => {
+            pub const $name: FirmwareTarget = FirmwareTarget {
+                id: $id,
+                platform: TargetPlatform::All,
+                caliptra_rom: CaliptraRomSpec::DEFAULT,
+                caliptra_rt: CaliptraRtSpec::DEFAULT,
+                mcu_rom: McuRomSpec::DEFAULT,
+                mcu_fw: McuFwSpec {
+                    id: $id,
+                    features: &[$id],
+                    profile: FirmwareProfile::Devel,
+                    example_app: false,
+                },
+                soc_manifest: SocManifestSpec { id: $id },
+                caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+                caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+                mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+                mcu_fw_filename: concat!("bare_metal/", $id, ".bin"),
+                soc_manifest_filename: concat!("mcu-test-soc-manifest-", $id, ".bin"),
+                flash_image_filename: concat!("mcu-test-flash-image-", $id, ".bin"),
+                pldm_fw_pkg_filename: concat!("mcu-test-pldm-fw-pkg-", $id, ".bin"),
+                update_flash_image_filename: Some(concat!(
+                    "mcu-test-update-flash-image-",
+                    $id,
+                    ".bin"
+                )),
+                user_app_elf_filename: concat!("mcu-test-user-app-elf-", $id, ".bin"),
+            };
+        };
+    }
+
+    fw_bundle!(TEST_ACTIVE_I3C1, "active-i3c1", false);
+    fw_bundle!(TEST_I3C_SIMPLE, "test-i3c-simple", false);
+    fw_bundle!(TEST_I3C_CONSTANT_WRITES, "test-i3c-constant-writes", false);
+    fw_bundle!(
+        TEST_MCTP_CAPSULE_LOOPBACK,
+        "test-mctp-capsule-loopback",
+        false
+    );
+    fw_bundle!(
+        TEST_FIRMWARE_UPDATE_STREAMING,
+        "test-firmware-update-streaming",
+        false
+    );
+    fw_bundle!(
+        TEST_STREAMING_BOOT_FLASH_WRITE_BACK,
+        "test-streaming-boot-flash-write-back",
+        false
+    );
+    fw_bundle!(
+        TEST_FIRMWARE_UPDATE_FLASH,
+        "test-firmware-update-flash",
+        false
+    );
+    fw_bundle!(TEST_FLASH_BASED_BOOT, "test-flash-based-boot", false);
+    fw_bundle!(TEST_PLDM_STREAMING_BOOT, "test-pldm-streaming-boot", false);
+    fw_bundle!(TEST_PLDM_FW_UPDATE_E2E, "test-pldm-fw-update-e2e", false);
+    default_fw_bundle!(TEST_DO_NOTHING, "test-do-nothing");
+    fw_bundle!(TEST_CALIPTRA_CERTS, "test-caliptra-certs", true);
+    fw_bundle!(TEST_CALIPTRA_CRYPTO, "test-caliptra-crypto", true);
+    fw_bundle!(TEST_CALIPTRA_MAILBOX, "test-caliptra-mailbox", true);
+    fw_bundle!(TEST_DMA, "test-dma", true);
+    fw_bundle!(
+        TEST_DOE_TRANSPORT_LOOPBACK,
+        "test-doe-transport-loopback",
+        true
+    );
+    fw_bundle!(TEST_DOE_USER_LOOPBACK, "test-doe-user-loopback", true);
+    fw_bundle!(TEST_DOE_DISCOVERY, "test-doe-discovery", true);
+    fw_bundle!(TEST_GET_DEVICE_STATE, "test-get-device-state", true);
+    fw_bundle!(TEST_FLASH_CTRL_INIT, "test-flash-ctrl-init", false);
+    fw_bundle!(
+        TEST_FLASH_CTRL_READ_WRITE_PAGE,
+        "test-flash-ctrl-read-write-page",
+        false
+    );
+    fw_bundle!(
+        TEST_FLASH_CTRL_ERASE_PAGE,
+        "test-flash-ctrl-erase-page",
+        false
+    );
+    fw_bundle!(
+        TEST_FLASH_STORAGE_READ_WRITE,
+        "test-flash-storage-read-write",
+        false
+    );
+    fw_bundle!(TEST_FLASH_STORAGE_ERASE, "test-flash-storage-erase", false);
+    fw_bundle!(TEST_FLASH_USERMODE, "test-flash-usermode", true);
+    fw_bundle!(TEST_LOG_FLASH_CIRCULAR, "test-log-flash-circular", false);
+    fw_bundle!(TEST_LOG_FLASH_LINEAR, "test-log-flash-linear", false);
+    fw_bundle!(TEST_LOG_FLASH_USERMODE, "test-log-flash-usermode", true);
+    fw_bundle!(
+        TEST_DEFMT_LOGGING_MAILBOX,
+        "test-defmt-logging-mailbox",
+        false
+    );
+    fw_bundle!(TEST_DEFMT_LOGGING_VDM, "test-defmt-logging-vdm", false);
+    fw_bundle!(TEST_MCTP_CTRL_CMDS, "test-mctp-ctrl-cmds", false);
+    fw_bundle!(TEST_MCTP_USER_LOOPBACK, "test-mctp-user-loopback", true);
+    fw_bundle!(TEST_MCTP_VDM_CMDS, "test-mctp-vdm-cmds", false);
+    fw_bundle!(TEST_PLDM_DISCOVERY, "test-pldm-discovery", false);
+    fw_bundle!(TEST_PLDM_FW_UPDATE, "test-pldm-fw-update", false);
+    fw_bundle!(TEST_MCI, "test-mci", true);
+    fw_bundle!(TEST_MCU_MBOX_DRIVER, "test-mcu-mbox-driver", false);
+    fw_bundle!(
+        TEST_MCU_MBOX_SOC_REQUESTER_LOOPBACK,
+        "test-mcu-mbox-soc-requester-loopback",
+        true
+    );
+    fw_bundle!(TEST_MCU_MBOX_CMDS, "test-mcu-mbox-cmds", false);
+    fw_bundle!(TEST_MBOX_SRAM, "test-mbox-sram", true);
+    fw_bundle!(TEST_EXTERNAL_OTP, "test-external-otp", true);
+    fw_bundle!(TEST_HANDOFF, "test-handoff", false);
+    fw_bundle!(TEST_DPE_HANDLE_STORE, "test-dpe-handle-store", true);
+    fw_bundle!(TEST_SW_PCR_STORE, "test-sw-pcr-store", true);
+    fw_bundle!(TEST_WARM_RESET, "test-warm-reset", true);
+    fw_bundle!(TEST_EXIT_IMMEDIATELY, "test-exit-immediately", false);
+    fw_bundle!(
+        TEST_MCU_ROM_FLASH_ACCESS,
+        "test-mcu-rom-flash-access",
+        false
+    );
+    macro_rules! rom_feature_fw_bundle {
+        ($name:ident, $id:expr, $feature:expr) => {
+            pub const $name: FirmwareTarget = FirmwareTarget {
+                id: $id,
+                platform: TargetPlatform::All,
+                caliptra_rom: CaliptraRomSpec::DEFAULT,
+                caliptra_rt: CaliptraRtSpec::DEFAULT,
+                mcu_rom: McuRomSpec {
+                    features: &[$feature],
+                },
+                mcu_fw: McuFwSpec {
+                    id: $id,
+                    features: &[],
+                    profile: FirmwareProfile::Devel,
+                    example_app: false,
+                },
+                soc_manifest: SocManifestSpec { id: $id },
+                caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+                caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+                mcu_rom_filename: concat!("mcu-test-rom-feature-", $feature, ".bin"),
+                mcu_fw_filename: concat!("mcu-test-runtime-", $id, ".bin"),
+                soc_manifest_filename: concat!("mcu-test-soc-manifest-", $id, ".bin"),
+                flash_image_filename: concat!("mcu-test-flash-image-", $id, ".bin"),
+                pldm_fw_pkg_filename: concat!("mcu-test-pldm-fw-pkg-", $id, ".bin"),
+                update_flash_image_filename: Some(concat!(
+                    "mcu-test-update-flash-image-",
+                    $id,
+                    ".bin"
+                )),
+                user_app_elf_filename: concat!("mcu-test-user-app-elf-", $id, ".bin"),
+            };
+        };
+    }
+
+    macro_rules! rom_fw_bundle {
+        ($name:ident, $id:expr) => {
+            pub const $name: FirmwareTarget = FirmwareTarget {
+                id: $id,
+                platform: TargetPlatform::All,
+                caliptra_rom: CaliptraRomSpec::DEFAULT,
+                caliptra_rt: CaliptraRtSpec::DEFAULT,
+                mcu_rom: McuRomSpec::DEFAULT,
+                mcu_fw: McuFwSpec {
+                    id: $id,
+                    features: &[],
+                    profile: FirmwareProfile::Devel,
+                    example_app: false,
+                },
+                soc_manifest: SocManifestSpec { id: $id },
+                caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+                caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+                mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+                mcu_fw_filename: concat!("mcu-test-runtime-", $id, ".bin"),
+                soc_manifest_filename: concat!("mcu-test-soc-manifest-", $id, ".bin"),
+                flash_image_filename: concat!("mcu-test-flash-image-", $id, ".bin"),
+                pldm_fw_pkg_filename: concat!("mcu-test-pldm-fw-pkg-", $id, ".bin"),
+                update_flash_image_filename: Some(concat!(
+                    "mcu-test-update-flash-image-",
+                    $id,
+                    ".bin"
+                )),
+                user_app_elf_filename: concat!("mcu-test-user-app-elf-", $id, ".bin"),
+            };
+        };
+    }
+
+    rom_feature_fw_bundle!(TEST_I3C_SERVICES, "test-i3c-services", "test-i3c-services");
+    rom_feature_fw_bundle!(TEST_ROM_HOOKS, "test-rom-hooks", "test-rom-hooks");
+    rom_feature_fw_bundle!(TEST_DOT_RECOVERY, "test-dot-recovery", "test-dot-recovery");
+    rom_feature_fw_bundle!(
+        TEST_DOT_RECOVERY_RESET_FLOW,
+        "test-dot-recovery-reset-flow",
+        "test-dot-recovery-reset-flow"
+    );
+    rom_fw_bundle!(TEST_SVN_MANIFEST, "test-svn-manifest");
+    rom_fw_bundle!(TEST_STABLE_OWNER_KEY, "stable-owner-key");
+    fw_bundle!(
+        TEST_MCTP_SPDM_ATTESTATION,
+        "test-mctp-spdm-attestation",
+        false
+    );
+    fw_bundle!(
+        TEST_MCTP_SPDM_ATTESTATION_PCR_QUOTE,
+        "test-mctp-spdm-attestation-pcr-quote",
+        false
+    );
+    fw_bundle!(
+        TEST_MCTP_SPDM_RESPONDER_CONFORMANCE,
+        "test-mctp-spdm-responder-conformance",
+        false
+    );
+    fw_bundle!(
+        TEST_MCTP_VDM_VALIDATOR,
+        "test-caliptra-util-host-mctp-vdm-validator",
+        false
+    );
+    rom_fw_bundle!(
+        TEST_OCP_DEV_IDENTITY_PROVISION_TOOL,
+        "test-ocp-dev-identity-provision-tool"
+    );
+    fw_bundle!(
+        TEST_CALIPTRA_UTIL_HOST_SPDM_VDM_VALIDATOR,
+        "test-caliptra-util-host-spdm-vdm-validator",
+        false
+    );
+    fw_bundle!(
+        TEST_CALIPTRA_UTIL_HOST_MCU_MAILBOX_VALIDATOR,
+        "test-caliptra-util-host-validator",
+        false
+    );
+
+    bare_metal_fw_bundle!(BARE_METAL, "caliptra-mcu-bare-metal");
+    bare_metal_fw_bundle!(
+        PROVISIONING_TEST_UNLOCKED_FW,
+        "caliptra-mcu-provisioning-test-unlocked-fw"
+    );
+    rom_fw_bundle!(TEST_MAILBOX_RESPONDER, "mcu-test-rom-caliptra-mcu-test-fw-mailbox-responder-caliptra-mcu-test-fw-mailbox-responder");
+    rom_fw_bundle!(TEST_HITLESS_UPDATE_FLOW, "mcu-test-rom-caliptra-mcu-test-fw-hitless-update-flow-caliptra-mcu-test-fw-hitless-update-flow");
+    rom_fw_bundle!(
+        TEST_AXI_BYPASS,
+        "mcu-test-rom-caliptra-mcu-test-fw-axi-bypass-caliptra-mcu-test-fw-axi-bypass"
+    );
+    rom_fw_bundle!(TEST_EXCEPTION_HANDLER, "mcu-test-rom-caliptra-mcu-test-fw-exception-handler-caliptra-mcu-test-fw-exception-handler");
+    rom_fw_bundle!(
+        TEST_USB_RESPONDER,
+        "mcu-test-rom-caliptra-mcu-test-fw-usb-responder-caliptra-mcu-test-fw-usb-responder"
+    );
+    rom_fw_bundle!(TEST_USB_OCP_RECOVERY, "test-usb-ocp-recovery");
+    rom_fw_bundle!(
+        TEST_SW_DIGEST_LOCK,
+        "mcu-test-rom-caliptra-mcu-test-fw-sw-digest-lock-caliptra-mcu-test-fw-sw-digest-lock"
+    );
+    rom_fw_bundle!(
+        TEST_OTP_BLANK_CHECK,
+        "mcu-test-rom-caliptra-mcu-test-fw-otp-blank-check-caliptra-mcu-test-fw-otp-blank-check"
+    );
+    rom_fw_bundle!(TEST_OTP_SCRAMBLE_CHECK, "mcu-test-rom-caliptra-mcu-test-fw-otp-scramble-check-caliptra-mcu-test-fw-otp-scramble-check");
+    rom_fw_bundle!(
+        TEST_LC_CTRL,
+        "mcu-test-rom-caliptra-mcu-test-fw-lc-ctrl-caliptra-mcu-test-fw-lc-ctrl"
+    );
+
+    pub const TEST_DEFMT_LOGGING_RELEASE: FirmwareTarget = FirmwareTarget {
+        id: "test-defmt-logging-release",
+        platform: TargetPlatform::All,
+        caliptra_rom: CaliptraRomSpec::DEFAULT,
+        caliptra_rt: CaliptraRtSpec::DEFAULT,
+        mcu_rom: McuRomSpec::DEFAULT,
+        mcu_fw: McuFwSpec {
+            id: "test-defmt-logging-release",
+            features: &["test-defmt-logging-release", "release"],
+            profile: FirmwareProfile::Release,
+            example_app: false,
+        },
+        soc_manifest: SocManifestSpec {
+            id: "test-defmt-logging-release",
+        },
+        caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+        caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_NAME,
+        mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+        mcu_fw_filename: "mcu-test-runtime-test-defmt-logging-release.bin",
+        soc_manifest_filename: "mcu-test-soc-manifest-test-defmt-logging-release.bin",
+        flash_image_filename: "mcu-test-flash-image-test-defmt-logging-release.bin",
+        pldm_fw_pkg_filename: "mcu-test-pldm-fw-pkg-test-defmt-logging-release.bin",
+        update_flash_image_filename: Some(
+            "mcu-test-update-flash-image-test-defmt-logging-release.bin",
+        ),
+        user_app_elf_filename: "mcu-test-user-app-elf-test-defmt-logging-release.bin",
+    };
+
+    pub const TEST_OCP_LOCK: FirmwareTarget = FirmwareTarget {
+        id: "test-ocp-lock",
+        platform: TargetPlatform::All,
+        caliptra_rom: CaliptraRomSpec::DEFAULT,
+        caliptra_rt: CaliptraRtSpec::OCP_LOCK,
+        mcu_rom: McuRomSpec::OCP_LOCK,
+        mcu_fw: McuFwSpec {
+            id: "test-ocp-lock",
+            features: &["test-ocp-lock"],
+            profile: FirmwareProfile::Devel,
+            example_app: true,
+        },
+        soc_manifest: SocManifestSpec {
+            id: "test-ocp-lock",
+        },
+        caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+        caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_OCP_LOCK_NAME,
+        mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+        mcu_fw_filename: "mcu-test-runtime-test-ocp-lock.bin",
+        soc_manifest_filename: "mcu-test-soc-manifest-test-ocp-lock.bin",
+        flash_image_filename: "mcu-test-flash-image-test-ocp-lock.bin",
+        pldm_fw_pkg_filename: "mcu-test-pldm-fw-pkg-test-ocp-lock.bin",
+        update_flash_image_filename: Some("mcu-test-update-flash-image-test-ocp-lock.bin"),
+        user_app_elf_filename: "mcu-test-user-app-elf-test-ocp-lock.bin",
+    };
+
+    pub const TEST_MCU_SVN_GT_FUSE: FirmwareTarget = FirmwareTarget {
+        id: "test-mcu-svn-gt-fuse",
+        platform: TargetPlatform::All,
+        caliptra_rom: CaliptraRomSpec::DEFAULT,
+        caliptra_rt: CaliptraRtSpec::SVN7,
+        mcu_rom: McuRomSpec::DEFAULT,
+        mcu_fw: McuFwSpec {
+            id: "test-mcu-svn-gt-fuse",
+            features: &[],
+            profile: FirmwareProfile::Devel,
+            example_app: false,
+        },
+        soc_manifest: SocManifestSpec {
+            id: "test-mcu-svn-gt-fuse",
+        },
+        caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+        caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_SVN7_NAME,
+        mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+        mcu_fw_filename: "mcu-test-runtime-test-mcu-svn-gt-fuse.bin",
+        soc_manifest_filename: "mcu-test-soc-manifest-test-mcu-svn-gt-fuse.bin",
+        flash_image_filename: "mcu-test-flash-image-test-mcu-svn-gt-fuse.bin",
+        pldm_fw_pkg_filename: "mcu-test-pldm-fw-pkg-test-mcu-svn-gt-fuse.bin",
+        update_flash_image_filename: Some("mcu-test-update-flash-image-test-mcu-svn-gt-fuse.bin"),
+        user_app_elf_filename: "mcu-test-user-app-elf-test-mcu-svn-gt-fuse.bin",
+    };
+
+    pub const TEST_MCU_SVN_LT_FUSE: FirmwareTarget = FirmwareTarget {
+        id: "test-mcu-svn-lt-fuse",
+        platform: TargetPlatform::All,
+        caliptra_rom: CaliptraRomSpec::DEFAULT,
+        caliptra_rt: CaliptraRtSpec::SVN128,
+        mcu_rom: McuRomSpec::DEFAULT,
+        mcu_fw: McuFwSpec {
+            id: "test-mcu-svn-lt-fuse",
+            features: &[],
+            profile: FirmwareProfile::Devel,
+            example_app: false,
+        },
+        soc_manifest: SocManifestSpec {
+            id: "test-mcu-svn-lt-fuse",
+        },
+        caliptra_rom_filename: FirmwareBinaries::CALIPTRA_ROM_NAME,
+        caliptra_rt_filename: FirmwareBinaries::CALIPTRA_FW_SVN128_NAME,
+        mcu_rom_filename: FirmwareBinaries::MCU_ROM_NAME,
+        mcu_fw_filename: "mcu-test-runtime-test-mcu-svn-lt-fuse.bin",
+        soc_manifest_filename: "mcu-test-soc-manifest-test-mcu-svn-lt-fuse.bin",
+        flash_image_filename: "mcu-test-flash-image-test-mcu-svn-lt-fuse.bin",
+        pldm_fw_pkg_filename: "mcu-test-pldm-fw-pkg-test-mcu-svn-lt-fuse.bin",
+        update_flash_image_filename: Some("mcu-test-update-flash-image-test-mcu-svn-lt-fuse.bin"),
+        user_app_elf_filename: "mcu-test-user-app-elf-test-mcu-svn-lt-fuse.bin",
+    };
+
+    pub const FIRMWARE_TARGETS: &[&FirmwareTarget] = &[
+        &TEST_ACTIVE_I3C1,
+        &TEST_I3C_SIMPLE,
+        &TEST_I3C_CONSTANT_WRITES,
+        &TEST_MCTP_CAPSULE_LOOPBACK,
+        &TEST_FIRMWARE_UPDATE_STREAMING,
+        &TEST_STREAMING_BOOT_FLASH_WRITE_BACK,
+        &TEST_FIRMWARE_UPDATE_FLASH,
+        &TEST_FLASH_BASED_BOOT,
+        &TEST_PLDM_STREAMING_BOOT,
+        &TEST_PLDM_FW_UPDATE_E2E,
+        &TEST_DO_NOTHING,
+        &TEST_CALIPTRA_CERTS,
+        &TEST_CALIPTRA_CRYPTO,
+        &TEST_CALIPTRA_MAILBOX,
+        &TEST_DMA,
+        &TEST_DOE_TRANSPORT_LOOPBACK,
+        &TEST_DOE_USER_LOOPBACK,
+        &TEST_DOE_DISCOVERY,
+        &TEST_GET_DEVICE_STATE,
+        &TEST_FLASH_CTRL_INIT,
+        &TEST_FLASH_CTRL_READ_WRITE_PAGE,
+        &TEST_FLASH_CTRL_ERASE_PAGE,
+        &TEST_FLASH_STORAGE_READ_WRITE,
+        &TEST_FLASH_STORAGE_ERASE,
+        &TEST_FLASH_USERMODE,
+        &TEST_LOG_FLASH_CIRCULAR,
+        &TEST_LOG_FLASH_LINEAR,
+        &TEST_LOG_FLASH_USERMODE,
+        &TEST_DEFMT_LOGGING_MAILBOX,
+        &TEST_DEFMT_LOGGING_RELEASE,
+        &TEST_DEFMT_LOGGING_VDM,
+        &TEST_MCTP_CTRL_CMDS,
+        &TEST_MCTP_USER_LOOPBACK,
+        &TEST_MCTP_VDM_CMDS,
+        &TEST_PLDM_DISCOVERY,
+        &TEST_PLDM_FW_UPDATE,
+        &TEST_MCI,
+        &TEST_MCU_MBOX_DRIVER,
+        &TEST_MCU_MBOX_SOC_REQUESTER_LOOPBACK,
+        &TEST_MCU_MBOX_CMDS,
+        &TEST_MBOX_SRAM,
+        &TEST_EXTERNAL_OTP,
+        &TEST_HANDOFF,
+        &TEST_DPE_HANDLE_STORE,
+        &TEST_SW_PCR_STORE,
+        &TEST_WARM_RESET,
+        &TEST_OCP_LOCK,
+        &TEST_EXIT_IMMEDIATELY,
+        &TEST_MCU_ROM_FLASH_ACCESS,
+        &TEST_MCU_SVN_GT_FUSE,
+        &TEST_MCU_SVN_LT_FUSE,
+        &TEST_USB_OCP_RECOVERY,
+        &TEST_I3C_SERVICES,
+        &TEST_ROM_HOOKS,
+        &TEST_DOT_RECOVERY,
+        &TEST_DOT_RECOVERY_RESET_FLOW,
+        &TEST_SVN_MANIFEST,
+        &TEST_STABLE_OWNER_KEY,
+        &TEST_MCTP_SPDM_ATTESTATION,
+        &TEST_MCTP_SPDM_ATTESTATION_PCR_QUOTE,
+        &TEST_MCTP_SPDM_RESPONDER_CONFORMANCE,
+        &TEST_MCTP_VDM_VALIDATOR,
+        &TEST_OCP_DEV_IDENTITY_PROVISION_TOOL,
+        &TEST_CALIPTRA_UTIL_HOST_SPDM_VDM_VALIDATOR,
+        &TEST_CALIPTRA_UTIL_HOST_MCU_MAILBOX_VALIDATOR,
+        &BARE_METAL,
+        &PROVISIONING_TEST_UNLOCKED_FW,
+        &TEST_MAILBOX_RESPONDER,
+        &TEST_HITLESS_UPDATE_FLOW,
+        &TEST_AXI_BYPASS,
+        &TEST_EXCEPTION_HANDLER,
+        &TEST_USB_RESPONDER,
+        &TEST_SW_DIGEST_LOCK,
+        &TEST_OTP_BLANK_CHECK,
+        &TEST_OTP_SCRAMBLE_CHECK,
+        &TEST_LC_CTRL,
+    ];
+}

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -12,7 +12,9 @@ mod runtime;
 mod utils;
 
 pub use all::{
-    all_build, emulator_build, AllBuildArgs, EmulatorBinaries, EmulatorBuildArgs, FirmwareBinaries,
+    all_build, emulator_build, AllBuildArgs, CaliptraRomBinary, CaliptraRtBinary, EmulatorBinaries,
+    EmulatorBuildArgs, FirmwareBinaries, FirmwareBundle, McuFwBinary, McuRomBinary,
+    SocManifestBinary,
 };
 pub use caliptra::{AuthManifestOwnerConfig, CaliptraBuilder, ImageCfg};
 pub use network_rom::network_rom_build;

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -257,7 +257,34 @@ pub struct InitParams<'a> {
     pub skip_otp_provisioning: bool,
 }
 
-impl InitParams<'_> {
+impl<'a> InitParams<'a> {
+    pub fn from_bundle(bundle: &'a caliptra_mcu_builder::FirmwareBundle) -> Self {
+        Self {
+            caliptra_rom: &bundle.caliptra_rom,
+            caliptra_firmware: &bundle.caliptra_rt,
+            soc_manifest: &bundle.soc_manifest,
+            mcu_rom: &bundle.mcu_rom,
+            mcu_firmware: &bundle.mcu_fw.bytes,
+            ..Default::default()
+        }
+    }
+
+    pub fn from_target(
+        binaries: &'a caliptra_mcu_builder::FirmwareBinaries,
+        target: &caliptra_mcu_builder::firmware::FirmwareTarget,
+    ) -> Self {
+        Self::from_bundle(binaries.as_bundle(target))
+    }
+
+    pub fn with_bundle(mut self, bundle: &'a caliptra_mcu_builder::FirmwareBundle) -> Self {
+        self.caliptra_rom = &bundle.caliptra_rom;
+        self.caliptra_firmware = &bundle.caliptra_rt;
+        self.soc_manifest = &bundle.soc_manifest;
+        self.mcu_rom = &bundle.mcu_rom;
+        self.mcu_firmware = &bundle.mcu_fw.bytes;
+        self
+    }
+
     pub fn summary(&self) -> InitParamsSummary {
         InitParamsSummary {
             rom_sha384: sha2::Sha384::digest(self.mcu_rom).into(),
@@ -938,12 +965,13 @@ fn mbox_read_fifo(mbox: caliptra_registers::mbox::RegisterBlock<impl MmioMut>) -
 #[test]
 fn reg_access_test() {
     let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env().unwrap();
+    let bundle = binaries.as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
 
     // Build flash image from firmware binaries
     let flash_image = build_flash_image_bytes(
-        Some(&binaries.caliptra_fw),
-        Some(&binaries.soc_manifest),
-        Some(&binaries.mcu_runtime),
+        Some(&bundle.caliptra_rt),
+        Some(&bundle.soc_manifest),
+        Some(&bundle.mcu_fw.bytes),
     );
 
     let mut hw = new(InitParams {
@@ -965,13 +993,11 @@ fn reg_access_test() {
             },
             ..Default::default()
         },
-        caliptra_rom: &binaries.caliptra_rom,
-        mcu_rom: &binaries.mcu_rom,
         vendor_pk_hash: binaries.vendor_pk_hash(),
         active_mode: true,
         vendor_pqc_type: Some(FwVerificationPqcKeyType::LMS),
         primary_flash_initial_contents: Some(flash_image),
-        ..Default::default()
+        ..InitParams::from_bundle(bundle)
     })
     .unwrap();
 
@@ -1019,8 +1045,9 @@ mod tests {
 
     #[test]
     pub fn test_mailbox_execute() -> Result<()> {
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_MAILBOX_RESPONDER;
         let mcu_rom = if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            binaries.test_rom(&firmware::hw_model_tests::MAILBOX_RESPONDER)?
+            binaries.as_bundle(target).mcu_rom.to_vec()
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {
                 platform: Some(platform()),
@@ -1086,8 +1113,9 @@ mod tests {
     #[cfg(not(feature = "fpga_realtime"))]
     #[test]
     pub fn test_usb_loopback() -> Result<()> {
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_USB_RESPONDER;
         let mcu_rom = if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            binaries.test_rom(&firmware::hw_model_tests::USB_RESPONDER)?
+            binaries.as_bundle(target).mcu_rom.to_vec()
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {
                 platform: Some(platform()),
@@ -1159,8 +1187,9 @@ mod tests {
     #[cfg(not(feature = "fpga_realtime"))]
     #[test]
     pub fn test_usb_ocp_recovery() -> Result<()> {
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_USB_OCP_RECOVERY;
         let mcu_rom = if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            binaries.test_rom(&firmware::hw_model_tests::USB_OCP_RECOVERY)?
+            binaries.as_bundle(target).mcu_rom.to_vec()
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {
                 platform: Some(platform()),

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -842,13 +842,15 @@ mod test {
     fn test_new_unbooted() {
         let (mcu_rom, mcu_runtime, caliptra_rom, caliptra_fw, vendor_pk_hash, soc_manifest) =
             if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
+                let bundle =
+                    binaries.as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
                 (
-                    binaries.mcu_rom.clone(),
-                    binaries.mcu_runtime.clone(),
-                    binaries.caliptra_rom.clone(),
-                    binaries.caliptra_fw.clone(),
+                    bundle.mcu_rom.to_vec(),
+                    bundle.mcu_fw.bytes.clone(),
+                    bundle.caliptra_rom.to_vec(),
+                    bundle.caliptra_rt.to_vec(),
                     binaries.vendor_pk_hash().unwrap(),
-                    binaries.soc_manifest.clone(),
+                    bundle.soc_manifest.to_vec(),
                 )
             } else {
                 let mcu_rom = caliptra_mcu_builder::rom_build(&CaliptraBuildArgs::default())

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -971,21 +971,21 @@ mod tests {
         use crate::DefaultHwModel;
 
         let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env().unwrap();
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING;
+        let bundle = binaries.as_bundle(target);
 
         // Build flash image from firmware binaries
         let flash_image = build_flash_image_bytes(
-            Some(&binaries.caliptra_fw),
-            Some(&binaries.soc_manifest),
-            Some(&binaries.mcu_runtime),
+            Some(&bundle.caliptra_rt),
+            Some(&bundle.soc_manifest),
+            Some(&bundle.mcu_fw.bytes),
         );
 
         let mut hw = new(InitParams {
-            caliptra_rom: &binaries.caliptra_rom,
-            mcu_rom: &binaries.mcu_rom,
             vendor_pk_hash: binaries.vendor_pk_hash(),
             active_mode: true,
             primary_flash_initial_contents: Some(flash_image),
-            ..Default::default()
+            ..InitParams::from_bundle(bundle)
         })
         .unwrap();
 

--- a/tests/integration/src/jtag/test_bare_metal_jtag.rs
+++ b/tests/integration/src/jtag/test_bare_metal_jtag.rs
@@ -26,9 +26,8 @@ mod test {
 
         // Pull bare-metal bytes from prebuilt bundle environment.
         let binaries = FirmwareBinaries::from_env().expect("Firmware bundle not found");
-        let bare_metal_bytes = binaries
-            .get_bare_metal("caliptra-mcu-bare-metal")
-            .expect("mcu_bare_metal binary not found");
+        let target = &caliptra_mcu_builder::firmware::targets::BARE_METAL;
+        let bare_metal_bytes = &binaries.as_bundle(target).mcu_fw.bytes;
         assert!(
             !bare_metal_bytes.is_empty(),
             "mcu_bare_metal binary is empty"

--- a/tests/integration/src/jtag/test_provisioning.rs
+++ b/tests/integration/src/jtag/test_provisioning.rs
@@ -38,9 +38,8 @@ mod test {
 
         // Pull provisioning FW from bundle
         let binaries = FirmwareBinaries::from_env().expect("Firmware bundle not found");
-        let bare_metal_bytes = binaries
-            .get_bare_metal("caliptra-mcu-provisioning-test-unlocked-fw")
-            .expect("caliptra-mcu-provisioning-test-unlocked-fw binary not found");
+        let target = &caliptra_mcu_builder::firmware::targets::PROVISIONING_TEST_UNLOCKED_FW;
+        let bare_metal_bytes = &binaries.as_bundle(target).mcu_fw.bytes;
         assert!(
             !bare_metal_bytes.is_empty(),
             "caliptra-mcu-provisioning-test-unlocked-fw binary is empty"

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -54,6 +54,7 @@ pub fn platform() -> &'static str {
 
 #[cfg(test)]
 mod test {
+    use caliptra_mcu_builder::firmware::FirmwareTarget;
     use caliptra_mcu_builder::flash_image::build_flash_image_bytes;
     use caliptra_mcu_builder::{
         target_dir, CaliptraBuildArgs, CaliptraBuilder, EmulatorBinaries, FirmwareBinaries,
@@ -63,7 +64,7 @@ mod test {
     use caliptra_mcu_hw_model::{DefaultHwModel, Fuses, InitParams, McuHwModel};
     use caliptra_mcu_testing_common::DeviceLifecycle;
     use random_port::PortPicker;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::AtomicU32;
     use std::sync::{Arc, Mutex};
     use std::{
         path::{Path, PathBuf},
@@ -84,8 +85,7 @@ mod test {
     }
 
     pub struct TestParams<'a> {
-        pub feature: Option<&'a str>,
-        pub rom_feature: Option<&'a str>,
+        pub target: &'static caliptra_mcu_builder::firmware::FirmwareTarget,
         pub network_rom_feature: Option<&'a str>,
         pub i3c_port: Option<u16>,
         pub dot_flash_initial_contents: Option<Vec<u8>>,
@@ -101,7 +101,6 @@ mod test {
         pub otp_memory: Option<Vec<u8>>,
         /// Enable FIPS zeroization PPD signal for cold boot testing.
         pub fips_zeroization: bool,
-        pub ocp_lock_en: bool,
         /// If true, drive the MCI generic input wire strap that forces the ROM
         /// to use the `CPTRA_SS_OWNER_PK_HASH` fuse as the owner, bypassing DOT.
         pub force_fuse_owner_pk_hash: bool,
@@ -111,7 +110,6 @@ mod test {
         pub custom_mcu_runtime: Option<Vec<u8>>,
         /// Optional bytes to prepend to the MCU firmware image (e.g., a manifest header).
         pub firmware_prefix: Option<Vec<u8>>,
-        pub fw_manifest_dot_hitless: bool,
         #[allow(dead_code)]
         pub active_i3c1: bool,
         pub lifecycle_controller_state: Option<caliptra_mcu_romtime::LifecycleControllerState>,
@@ -125,22 +123,23 @@ mod test {
         /// with these entries before the firmware boots. Honored on both
         /// emulator and FPGA via `BootParams::primary_flash_initial_contents`.
         pub seeded_log_entries: Option<&'static [&'static [u8]]>,
-        /// If true, include the example app in the runtime build instead of the user app.
-        pub example_app: bool,
-        /// Cargo profile to use for a from-source runtime build.
-        pub profile: Option<&'a str>,
-        /// Override the Caliptra firmware SVN. Forces a from-source
-        /// Caliptra FW + SoC manifest build (ignoring any prebuilt
-        /// Caliptra FW) so the reported `FW_INFO.fw_svn` is known. Only
-        /// honored on the `firmware_prefix` build path.
-        pub caliptra_svn: Option<u16>,
+    }
+
+    impl TestParams<'_> {
+        pub fn from_target(
+            target: &'static caliptra_mcu_builder::firmware::FirmwareTarget,
+        ) -> Self {
+            Self {
+                target,
+                ..Default::default()
+            }
+        }
     }
 
     impl Default for TestParams<'_> {
         fn default() -> Self {
             Self {
-                feature: None,
-                rom_feature: None,
+                target: &caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING,
                 network_rom_feature: None,
                 i3c_port: None,
                 dot_flash_initial_contents: None,
@@ -152,12 +151,10 @@ mod test {
                 custom_caliptra_fw: None,
                 otp_memory: None,
                 fips_zeroization: false,
-                ocp_lock_en: false,
                 force_fuse_owner_pk_hash: false,
                 custom_mcu_rom: None,
                 custom_mcu_runtime: None,
                 firmware_prefix: None,
-                fw_manifest_dot_hitless: false,
                 active_i3c1: false,
                 lifecycle_controller_state: None,
                 vendor_pqc_type: Some(caliptra_image_types::FwVerificationPqcKeyType::LMS),
@@ -165,9 +162,6 @@ mod test {
                 prod_dbg_unlock_keypairs: Vec::new(),
                 use_strap_secrets: false,
                 seeded_log_entries: None,
-                example_app: false,
-                profile: None,
-                caliptra_svn: None,
             }
         }
     }
@@ -184,56 +178,38 @@ mod test {
         target_dir().join(TARGET).join("release").join(name)
     }
 
-    // Get ROM from prebuilt or compile
-    fn get_or_compile_rom(feature: &str) -> PathBuf {
-        if let Ok(binaries) = FirmwareBinaries::from_env() {
-            // Empty feature → use the generic prebuilt ROM.
-            // Otherwise, only use the prebuilt ROM if it was actually built
-            // for the requested feature (i.e. don't silently fall back to the
-            // generic ROM which lacks the requested feature flags).
-            let rom_data = if feature.is_empty() {
-                Some(binaries.mcu_rom.clone())
-            } else {
-                let expected_name = format!("mcu-test-rom-feature-{}.bin", feature);
-                binaries
-                    .test_roms
-                    .iter()
-                    .find(|(name, _)| name == &expected_name)
-                    .map(|(_, data)| data.clone())
-            };
-            if let Some(rom_data) = rom_data {
-                let safe_name = feature.replace('/', "_");
-                let filename = if safe_name.is_empty() {
-                    "mcu_rom_prebuilt.bin".to_string()
-                } else {
-                    format!("mcu_rom_prebuilt_{}.bin", safe_name)
-                };
-                let output = target_binary(&filename);
-                if let Some(parent) = output.parent() {
-                    std::fs::create_dir_all(parent).ok();
-                }
-                std::fs::write(&output, &rom_data).expect("Failed to write prebuilt ROM to file");
-                return output;
-            }
+    fn get_or_compile_rom(target: &FirmwareTarget) -> PathBuf {
+        let binaries = FirmwareBinaries::from_env().unwrap();
+        let bundle = binaries.as_bundle(target);
+        let safe_name = target.id().replace('/', "_");
+        let filename = format!("mcu_rom_prebuilt_{}.bin", safe_name);
+        let output = target_binary(&filename);
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).ok();
         }
-        // Fall back to compilation
-        compile_rom(feature)
+        std::fs::write(&output, &bundle.mcu_rom.0).expect("Failed to write prebuilt ROM to file");
+        output
     }
 
     // only build the default ROM once
-    pub static ROM: LazyLock<PathBuf> = LazyLock::new(|| get_or_compile_rom(""));
-    pub static ROM_FW_MANIFEST_DOT: LazyLock<Vec<u8>> =
-        LazyLock::new(|| std::fs::read(get_or_compile_rom("test-fw-manifest-dot")).unwrap());
-    pub static ROM_FW_MANIFEST_DOT_HITLESS: LazyLock<Vec<u8>> = LazyLock::new(|| {
-        std::fs::read(get_or_compile_rom("test-fw-manifest-dot-hitless")).unwrap()
+    pub static ROM: LazyLock<PathBuf> = LazyLock::new(|| {
+        get_or_compile_rom(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING)
     });
 
     pub static TEST_LOCK: LazyLock<Mutex<AtomicU32>> =
         LazyLock::new(|| Mutex::new(AtomicU32::new(0)));
 
-    // Compile the ROM for a given feature flag (empty string for default ROM).
+    pub fn get_rom_for_target(target: &FirmwareTarget) -> PathBuf {
+        get_or_compile_rom(target)
+    }
+
     pub fn get_rom_with_feature(feature: &str) -> PathBuf {
-        get_or_compile_rom(feature)
+        let target = caliptra_mcu_builder::firmware::targets::FIRMWARE_TARGETS
+            .iter()
+            .find(|t| t.id() == feature || (feature.is_empty() && t.id() == "test-do-nothing"))
+            .copied()
+            .unwrap_or(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
+        get_or_compile_rom(target)
     }
 
     fn platform() -> &'static str {
@@ -241,37 +217,6 @@ mod test {
             "fpga"
         } else {
             "emulator"
-        }
-    }
-
-    fn compile_rom(feature: &str) -> PathBuf {
-        let requested_feature = feature;
-        let feature = if TEST_HW_REVISION == "2.1.0" {
-            if feature.is_empty() {
-                "hw-2-1".to_string()
-            } else {
-                format!("hw-2-1,{feature}")
-            }
-        } else {
-            feature.to_string()
-        };
-        // Return the feature-suffixed path directly from rom_build.
-        // Do NOT copy to a generic name: subsequent builds re-create the
-        // intermediate mcu-rom-<platform>.bin (without the appended ROM
-        // digest), which would silently clobber the copy.
-        let output: PathBuf = caliptra_mcu_builder::rom_build(&CaliptraBuildArgs {
-            platform: Some(platform()),
-            features: Some(&feature),
-            ..Default::default()
-        })
-        .expect("ROM build failed");
-        assert!(output.exists());
-        if requested_feature.is_empty() {
-            let stable_output = target_binary(&format!("mcu_rom_default_{}.bin", platform()));
-            std::fs::copy(&output, &stable_output).expect("Failed to copy default MCU ROM");
-            stable_output
-        } else {
-            output
         }
     }
 
@@ -328,73 +273,6 @@ mod test {
         .expect("Runtime failed to compile");
         assert!(output.exists());
         output
-    }
-
-    /// Check if a prebuilt feature-specific MCU ROM is available.
-    pub fn has_prebuilt_rom(feature: &str) -> bool {
-        if let Ok(binaries) = FirmwareBinaries::from_env() {
-            // test_feature_rom always returns data (falls back to generic ROM)
-            let _ = binaries.test_feature_rom(feature);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Check if prebuilt binaries are available for the given feature.
-    pub fn has_prebuilt_binaries(feature: &str) -> bool {
-        if let Ok(binaries) = FirmwareBinaries::from_env() {
-            binaries.test_runtime(feature).is_ok() && binaries.test_soc_manifest(feature).is_ok()
-        } else {
-            false
-        }
-    }
-
-    pub struct TestBinaries {
-        pub vendor_pk_hash_u8: Vec<u8>,
-        pub caliptra_rom: Vec<u8>,
-        pub caliptra_fw: Vec<u8>,
-        pub mcu_rom: Vec<u8>,
-        pub soc_manifest: Vec<u8>,
-        pub mcu_runtime: Vec<u8>,
-    }
-
-    fn prebuilt_binaries(params: &TestParams, binaries: &'static FirmwareBinaries) -> TestBinaries {
-        let is_ocp_lock = params.ocp_lock_en
-            || params.feature.is_some_and(|f| f.contains("ocp-lock"))
-            || params.rom_feature.is_some_and(|f| f.contains("ocp-lock"));
-        let caliptra_fw = if is_ocp_lock {
-            binaries.caliptra_fw_ocp_lock.clone()
-        } else {
-            binaries.caliptra_fw.clone()
-        };
-        let mut test_binaries = TestBinaries {
-            vendor_pk_hash_u8: binaries
-                .vendor_pk_hash()
-                .expect("Failed to get Vendor PK hash")
-                .to_vec(),
-            caliptra_rom: binaries.caliptra_rom.clone(),
-            caliptra_fw,
-            mcu_rom: binaries.mcu_rom.clone(),
-            soc_manifest: binaries.soc_manifest.clone(),
-            mcu_runtime: binaries.mcu_runtime.clone(),
-        };
-
-        // check for prebuilt binaries for our test feature
-        if let Some(feature) = params.feature {
-            let err = format!(
-                "Failed to get MCU firmware and manifest for feature {}",
-                feature
-            );
-            test_binaries.soc_manifest = binaries.test_soc_manifest(feature).expect(&err).clone();
-            test_binaries.mcu_runtime = binaries.test_runtime(feature).expect(&err).clone();
-        }
-
-        if let Some(rom_feature) = params.rom_feature {
-            test_binaries.mcu_rom = binaries.test_feature_rom(rom_feature);
-        }
-
-        test_binaries
     }
 
     // Sample IDevID ECC Cert (same as ECC_DEVID_CERT_DER in external_otp component)
@@ -1001,195 +879,39 @@ mod test {
         Some(flash)
     }
 
-    pub fn build_test_binaries(params: &TestParams) -> TestBinaries {
-        // Get MCU runtime: prefer an explicit override, then prebuilt for the
-        // requested feature, and fall back to compilation.
-        let mcu_runtime_path = if let Some(runtime_bytes) = params.custom_mcu_runtime.as_ref() {
-            let path = target_binary("mcu_runtime_custom_for_builder.bin");
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).ok();
-            }
-            std::fs::write(&path, runtime_bytes).expect("Failed to write custom runtime to file");
-            path
-        } else if let Ok(binaries) = FirmwareBinaries::from_env() {
-            let runtime_bytes = if let Some(feature) = params.feature {
-                match binaries.test_runtime(feature) {
-                    Ok(bytes) => Some(bytes.clone()),
-                    Err(_) => None,
-                }
-            } else {
-                Some(binaries.mcu_runtime.clone())
-            };
-            if let Some(bytes) = runtime_bytes {
-                let path = target_binary("mcu_runtime_prebuilt_for_builder.bin");
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).ok();
-                }
-                std::fs::write(&path, &bytes).expect("Failed to write prebuilt runtime to file");
-                path
-            } else if params.rom_only {
-                compile_runtime(None, false)
-            } else {
-                compile_runtime(params.feature, false)
-            }
-        } else if params.rom_only {
-            compile_runtime(None, false)
-        } else {
-            compile_runtime_with_profile(params.feature, params.example_app, params.profile)
-        };
-
-        // When a firmware prefix is provided, create a modified binary that
-        // includes the prefix so the SOC manifest digest covers both.
-        let (mcu_runtime_for_builder, mcu_runtime_bytes) =
-            if let Some(prefix) = &params.firmware_prefix {
-                let original = if params.rom_only {
-                    // RISC-V "j ." (jump to self) instruction: 0x0000006f.
-                    // We provide it as a small byte array.
-                    vec![0x6f, 0x00, 0x00, 0x00, 0x6f, 0x00, 0x00, 0x00]
-                } else {
-                    std::fs::read(&mcu_runtime_path).unwrap()
-                };
-                let mut prefixed = prefix.to_vec();
-                prefixed.extend_from_slice(&original);
-
-                // Write the prefixed binary to a temp file for CaliptraBuilder
-                let prefixed_path = mcu_runtime_path.with_extension("prefixed");
-                std::fs::write(&prefixed_path, &prefixed).unwrap();
-                (prefixed_path, prefixed)
-            } else {
-                let bytes = std::fs::read(&mcu_runtime_path).unwrap();
-                (mcu_runtime_path, bytes)
-            };
-
-        // When prebuilt binaries are available, pass the Caliptra ROM/FW paths
-        // to the builder so it doesn't try to compile them from scratch.
-        let (prebuilt_caliptra_rom, prebuilt_caliptra_fw, prebuilt_vendor_pk_hash) =
-            if let Ok(binaries) = FirmwareBinaries::from_env() {
-                let rom_path =
-                    std::env::temp_dir().join("build_test_binaries_caliptra_rom_prebuilt.bin");
-                std::fs::write(&rom_path, &binaries.caliptra_rom)
-                    .expect("Failed to write prebuilt Caliptra ROM");
-                let is_ocp_lock = params.ocp_lock_en
-                    || params.feature.is_some_and(|f| f.contains("ocp-lock"))
-                    || params.rom_feature.is_some_and(|f| f.contains("ocp-lock"));
-                let fw_data = if is_ocp_lock {
-                    &binaries.caliptra_fw_ocp_lock
-                } else {
-                    &binaries.caliptra_fw
-                };
-                let fw_path =
-                    std::env::temp_dir().join("build_test_binaries_caliptra_fw_prebuilt.bin");
-                std::fs::write(&fw_path, fw_data).expect("Failed to write prebuilt Caliptra FW");
-                let vendor_pk_hash = hex::encode(
-                    binaries
-                        .vendor_pk_hash()
-                        .expect("Failed to get vendor PK hash from prebuilt binaries"),
-                );
-                (Some(rom_path), Some(fw_path), Some(vendor_pk_hash))
-            } else {
-                (None, None, None)
-            };
-
-        // When a Caliptra SVN override is requested, force a from-source
-        // build of the Caliptra FW (and matching SoC manifest) so the
-        // requested SVN is honored rather than a prebuilt SVN-0 image.
-        let (prebuilt_caliptra_fw, prebuilt_vendor_pk_hash) = if params.caliptra_svn.is_some() {
-            (None, None)
-        } else {
-            (prebuilt_caliptra_fw, prebuilt_vendor_pk_hash)
-        };
-
-        let mut builder = CaliptraBuilder::new(&caliptra_mcu_builder::CaliptraBuildArgs {
-            fpga: cfg!(feature = "fpga_realtime"),
-            ocp_lock: params
-                .feature
-                .map(|f| f.contains("ocp-lock"))
-                .unwrap_or(false)
-                || params.ocp_lock_en,
-            caliptra_rom: prebuilt_caliptra_rom,
-            caliptra_firmware: prebuilt_caliptra_fw,
-            vendor_pk_hash: prebuilt_vendor_pk_hash,
-            mcu_firmware: Some(mcu_runtime_for_builder),
-            svn: params.caliptra_svn,
-            ..Default::default()
-        });
-        let caliptra_rom = std::fs::read(
-            builder
-                .get_caliptra_rom()
-                .expect("Failed to build Caliptra ROM"),
-        )
-        .unwrap();
-
-        let caliptra_fw = std::fs::read(
-            builder
-                .get_caliptra_fw()
-                .expect("Failed to build Caliptra ROM"),
-        )
-        .unwrap();
-
-        let mcu_rom = if params.firmware_prefix.is_some() && params.rom_feature.is_none() {
-            if params.fw_manifest_dot_hitless {
-                ROM_FW_MANIFEST_DOT_HITLESS.clone()
-            } else {
-                ROM_FW_MANIFEST_DOT.clone()
-            }
-        } else if let Some(f) = params.rom_feature {
-            std::fs::read(compile_rom(f)).unwrap()
-        } else if params.rom_only && params.feature.is_some() {
-            std::fs::read(compile_rom(params.feature.unwrap())).unwrap()
-        } else {
-            std::fs::read(ROM.to_path_buf()).unwrap()
-        };
-        let soc_manifest = std::fs::read(
-            builder
-                .get_soc_manifest(None)
-                .expect("Failed to build SoC manifest"),
-        )
-        .unwrap();
-        let vendor_pk_hash_u8 = hex::decode(builder.get_vendor_pk_hash().unwrap())
-            .expect("Invalid hex string for vendor_pk_hash");
-
-        TestBinaries {
-            vendor_pk_hash_u8,
-            caliptra_rom,
-            caliptra_fw,
-            mcu_rom,
-            soc_manifest,
-            mcu_runtime: mcu_runtime_bytes,
-        }
-    }
-
     pub fn start_runtime_hw_model(params: TestParams) -> DefaultHwModel {
-        let TestBinaries {
-            vendor_pk_hash_u8,
-            caliptra_rom,
-            caliptra_fw,
-            mcu_rom,
-            soc_manifest,
-            mcu_runtime,
-        } = match FirmwareBinaries::from_env() {
-            Ok(binaries)
-                if params.firmware_prefix.is_none()
-                    && params.custom_mcu_runtime.is_none()
-                    && (params.rom_feature.is_none()
-                        || has_prebuilt_rom(params.rom_feature.unwrap()))
-                    && (params.feature.is_none()
-                        || has_prebuilt_binaries(params.feature.unwrap())) =>
-            {
-                prebuilt_binaries(&params, binaries)
-            }
-            _ => {
-                println!("Could not find prebuilt firmware binaries, building firmware...");
-                build_test_binaries(&params)
-            }
-        };
+        let binaries = FirmwareBinaries::from_env().unwrap();
+        let bundle = binaries.as_bundle(params.target);
 
-        // Use custom MCU ROM if provided, otherwise use prebuilt/compiled
+        let vendor_pk_hash_u8 = binaries
+            .vendor_pk_hash_for_target(params.target)
+            .unwrap_or_else(|| {
+                binaries
+                    .vendor_pk_hash()
+                    .expect("Failed to get Vendor PK hash")
+            })
+            .to_vec();
+
+        let caliptra_rom = bundle.caliptra_rom.0.clone();
+        let caliptra_fw = bundle.caliptra_rt.0.clone();
         let mcu_rom = if let Some(custom_rom) = params.custom_mcu_rom {
             custom_rom
         } else {
-            mcu_rom
+            bundle.mcu_rom.0.clone()
         };
+        let mcu_runtime = if let Some(custom_rt) = params.custom_mcu_runtime {
+            custom_rt
+        } else {
+            bundle.mcu_fw.bytes.clone()
+        };
+        let mcu_runtime = if let Some(prefix) = &params.firmware_prefix {
+            let mut prefixed = prefix.clone();
+            prefixed.extend_from_slice(&mcu_runtime);
+            prefixed
+        } else {
+            mcu_runtime
+        };
+        let soc_manifest = bundle.soc_manifest.0.clone();
 
         // Use custom Caliptra FW if provided, otherwise use prebuilt/compiled
         let (caliptra_fw, vendor_pk_hash_u8, soc_manifest) =
@@ -1337,7 +1059,11 @@ mod test {
             otp_memory: otp_memory.as_deref(),
             primary_flash_initial_contents,
             flash_boot: params.flash_boot,
-            ocp_lock_en: params.ocp_lock_en,
+            ocp_lock_en: params
+                .target
+                .caliptra_rt_spec()
+                .features()
+                .contains(&"ocp-lock"),
             fips_zeroization: params.fips_zeroization,
             force_fuse_owner_pk_hash: params.force_fuse_owner_pk_hash,
             debug_intent: params.debug_intent,
@@ -1642,68 +1368,59 @@ mod test {
     }
 
     /// Get prebuilt runtime from FirmwareBinaries if available, writing it to a temp file.
-    /// Returns the path to the runtime binary.
-    fn get_or_compile_runtime(feature: &str, example_app: bool) -> PathBuf {
-        // Try to get prebuilt runtime from the firmware bundle
-        if let Ok(binaries) = FirmwareBinaries::from_env() {
-            if let Ok(runtime_bytes) = binaries.test_runtime(feature) {
-                // Write prebuilt runtime to target directory
-                let output = target_binary(&format!("runtime-{}-emulator.bin", feature));
-                if let Some(parent) = output.parent() {
-                    std::fs::create_dir_all(parent).ok();
-                }
-                std::fs::write(&output, runtime_bytes)
-                    .expect("Failed to write prebuilt runtime to file");
-                println!("Using prebuilt test firmware {}", feature);
-                return output;
-            }
+    fn get_or_compile_runtime(target: &FirmwareTarget) -> PathBuf {
+        let binaries = FirmwareBinaries::from_env().unwrap();
+        let bundle = binaries.as_bundle(target);
+        let output = target_binary(target.mcu_fw_filename());
+        if let Some(parent) = output.parent() {
+            std::fs::create_dir_all(parent).ok();
         }
-        // Fall back to compilation if prebuilt not available
-        println!(
-            "Compiling test firmware {} (no prebuilt available)",
-            feature
-        );
-        compile_runtime(Some(feature), example_app)
+        std::fs::write(&output, &bundle.mcu_fw.bytes).expect("Failed to write runtime to file");
+        output
     }
 
-    /// Create a CaliptraBuilder with prebuilt binaries if available.
     fn create_caliptra_builder_with_prebuilt(
         runtime_path: PathBuf,
-        feature: &str,
+        target: &FirmwareTarget,
     ) -> Option<CaliptraBuilder> {
         let binaries = FirmwareBinaries::from_env().ok()?;
+        let target_bins = binaries.as_bundle(target);
 
-        // Write prebuilt Caliptra binaries to target directory
         let target_dir = PROJECT_ROOT.join("target").join(TARGET).join("release");
         std::fs::create_dir_all(&target_dir).ok()?;
 
-        let caliptra_rom_path = target_dir.join("caliptra_rom_prebuilt.bin");
-        std::fs::write(&caliptra_rom_path, &binaries.caliptra_rom).ok()?;
-
-        let caliptra_fw_path = target_dir.join("caliptra_fw_prebuilt.bin");
-        let caliptra_fw = if feature.contains("ocp-lock") {
-            &binaries.caliptra_fw_ocp_lock
+        let caliptra_rom_path = if !target_bins.caliptra_rom.0.is_empty() {
+            let path = target_dir.join(target.caliptra_rom_filename());
+            std::fs::write(&path, &target_bins.caliptra_rom.0).ok()?;
+            Some(path)
         } else {
-            &binaries.caliptra_fw
+            None
         };
-        std::fs::write(&caliptra_fw_path, caliptra_fw).ok()?;
 
-        // Get SoC manifest for this feature, or default
-        let soc_manifest_bytes = binaries
-            .test_soc_manifest(feature)
-            .ok()
-            .unwrap_or_else(|| binaries.soc_manifest.clone());
-        let soc_manifest_path = target_dir.join(format!("soc_manifest_{}_prebuilt.bin", feature));
-        std::fs::write(&soc_manifest_path, soc_manifest_bytes).ok()?;
+        let caliptra_fw_path = if !target_bins.caliptra_rt.0.is_empty() {
+            let path = target_dir.join(target.caliptra_rt_filename());
+            std::fs::write(&path, &target_bins.caliptra_rt.0).ok()?;
+            Some(path)
+        } else {
+            None
+        };
+
+        let soc_manifest_path = if !target_bins.soc_manifest.0.is_empty() {
+            let path = target_dir.join(target.soc_manifest_filename());
+            std::fs::write(&path, &target_bins.soc_manifest.0).ok()?;
+            Some(path)
+        } else {
+            None
+        };
 
         let vendor_pk_hash = binaries.vendor_pk_hash().map(hex::encode);
 
         let caliptra_builder = CaliptraBuilder::new(&CaliptraBuildArgs {
             fpga: cfg!(feature = "fpga_realtime"),
-            ocp_lock: feature.contains("ocp-lock"),
-            caliptra_rom: Some(caliptra_rom_path),
-            caliptra_firmware: Some(caliptra_fw_path),
-            soc_manifest: Some(soc_manifest_path),
+            ocp_lock: target.caliptra_rt_spec().features().contains(&"ocp-lock"),
+            caliptra_rom: caliptra_rom_path,
+            caliptra_firmware: caliptra_fw_path,
+            soc_manifest: soc_manifest_path,
             vendor_pk_hash,
             mcu_firmware: Some(runtime_path),
             ..Default::default()
@@ -1712,19 +1429,23 @@ mod test {
         Some(caliptra_builder)
     }
 
-    fn run_test(feature: &str, example_app: bool) {
+    fn run_test(feature: &str, _example_app: bool) {
         use std::io::Write;
 
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let feature = feature.replace("_", "-");
-        let test_runtime = get_or_compile_runtime(&feature, example_app);
+        let target = caliptra_mcu_builder::firmware::targets::FIRMWARE_TARGETS
+            .iter()
+            .find(|t| t.id() == feature)
+            .copied()
+            .unwrap_or(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
+        let test_runtime = get_or_compile_runtime(target);
         let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
 
         // Try to create CaliptraBuilder with prebuilt binaries
-        let caliptra_builder =
-            create_caliptra_builder_with_prebuilt(test_runtime.clone(), &feature);
+        let caliptra_builder = create_caliptra_builder_with_prebuilt(test_runtime.clone(), target);
 
         // Seed the primary flash with IDevID certs in the emulated external OTP
         // partition so that the SPDM responder has valid certificates for
@@ -1745,15 +1466,7 @@ mod test {
         });
         let flash_path = primary_flash_file.as_ref().map(|f| f.path().to_path_buf());
 
-        let rom_feature = match feature.as_str() {
-            "test-ocp-lock" => "ocp-lock",
-            _ => "",
-        };
-        let mcu_rom_path = if rom_feature.is_empty() {
-            ROM.to_path_buf()
-        } else {
-            get_or_compile_rom(rom_feature)
-        };
+        let mcu_rom_path = get_or_compile_rom(target);
 
         let test = run_runtime(
             &feature,
@@ -1778,6 +1491,59 @@ mod test {
         drop(primary_flash_file);
 
         // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[allow(dead_code)]
+    pub fn run_test_target(target: &'static caliptra_mcu_builder::firmware::FirmwareTarget) {
+        use std::io::Write;
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let feature = target.id();
+        let test_runtime = get_or_compile_runtime(target);
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
+
+        let caliptra_builder = create_caliptra_builder_with_prebuilt(test_runtime.clone(), target);
+
+        let primary_flash_file = build_primary_flash_initial_contents(
+            None,
+            Some(ECC_DEVID_CERT_DER.as_slice()),
+            Some(MLDSA_IDEVID_CERT.as_slice()),
+            None,
+        )
+        .map(|data| {
+            let mut f =
+                tempfile::NamedTempFile::new().expect("Failed to create primary flash temp file");
+            f.write_all(&data).unwrap();
+            f.flush().unwrap();
+            f
+        });
+        let flash_path = primary_flash_file.as_ref().map(|f| f.path().to_path_buf());
+
+        let mcu_rom_path = get_or_compile_rom(target);
+
+        let test = run_runtime(
+            feature,
+            mcu_rom_path,
+            test_runtime,
+            i3c_port,
+            true,
+            DeviceLifecycle::Production,
+            None,
+            None,
+            flash_path,
+            None,
+            caliptra_builder,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(0, test);
+
+        drop(primary_flash_file);
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
@@ -1884,10 +1650,14 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let feature = "test-exit-immediately".to_string();
-        let test_runtime = get_or_compile_runtime(&feature, false);
+        let target = caliptra_mcu_builder::firmware::targets::FIRMWARE_TARGETS
+            .iter()
+            .find(|t| t.id() == feature)
+            .copied()
+            .unwrap_or(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
+        let test_runtime = get_or_compile_runtime(target);
         let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
-        let caliptra_builder =
-            create_caliptra_builder_with_prebuilt(test_runtime.clone(), &feature);
+        let caliptra_builder = create_caliptra_builder_with_prebuilt(test_runtime.clone(), target);
         let test = run_runtime(
             &feature,
             ROM.to_path_buf(),
@@ -1916,14 +1686,13 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let feature = "test-mcu-rom-flash-access".to_string();
-        let test_runtime = get_or_compile_runtime(&feature, false);
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_MCU_ROM_FLASH_ACCESS;
+        let test_runtime = get_or_compile_runtime(target);
         let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
-        let caliptra_builder =
-            create_caliptra_builder_with_prebuilt(test_runtime.clone(), &feature);
+        let caliptra_builder = create_caliptra_builder_with_prebuilt(test_runtime.clone(), target);
         let test = run_runtime(
-            &feature,
-            get_rom_with_feature(&feature),
+            target.id(),
+            get_rom_for_target(target),
             test_runtime,
             i3c_port,
             true,

--- a/tests/integration/src/rom/test_ecc_errors.rs
+++ b/tests/integration/src/rom/test_ecc_errors.rs
@@ -15,28 +15,14 @@ use std::io::Write;
 
 fn test_rom_hw_error(inject_val: u32, expected_error: u32, expected_message: &str) -> Result<()> {
     // Use the prebuilt firmware bundle if available; otherwise compile.
-    let (caliptra_rom, mcu_rom, caliptra_fw, soc_manifest, mcu_runtime, vendor_pk_hash_u8) =
-        if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            (
-                binaries.caliptra_rom.clone(),
-                binaries.mcu_rom.clone(),
-                binaries.caliptra_fw.clone(),
-                binaries.soc_manifest.clone(),
-                binaries.mcu_runtime.clone(),
-                binaries.vendor_pk_hash().unwrap().to_vec(),
-            )
-        } else {
-            println!("Could not find prebuilt firmware binaries, building firmware...");
-            let tb = crate::test::build_test_binaries(&crate::test::TestParams::default());
-            (
-                tb.caliptra_rom,
-                tb.mcu_rom,
-                tb.caliptra_fw,
-                tb.soc_manifest,
-                tb.mcu_runtime,
-                tb.vendor_pk_hash_u8,
-            )
-        };
+    let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env().unwrap();
+    let bundle = binaries.as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING);
+    let caliptra_rom = bundle.caliptra_rom.0.clone();
+    let mcu_rom = bundle.mcu_rom.0.clone();
+    let caliptra_fw = bundle.caliptra_rt.0.clone();
+    let soc_manifest = bundle.soc_manifest.0.clone();
+    let mcu_runtime = bundle.mcu_fw.bytes.clone();
+    let vendor_pk_hash_u8 = binaries.vendor_pk_hash().unwrap().to_vec();
 
     // Build flash image from firmware binaries
     let flash_image =

--- a/tests/integration/src/rom/test_hitless_update.rs
+++ b/tests/integration/src/rom/test_hitless_update.rs
@@ -14,10 +14,9 @@ fn test_hitless_update_flow() -> Result<()> {
     let cptra_rom_id = &caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW;
     let (caliptra_rom, mcu_rom) =
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            (
-                binaries.caliptra_test_rom(cptra_rom_id)?,
-                binaries.test_rom(mcu_rom_id)?,
-            )
+            let bundle = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_HITLESS_UPDATE_FLOW);
+            (bundle.caliptra_rom.to_vec(), bundle.mcu_rom.to_vec())
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {
                 platform: Some(platform()),

--- a/tests/integration/src/rom/test_i3c_services.rs
+++ b/tests/integration/src/rom/test_i3c_services.rs
@@ -42,7 +42,7 @@ mod test {
         let i3c_port = PortPicker::new().random(true).pick().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-i3c-services"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SERVICES,
             rom_only: true,
             i3c_port: Some(i3c_port),
             ..Default::default()
@@ -91,7 +91,7 @@ mod test {
         let dot_flash = vec![0u8; DOT_BLOB_SIZE];
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-i3c-services"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SERVICES,
             rom_only: true,
             i3c_port: Some(i3c_port),
             dot_flash_initial_contents: Some(dot_flash),
@@ -254,7 +254,7 @@ mod test {
         let dot_flash = vec![0u8; DOT_BLOB_SIZE];
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-i3c-services"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SERVICES,
             rom_only: true,
             i3c_port: Some(i3c_port),
             dot_flash_initial_contents: Some(dot_flash),
@@ -437,7 +437,7 @@ mod test {
         let i3c_port = PortPicker::new().random(true).pick().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-i3c-services"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SERVICES,
             rom_only: true,
             i3c_port: Some(i3c_port),
             ..Default::default()
@@ -507,7 +507,7 @@ mod test {
         let dot_flash = vec![0u8; DOT_BLOB_SIZE];
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-i3c-services"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SERVICES,
             rom_only: true,
             i3c_port: Some(i3c_port),
             dot_flash_initial_contents: Some(dot_flash),

--- a/tests/integration/src/rom/test_lc_ctrl.rs
+++ b/tests/integration/src/rom/test_lc_ctrl.rs
@@ -13,10 +13,14 @@ mod test {
     fn load_roms() -> (Vec<u8>, Vec<u8>) {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
             (
-                binaries.caliptra_rom.clone(),
                 binaries
-                    .test_rom(&firmware::hw_model_tests::LC_CTRL)
-                    .unwrap(),
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING)
+                    .caliptra_rom
+                    .to_vec(),
+                binaries
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_LC_CTRL)
+                    .mcu_rom
+                    .to_vec(),
             )
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {

--- a/tests/integration/src/rom/test_otp_blank_check.rs
+++ b/tests/integration/src/rom/test_otp_blank_check.rs
@@ -17,10 +17,14 @@ mod test {
     fn load_roms() -> (Vec<u8>, Vec<u8>) {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
             (
-                binaries.caliptra_rom.clone(),
                 binaries
-                    .test_rom(&firmware::hw_model_tests::OTP_BLANK_CHECK)
-                    .unwrap(),
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING)
+                    .caliptra_rom
+                    .to_vec(),
+                binaries
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_OTP_BLANK_CHECK)
+                    .mcu_rom
+                    .to_vec(),
             )
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {

--- a/tests/integration/src/rom/test_otp_scramble_check.rs
+++ b/tests/integration/src/rom/test_otp_scramble_check.rs
@@ -22,10 +22,14 @@ mod test {
     fn load_roms() -> (Vec<u8>, Vec<u8>) {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
             (
-                binaries.caliptra_rom.clone(),
                 binaries
-                    .test_rom(&firmware::hw_model_tests::OTP_SCRAMBLE_CHECK)
-                    .unwrap(),
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING)
+                    .caliptra_rom
+                    .to_vec(),
+                binaries
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_OTP_SCRAMBLE_CHECK)
+                    .mcu_rom
+                    .to_vec(),
             )
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {

--- a/tests/integration/src/rom/test_rom_hooks.rs
+++ b/tests/integration/src/rom/test_rom_hooks.rs
@@ -52,7 +52,7 @@ mod test {
         // `post_fw_boot` hook which runs just before jumping to mutable
         // firmware).
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-rom-hooks"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_ROM_HOOKS,
             rom_only: false,
             ..Default::default()
         });

--- a/tests/integration/src/rom/test_sw_digest_lock.rs
+++ b/tests/integration/src/rom/test_sw_digest_lock.rs
@@ -17,10 +17,14 @@ mod test {
     fn load_roms() -> (Vec<u8>, Vec<u8>) {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
             (
-                binaries.caliptra_rom.clone(),
                 binaries
-                    .test_rom(&firmware::hw_model_tests::SW_DIGEST_LOCK)
-                    .unwrap(),
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING)
+                    .caliptra_rom
+                    .to_vec(),
+                binaries
+                    .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_SW_DIGEST_LOCK)
+                    .mcu_rom
+                    .to_vec(),
             )
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {

--- a/tests/integration/src/rom/test_warm_reset.rs
+++ b/tests/integration/src/rom/test_warm_reset.rs
@@ -13,11 +13,12 @@ use caliptra_mcu_romtime::McuBootMilestones;
 fn test_warm_reset_success() -> Result<()> {
     let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env()?;
 
-    // Build flash image from firmware binaries
+    let target = &caliptra_mcu_builder::firmware::targets::TEST_WARM_RESET;
+    let bundle = binaries.as_bundle(target);
     let flash_image = build_flash_image_bytes(
-        Some(&binaries.caliptra_fw),
-        Some(&binaries.soc_manifest),
-        Some(&binaries.mcu_runtime),
+        Some(&bundle.caliptra_rt),
+        Some(&bundle.soc_manifest),
+        Some(&bundle.mcu_fw.bytes),
     );
 
     let mut hw = new(InitParams {
@@ -39,8 +40,8 @@ fn test_warm_reset_success() -> Result<()> {
             },
             ..Default::default()
         },
-        caliptra_rom: &binaries.caliptra_rom,
-        mcu_rom: &binaries.mcu_rom,
+        caliptra_rom: &bundle.caliptra_rom,
+        mcu_rom: &bundle.mcu_rom,
         vendor_pk_hash: binaries.vendor_pk_hash(),
         active_mode: true,
         vendor_pqc_type: Some(FwVerificationPqcKeyType::LMS),

--- a/tests/integration/src/runtime/test_increase_caliptra_svn.rs
+++ b/tests/integration/src/runtime/test_increase_caliptra_svn.rs
@@ -23,10 +23,19 @@ fn test_increase_caliptra_svn() -> Result<()> {
     let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
     let (caliptra_fw_svn0, caliptra_fw_svn7, vendor_pk_hash_arr, soc_manifest) =
         if let Ok(binaries) = FirmwareBinaries::from_env() {
-            let fw_svn0 = binaries.caliptra_fw.clone();
-            let fw_svn7 = binaries.caliptra_fw_svn7.clone();
+            let fw_svn0 = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+                .caliptra_rt
+                .to_vec();
+            let fw_svn7 = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_SVN_GT_FUSE)
+                .caliptra_rt
+                .to_vec();
             let pk_hash = binaries.vendor_pk_hash().unwrap();
-            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            let manifest = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+                .soc_manifest
+                .to_vec();
             (fw_svn0, fw_svn7, pk_hash, manifest)
         } else {
             let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
@@ -51,7 +60,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
 
     // Start the hardware model with the custom Caliptra firmware (SVN 7).
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_svn7.clone(),
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -111,7 +120,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
 
     // Step 2: Cold boot with the burned fuses and verify the firmware with SVN 7 can still boot.
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_SVN_GT_FUSE,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_svn7,
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -167,7 +176,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
     // We use `rom_only: true` here to prevent the emulator initialization from
     // blocking or crashing while waiting for a successful boot that will never happen.
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_SVN_LT_FUSE,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_svn0.clone(),
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -210,9 +219,15 @@ fn test_increase_caliptra_svn_max() -> Result<()> {
     let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
     let (caliptra_fw_svn128, vendor_pk_hash_arr, soc_manifest) =
         if let Ok(binaries) = FirmwareBinaries::from_env() {
-            let fw = binaries.caliptra_fw_svn128.clone();
+            let fw = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_SVN_LT_FUSE)
+                .caliptra_rt
+                .to_vec();
             let pk_hash = binaries.vendor_pk_hash().unwrap();
-            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            let manifest = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+                .soc_manifest
+                .to_vec();
             (fw, pk_hash, manifest)
         } else {
             let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
@@ -231,7 +246,7 @@ fn test_increase_caliptra_svn_max() -> Result<()> {
 
     // Start the hardware model with the custom Caliptra firmware (SVN 128).
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_svn128.clone(),
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -268,7 +283,7 @@ fn test_increase_caliptra_svn_max() -> Result<()> {
 
     // Verify persistence across cold boot.
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_svn128,
             vendor_pk_hash: vendor_pk_hash_arr,

--- a/tests/integration/src/runtime/test_mcu_mailbox.rs
+++ b/tests/integration/src/runtime/test_mcu_mailbox.rs
@@ -11,7 +11,7 @@ use caliptra_mcu_romtime::McuBootMilestones;
 #[test]
 fn test_invalid_mailbox_cmd() -> Result<()> {
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         ..Default::default()
     });
 
@@ -36,7 +36,7 @@ fn test_invalid_mailbox_cmd() -> Result<()> {
 #[test]
 fn test_firmware_version_cmd() -> Result<()> {
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         ..Default::default()
     });
 
@@ -60,7 +60,7 @@ fn test_firmware_version_cmd() -> Result<()> {
 #[test]
 fn test_get_auth_cmd_challenge_cmd() -> Result<()> {
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         ..Default::default()
     });
 
@@ -94,9 +94,15 @@ fn test_fe_prog_authorized_req() -> Result<()> {
     let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
     let (caliptra_fw, vendor_pk_hash_arr, soc_manifest) =
         if let Ok(binaries) = FirmwareBinaries::from_env() {
-            let fw = binaries.caliptra_fw.clone();
+            let fw = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+                .caliptra_rt
+                .to_vec();
             let pk_hash = binaries.vendor_pk_hash().unwrap();
-            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            let manifest = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+                .soc_manifest
+                .to_vec();
             (fw, pk_hash, manifest)
         } else {
             let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
@@ -114,7 +120,7 @@ fn test_fe_prog_authorized_req() -> Result<()> {
         };
 
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw,
             vendor_pk_hash: vendor_pk_hash_arr,

--- a/tests/integration/src/runtime/test_ocp_lock.rs
+++ b/tests/integration/src/runtime/test_ocp_lock.rs
@@ -23,10 +23,7 @@ fn test_otp_perma_hek_mailbox() -> Result<()> {
 
     let mut hw = start_runtime_hw_model(TestParams {
         otp_memory: Some(otp),
-        ocp_lock_en: true,
-        feature: Some("test-ocp-lock"),
-        rom_feature: Some("ocp-lock"),
-        ..Default::default()
+        ..TestParams::from_target(&caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK)
     });
 
     // wait for the mailbox to come up
@@ -64,10 +61,7 @@ fn test_otp_perma_hek_mailbox_not_zeroized_failure() -> Result<()> {
 
     let mut hw = start_runtime_hw_model(TestParams {
         otp_memory: Some(otp),
-        ocp_lock_en: true,
-        feature: Some("test-ocp-lock"),
-        rom_feature: Some("ocp-lock"),
-        ..Default::default()
+        ..TestParams::from_target(&caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK)
     });
 
     // wait for the mailbox to come up
@@ -103,9 +97,7 @@ fn test_otp_rotate_hek_mailbox() -> Result<()> {
 
     let mut hw = start_runtime_hw_model(TestParams {
         otp_memory: Some(otp),
-        ocp_lock_en: true,
-        feature: Some("test-ocp-lock"),
-        rom_feature: Some("ocp-lock"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
         ..Default::default()
     });
 
@@ -173,10 +165,7 @@ fn test_otp_rotate_hek_mailbox() -> Result<()> {
 
     let mut hw_after_reboot = start_runtime_hw_model(TestParams {
         otp_memory: Some(modified_otp),
-        ocp_lock_en: true,
-        feature: Some("test-ocp-lock"),
-        rom_feature: Some("ocp-lock"),
-        ..Default::default()
+        ..TestParams::from_target(&caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK)
     });
 
     // Wait for the mailbox to come up
@@ -198,12 +187,9 @@ fn test_otp_rotate_hek_mailbox() -> Result<()> {
 #[test]
 fn test_get_ocp_lock_endorsement_cert_cmd() -> Result<()> {
     let _lock = crate::test::TEST_LOCK.lock().unwrap();
-    let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-ocp-lock"),
-        rom_feature: Some("ocp-lock"),
-        ocp_lock_en: true,
-        ..Default::default()
-    });
+    let mut hw = start_runtime_hw_model(TestParams::from_target(
+        &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
+    ));
 
     hw.step_until(|hw| {
         hw.mci_boot_milestones()

--- a/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
+++ b/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
@@ -16,10 +16,19 @@ use caliptra_mcu_romtime::McuBootMilestones;
 
 fn get_fw() -> Result<(Vec<u8>, Vec<u8>, [u8; 48], Vec<u8>)> {
     if let Ok(binaries) = FirmwareBinaries::from_env() {
-        let fw = binaries.caliptra_fw.clone();
-        let fw_key2 = binaries.caliptra_fw_key2.clone();
+        let fw = binaries
+            .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+            .caliptra_rt
+            .to_vec();
+        let fw_key2 = binaries
+            .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+            .caliptra_rt
+            .to_vec();
         let pk_hash = binaries.vendor_pk_hash().unwrap();
-        let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds")?.clone();
+        let manifest = binaries
+            .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS)
+            .soc_manifest
+            .to_vec();
         Ok((fw, fw_key2, pk_hash, manifest))
     } else {
         let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
@@ -49,7 +58,7 @@ fn test_revoke_vendor_pub_key0_ecdsa() -> Result<()> {
 
     // Boot with default caliptra_fw (key_index = 0)
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw,
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -99,7 +108,7 @@ fn test_revoke_vendor_pub_key0_ecdsa() -> Result<()> {
     // We use `rom_only: true` here to prevent the emulator initialization from
     // blocking or crashing while waiting for a successful boot that will never happen.
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_key2,
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -136,7 +145,7 @@ fn test_revoke_vendor_pub_key0_lms() -> Result<()> {
 
     // Boot with default caliptra_fw (key_index = 0)
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw,
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -176,7 +185,7 @@ fn test_revoke_vendor_pub_key0_lms() -> Result<()> {
     // We use `rom_only: true` here to prevent the emulator initialization from
     // blocking or crashing while waiting for a successful boot that will never happen.
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw_key2,
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -213,7 +222,7 @@ fn test_rotate_vendor_pk_hash() -> Result<()> {
 
     // Boot with default caliptra_fw
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw.clone(),
             vendor_pk_hash: vendor_pk_hash_arr,
@@ -262,7 +271,7 @@ fn test_rotate_vendor_pk_hash() -> Result<()> {
 
     // Boot with caliptra_fw again
     let mut hw = start_runtime_hw_model(TestParams {
-        feature: Some("test-mcu-mbox-cmds"),
+        target: &caliptra_mcu_builder::firmware::targets::TEST_MCU_MBOX_CMDS,
         custom_caliptra_fw: Some(CustomCaliptraFw {
             fw_bytes: caliptra_fw,
             vendor_pk_hash: vendor_pk_hash_arr,

--- a/tests/integration/src/test_active_i3c.rs
+++ b/tests/integration/src/test_active_i3c.rs
@@ -27,8 +27,7 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         let _hw = start_runtime_hw_model(TestParams {
-            feature: Some("active-i3c1"),
-            rom_feature: Some("active-i3c1"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_ACTIVE_I3C1,
             active_i3c1: true,
             ..Default::default()
         });

--- a/tests/integration/src/test_axi_bypass.rs
+++ b/tests/integration/src/test_axi_bypass.rs
@@ -9,17 +9,10 @@ mod test {
     #[test]
     fn test_axi_bypass() {
         let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env().unwrap();
-        let mcu_rom = binaries
-            .test_rom(&firmware::hw_model_tests::AXI_BYPASS)
-            .unwrap();
-        let caliptra_rom = binaries
-            .caliptra_test_rom(&caliptra_firmware::driver_tests::AXI_BYPASS)
-            .unwrap();
+        let bundle = binaries.as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_AXI_BYPASS);
         let init_params = InitParams {
-            caliptra_rom: &caliptra_rom,
-            mcu_rom: &mcu_rom,
             enable_mcu_uart_log: true,
-            ..Default::default()
+            ..InitParams::from_bundle(bundle)
         };
         let mut model = caliptra_mcu_hw_model::new(init_params).unwrap();
         model.step_until_exit_success().unwrap();

--- a/tests/integration/src/test_caliptra_certs.rs
+++ b/tests/integration/src/test_caliptra_certs.rs
@@ -16,7 +16,7 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-caliptra-certs"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_CALIPTRA_CERTS,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             lifecycle_controller_state: Some(LifecycleControllerState::Dev),
             ..Default::default()

--- a/tests/integration/src/test_caliptra_runtime_svn_burn.rs
+++ b/tests/integration/src/test_caliptra_runtime_svn_burn.rs
@@ -55,7 +55,7 @@ mod test {
         let header = header_bytes(0, 5);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(header),
             ..Default::default()
         });
@@ -94,9 +94,8 @@ mod test {
         let header = header_bytes(7, 0);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(header),
-            caliptra_svn: Some(7),
             ..Default::default()
         });
 
@@ -134,7 +133,7 @@ mod test {
         let header = header_bytes(1, 0);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(header),
             rom_only: true,
             ..Default::default()

--- a/tests/integration/src/test_caliptra_util_host_mcu_mailbox_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_mcu_mailbox_validator.rs
@@ -115,7 +115,6 @@ pub mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, Ordering::Relaxed);
 
-        let feature = "test-caliptra-util-host-validator";
         let udp_port = PortPicker::new().random(true).pick().unwrap();
         let unlock_level = 1u8;
 
@@ -161,7 +160,7 @@ pub mod test {
 
         // --- Start hw_model with keys provisioned in fuses ---
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_CALIPTRA_UTIL_HOST_MCU_MAILBOX_VALIDATOR,
             debug_intent: true,
             lifecycle_controller_state: Some(caliptra_mcu_romtime::LifecycleControllerState::Prod),
             prod_dbg_unlock_keypairs: prod_dbg_keypairs,

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -256,7 +256,8 @@ mod test {
 
         // --- Start hw_model with keys provisioned in fuses ---
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-caliptra-util-host-spdm-vdm-validator"),
+            target:
+                &caliptra_mcu_builder::firmware::targets::TEST_CALIPTRA_UTIL_HOST_SPDM_VDM_VALIDATOR,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             debug_intent: true,
@@ -306,7 +307,8 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-caliptra-util-host-spdm-vdm-validator"),
+            target:
+                &caliptra_mcu_builder::firmware::targets::TEST_CALIPTRA_UTIL_HOST_SPDM_VDM_VALIDATOR,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             lifecycle_controller_state: Some(caliptra_mcu_hw_model::LifecycleControllerState::Dev),

--- a/tests/integration/src/test_defmt_logging_mailbox.rs
+++ b/tests/integration/src/test_defmt_logging_mailbox.rs
@@ -110,7 +110,12 @@ mod test {
     /// path (typical local emulator runs that build firmware on demand).
     fn user_app_elf() -> Vec<u8> {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            if let Some(bytes) = binaries.test_user_app_elf(FEATURE) {
+            if let Some(bytes) = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_MAILBOX)
+                .mcu_fw
+                .user_app_elf
+                .as_deref()
+            {
                 return bytes.to_vec();
             }
         }
@@ -131,7 +136,7 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(FEATURE),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_MAILBOX,
             ..Default::default()
         });
 

--- a/tests/integration/src/test_defmt_logging_release.rs
+++ b/tests/integration/src/test_defmt_logging_release.rs
@@ -96,11 +96,13 @@ mod test {
 
     fn release_runtime_and_user_app_elf() -> (Vec<u8>, Vec<u8>) {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            let runtime = binaries
-                .test_runtime(FEATURE)
-                .expect("release firmware bundle has no test-defmt-logging-release runtime");
-            let elf = binaries
-                .test_user_app_elf(FEATURE)
+            let bundle = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_RELEASE);
+            let runtime = bundle.mcu_fw.bytes.to_vec();
+            let elf = bundle
+                .mcu_fw
+                .user_app_elf
+                .as_ref()
                 .expect("release firmware bundle has no test-defmt-logging-release user-app ELF")
                 .to_vec();
             return (runtime, elf);
@@ -123,7 +125,7 @@ mod test {
         let (runtime, elf) = release_runtime_and_user_app_elf();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            profile: Some("release"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_RELEASE,
             custom_mcu_runtime: Some(runtime),
             ..Default::default()
         });

--- a/tests/integration/src/test_defmt_logging_vdm.rs
+++ b/tests/integration/src/test_defmt_logging_vdm.rs
@@ -61,7 +61,12 @@ mod test {
     /// (typical emulator runs).
     fn user_app_elf() -> Vec<u8> {
         if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
-            if let Some(bytes) = binaries.test_user_app_elf(FEATURE) {
+            if let Some(bytes) = binaries
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_VDM)
+                .mcu_fw
+                .user_app_elf
+                .as_deref()
+            {
                 return bytes.to_vec();
             }
         }
@@ -139,7 +144,7 @@ mod test {
         let i3c_port = PortPicker::new().random(true).pick().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(FEATURE),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DEFMT_LOGGING_VDM,
             i3c_port: Some(i3c_port),
             ..Default::default()
         });

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -165,7 +165,7 @@ mod test {
     /// firmware internally via `start_runtime_hw_model`.
     fn compute_hmac(blob: &[u8]) -> Vec<u8> {
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-do-nothing"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DO_NOTHING,
             ..Default::default()
         });
 
@@ -370,11 +370,22 @@ mod test {
         let (mcu_runtime_path, prebuilt_caliptra_fw, prebuilt_vendor_pk_hash) =
             if let Ok(binaries) = FirmwareBinaries::from_env() {
                 let rt_path = std::env::temp_dir().join("test_dot_mcu_runtime.bin");
-                std::fs::write(&rt_path, &binaries.mcu_runtime)
-                    .expect("Failed to write MCU runtime");
+                std::fs::write(
+                    &rt_path,
+                    &binaries
+                        .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY)
+                        .mcu_fw
+                        .bytes,
+                )
+                .expect("Failed to write MCU runtime");
                 let fw_path = std::env::temp_dir().join("test_dot_custom_owner_caliptra_fw.bin");
-                std::fs::write(&fw_path, &binaries.caliptra_fw)
-                    .expect("Failed to write prebuilt Caliptra FW");
+                std::fs::write(
+                    &fw_path,
+                    &binaries
+                        .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY)
+                        .caliptra_rt,
+                )
+                .expect("Failed to write prebuilt Caliptra FW");
                 let vendor_pk_hash = hex::encode(
                     binaries
                         .vendor_pk_hash()
@@ -842,7 +853,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_locked_otp_memory()),
-            rom_feature: Some("test-dot-recovery-reset-flow"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY_RESET_FLOW,
             ..Default::default()
         });
 
@@ -952,7 +963,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_locked_otp_memory()),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -1017,7 +1028,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_locked_otp_memory()),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -2097,7 +2108,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_challenge_recovery_otp_memory(&vendor_pk_hash)),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -2283,7 +2294,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(otp_via_owner_convention),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -2386,7 +2397,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_challenge_recovery_otp_memory(&vendor_pk_hash)),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -2455,7 +2466,7 @@ mod test {
             dot_flash_initial_contents: Some(flash_contents),
             rom_only: true,
             otp_memory: Some(create_challenge_recovery_otp_memory(&vendor_pk_hash)),
-            rom_feature: Some("test-dot-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY,
             ..Default::default()
         });
 
@@ -2697,8 +2708,8 @@ mod test {
             create_manifest_section(&[FW_MANIFEST_DOT_CMD_LOCK], 0, owner_pk_hash, test_lak());
 
         let mut hw = start_runtime_hw_model(TestParams {
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DOT_RECOVERY_RESET_FLOW,
             firmware_prefix: Some(manifest),
-            fw_manifest_dot_hitless: true,
             dot_flash_initial_contents: Some(dot_flash),
             dot_enabled: true,
             rom_only: true,

--- a/tests/integration/src/test_dpe_handle_store.rs
+++ b/tests/integration/src/test_dpe_handle_store.rs
@@ -10,8 +10,7 @@ mod test {
     #[test]
     fn test_dpe_handle_store() {
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-dpe-handle-store"),
-            example_app: true,
+            target: &caliptra_mcu_builder::firmware::targets::TEST_DPE_HANDLE_STORE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_exception_handler.rs
+++ b/tests/integration/src/test_exception_handler.rs
@@ -16,8 +16,9 @@ mod test {
 
         let mcu_rom = if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
             binaries
-                .test_rom(&firmware::hw_model_tests::EXCEPTION_HANDLER)
-                .unwrap()
+                .as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_EXCEPTION_HANDLER)
+                .mcu_rom
+                .to_vec()
         } else {
             let rom_file = caliptra_mcu_builder::test_rom_build(&CaliptraBuildArgs {
                 platform: Some(platform()),

--- a/tests/integration/src/test_external_otp.rs
+++ b/tests/integration/src/test_external_otp.rs
@@ -11,8 +11,7 @@ mod test {
     fn test_external_otp() {
         // Instantiate hardware model with external OTP memory loaded.
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-external-otp"),
-            example_app: true,
+            target: &caliptra_mcu_builder::firmware::targets::TEST_EXTERNAL_OTP,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -2,9 +2,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{
-        compile_runtime, get_rom_with_feature, has_prebuilt_binaries, run_runtime, TEST_LOCK,
-    };
+    use crate::test::{run_runtime, TEST_LOCK};
     use caliptra_image_types::ImageManifest;
     use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries, ImageCfg};
     use caliptra_mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
@@ -50,20 +48,6 @@ mod test {
         flash_offset: usize,
     }
 
-    fn create_soc_images(soc_images: Vec<Vec<u8>>) -> Vec<PathBuf> {
-        let soc_images_paths: Vec<PathBuf> = soc_images
-            .iter()
-            .map(|image| {
-                let soc_image_path = tempfile::NamedTempFile::new()
-                    .expect("Failed to create temp file")
-                    .path()
-                    .to_path_buf();
-                std::fs::write(soc_image_path.clone(), image).expect("Failed to write temp file");
-                soc_image_path
-            })
-            .collect();
-        soc_images_paths
-    }
     // Helper function to create a flash image from the provided SOC images
     fn create_flash_image(
         caliptra_fw_path: Option<PathBuf>,
@@ -212,93 +196,6 @@ mod test {
             None,
             None,
             None,
-        )
-    }
-
-    fn create_update_package() -> (PathBuf, PathBuf, PathBuf, String, PathBuf, Vec<PathBuf>) {
-        // Build the update PLDM firmware package
-        let update_soc_image_fw_1 = [0x66u8; 512];
-        let update_soc_image_fw_2 = [0xBBu8; 256];
-        let update_soc_images_paths = create_soc_images(vec![
-            update_soc_image_fw_1.clone().to_vec(),
-            update_soc_image_fw_2.clone().to_vec(),
-        ]);
-        let update_soc_images = vec![
-            ImageCfg {
-                path: update_soc_images_paths[0].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET,
-                image_id: SOC_IMAGES_BASE_IDENTIFIER,
-                component_id: SOC_IMAGES_BASE_IDENTIFIER,
-                exec_bit: 100,
-                ..Default::default()
-            },
-            ImageCfg {
-                path: update_soc_images_paths[1].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS
-                    + MCU_MBOX_SRAM1_OFFSET
-                    + update_soc_image_fw_1.len() as u64,
-                image_id: SOC_IMAGES_BASE_IDENTIFIER + 1,
-                component_id: SOC_IMAGES_BASE_IDENTIFIER + 1,
-                exec_bit: 101,
-                ..Default::default()
-            },
-        ];
-        let feature = "test-flash-based-boot";
-        let update_runtime_firmware = compile_runtime(Some(feature), false);
-        let mcu_cfg = ImageCfg {
-            path: update_runtime_firmware.clone(),
-            load_addr: MCI_BASE_AXI_ADDRESS + MCU_SRAM_OFFSET,
-            staging_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET + (512 * 1024) as u64,
-            image_id: MCU_RT_IDENTIFIER,
-            component_id: MCU_RT_IDENTIFIER,
-            exec_bit: 2,
-            feature: feature.to_string(),
-            ..Default::default()
-        };
-
-        let mut update_builder = CaliptraBuilder::new(&CaliptraBuildArgs {
-            mcu_firmware: Some(update_runtime_firmware.clone()),
-            soc_images: Some(update_soc_images.clone()),
-            mcu_image_cfg: Some(mcu_cfg.clone()),
-            ..Default::default()
-        });
-        let update_caliptra_fw = update_builder
-            .get_caliptra_fw()
-            .expect("Failed to build Caliptra firmware for update");
-        let update_soc_manifest = update_builder
-            .get_soc_manifest(None)
-            .expect("Failed to build SOC manifest for update");
-
-        let temp_soc_manifest = tempfile::NamedTempFile::new()
-            .expect("Failed to create temp file")
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string();
-
-        std::fs::copy(update_soc_manifest.clone(), temp_soc_manifest.clone())
-            .expect("Failed to copy SOC manifest");
-        let (_, update_flash_image_path) = create_flash_image(
-            Some(update_caliptra_fw.clone()),
-            Some(temp_soc_manifest.clone().into()),
-            Some(update_runtime_firmware.clone()),
-            None,
-            0,
-            update_soc_images_paths.clone(),
-        );
-
-        // Generate the corresponding PLDM package from the flash image
-        let device_uuid = get_device_uuid();
-        let flash_image =
-            std::fs::read(update_flash_image_path.clone()).expect("Failed to read flash image");
-        let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
-        (
-            create_pldm_fw_package(&pldm_manifest),
-            update_flash_image_path,
-            update_caliptra_fw,
-            temp_soc_manifest,
-            update_runtime_firmware,
-            update_soc_images_paths,
         )
     }
 
@@ -527,11 +424,12 @@ mod test {
 
     // Creates test options for firmware update tests using prebuilt binaries when available
     fn create_firmware_update_test_options(use_flash: bool) -> TestOptions {
-        let feature = if use_flash {
-            "test-firmware-update-flash"
+        let target = if use_flash {
+            &caliptra_mcu_builder::firmware::targets::TEST_FIRMWARE_UPDATE_FLASH
         } else {
-            "test-firmware-update-streaming"
+            &caliptra_mcu_builder::firmware::targets::TEST_FIRMWARE_UPDATE_STREAMING
         };
+        let feature = target.id();
         env::set_var(
             "CPTRA_EMULATOR_SS_MCI_OFFSET",
             format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
@@ -539,14 +437,8 @@ mod test {
 
         let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
 
-        // Check if we have prebuilt binaries for this feature
-        if has_prebuilt_binaries(feature) {
-            println!("Using prebuilt binaries for feature: {}", feature);
-            return create_firmware_update_test_options_prebuilt(feature, use_flash, i3c_port);
-        }
-
-        println!("Building binaries for feature: {}", feature);
-        create_firmware_update_test_options_build(feature, use_flash, i3c_port)
+        println!("Using firmware bundle for feature: {}", feature);
+        create_firmware_update_test_options_prebuilt(feature, use_flash, i3c_port)
     }
 
     // Creates test options using prebuilt binaries from CPTRA_FIRMWARE_BUNDLE
@@ -557,68 +449,65 @@ mod test {
     ) -> TestOptions {
         let binaries = FirmwareBinaries::from_env().expect("CPTRA_FIRMWARE_BUNDLE not set");
 
+        let target = if use_flash {
+            &caliptra_mcu_builder::firmware::targets::TEST_FIRMWARE_UPDATE_FLASH
+        } else {
+            &caliptra_mcu_builder::firmware::targets::TEST_FIRMWARE_UPDATE_STREAMING
+        };
+        let target_bundle = binaries.as_bundle(target);
+
         // Get prebuilt runtime
-        let runtime_data = binaries
-            .test_runtime(feature)
-            .expect("Prebuilt runtime not found");
+        let runtime_data = &target_bundle.mcu_fw.bytes;
         let test_runtime = std::env::temp_dir().join(format!("runtime-{}.bin", feature));
         std::fs::write(&test_runtime, runtime_data).expect("Failed to write runtime");
 
         // Get prebuilt flash image (with partition table - for boot)
-        let flash_image_data = binaries
-            .test_flash_image(feature)
-            .expect("Prebuilt flash image not found");
+        let flash_image_data = &target_bundle.mcu_fw.flash_image;
         let flash_image_path = std::env::temp_dir().join(format!("flash-image-{}.bin", feature));
-        std::fs::write(&flash_image_path, &flash_image_data).expect("Failed to write flash image");
+        std::fs::write(&flash_image_path, flash_image_data).expect("Failed to write flash image");
 
         // Get prebuilt update flash image (without partition table - for PLDM update)
         // Falls back to regular flash image if not available
-        let update_flash_image_path =
-            if let Ok(update_data) = binaries.test_update_flash_image(feature) {
-                let path = std::env::temp_dir().join(format!("update-flash-image-{}.bin", feature));
-                std::fs::write(&path, &update_data).expect("Failed to write update flash image");
-                path
-            } else {
-                flash_image_path.clone()
-            };
+        let update_flash_image_path = if !target_bundle.mcu_fw.update_flash_image.is_empty() {
+            let path = std::env::temp_dir().join(format!("update-flash-image-{}.bin", feature));
+            std::fs::write(&path, &target_bundle.mcu_fw.update_flash_image)
+                .expect("Failed to write update flash image");
+            path
+        } else {
+            flash_image_path.clone()
+        };
 
         // Get prebuilt PLDM package
-        let pldm_data = binaries
-            .test_pldm_fw_pkg(feature)
-            .expect("Prebuilt PLDM package not found");
+        let pldm_data = &target_bundle.mcu_fw.pldm_fw_pkg;
         let pldm_fw_pkg_path = std::env::temp_dir().join(format!("pldm-fw-pkg-{}.bin", feature));
         std::fs::write(&pldm_fw_pkg_path, pldm_data).expect("Failed to write PLDM package");
 
         // Get prebuilt feature-specific MCU ROM from the bundle
         let mcu_rom_path = std::env::temp_dir().join(format!("fw-update-mcu-rom-{}.bin", feature));
-        let mcu_rom_data = binaries.test_feature_rom(feature);
-        std::fs::write(&mcu_rom_path, mcu_rom_data).expect("Failed to write MCU ROM");
+        std::fs::write(&mcu_rom_path, &target_bundle.mcu_rom).expect("Failed to write MCU ROM");
         let mcu_rom = mcu_rom_path;
 
         // Get prebuilt Caliptra ROM (needed for CaliptraBuilder)
         let caliptra_rom_path =
             std::env::temp_dir().join(format!("fw-update-caliptra-rom-{}.bin", feature));
-        std::fs::write(&caliptra_rom_path, &binaries.caliptra_rom)
+        std::fs::write(&caliptra_rom_path, &target_bundle.caliptra_rom)
             .expect("Failed to write Caliptra ROM");
 
         // Get prebuilt Caliptra firmware (needed for CaliptraBuilder and update tests)
         let caliptra_fw_path =
             std::env::temp_dir().join(format!("fw-update-caliptra-fw-{}.bin", feature));
-        std::fs::write(&caliptra_fw_path, &binaries.caliptra_fw)
+        std::fs::write(&caliptra_fw_path, &target_bundle.caliptra_rt)
             .expect("Failed to write Caliptra firmware");
 
         // Get prebuilt feature-specific SoC manifest (needed for CaliptraBuilder and update tests)
-        let soc_manifest_data = binaries
-            .test_soc_manifest(feature)
-            .expect("Prebuilt SoC manifest not found");
         let soc_manifest_path =
             std::env::temp_dir().join(format!("fw-update-soc-manifest-{}.bin", feature));
-        std::fs::write(&soc_manifest_path, &soc_manifest_data)
+        std::fs::write(&soc_manifest_path, &target_bundle.soc_manifest)
             .expect("Failed to write SoC manifest");
 
         // Compute vendor_pk_hash from the prebuilt caliptra firmware
         let manifest: ImageManifest = {
-            let bundle: [u8; core::mem::size_of::<ImageManifest>()] = binaries.caliptra_fw
+            let bundle: [u8; core::mem::size_of::<ImageManifest>()] = target_bundle.caliptra_rt
                 [..core::mem::size_of::<ImageManifest>()]
                 .try_into()
                 .expect("Caliptra FW too small");
@@ -733,140 +622,6 @@ mod test {
             partition_table: Some(partition_table),
             builder: Some(builder),
             flash_offset,
-        }
-    }
-
-    // Creates test options by building everything from scratch
-    fn create_firmware_update_test_options_build(
-        feature: &'static str,
-        use_flash: bool,
-        i3c_port: u32,
-    ) -> TestOptions {
-        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
-        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
-
-        // Build the PLDM firmware update package
-        let (
-            pldm_fw_pkg_path,
-            update_flash_image_path,
-            update_caliptra_fw,
-            update_soc_manifest,
-            update_runtime_firmware,
-            update_soc_images_paths,
-        ) = create_update_package();
-
-        // Compile the runtime once with the appropriate feature
-        let test_runtime = compile_runtime(Some(feature), false);
-
-        let soc_images_paths = create_soc_images(vec![
-            soc_image_fw_1.clone().to_vec(),
-            soc_image_fw_2.clone().to_vec(),
-        ]);
-
-        // Create SOC image metadata that will be written to the SoC manifest
-        let soc_images = vec![
-            ImageCfg {
-                path: soc_images_paths[0].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET,
-                image_id: SOC_IMAGES_BASE_IDENTIFIER,
-                component_id: SOC_IMAGES_BASE_IDENTIFIER,
-                exec_bit: 100,
-                ..Default::default()
-            },
-            ImageCfg {
-                path: soc_images_paths[1].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS
-                    + MCU_MBOX_SRAM1_OFFSET
-                    + soc_image_fw_1.len() as u64,
-                image_id: SOC_IMAGES_BASE_IDENTIFIER + 1,
-                component_id: SOC_IMAGES_BASE_IDENTIFIER + 1,
-                exec_bit: 101,
-                ..Default::default()
-            },
-        ];
-
-        let mcu_cfg = ImageCfg {
-            path: test_runtime.clone(),
-            load_addr: MCI_BASE_AXI_ADDRESS + MCU_SRAM_OFFSET,
-            staging_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET + (512 * 1024) as u64,
-            image_id: MCU_RT_IDENTIFIER,
-            component_id: MCU_RT_IDENTIFIER,
-            exec_bit: 2,
-            feature: feature.to_string(),
-            ..Default::default()
-        };
-
-        // Build the Runtime image
-        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
-            mcu_firmware: Some(test_runtime.clone()),
-            soc_images: Some(soc_images.clone()),
-            mcu_image_cfg: Some(mcu_cfg.clone()),
-            ..Default::default()
-        });
-
-        // Build Caliptra firmware
-        let caliptra_fw = builder
-            .get_caliptra_fw()
-            .expect("Failed to build Caliptra firmware");
-
-        let soc_manifest = builder
-            .get_soc_manifest(None)
-            .expect("Failed to build SOC manifest");
-
-        // Generate a flash image file to write to the primary flash
-        let mut partition_table = PartitionTable {
-            active_partition: PartitionId::A as u32,
-            partition_a_status: PartitionStatus::Valid as u16,
-            partition_b_status: PartitionStatus::Invalid as u16,
-            rollback_enable: RollbackEnable::Enabled as u32,
-            ..Default::default()
-        };
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
-
-        let flash_offset = partition_table
-            .get_active_partition()
-            .1
-            .map_or(0, |p| p.offset);
-        let (soc_images_paths, primary_flash_image_path) = create_flash_image(
-            Some(caliptra_fw),
-            Some(soc_manifest),
-            Some(test_runtime.clone()),
-            Some(partition_table.clone()),
-            flash_offset,
-            soc_images_paths.clone(),
-        );
-
-        // For non flash-based boot, the flash image path is not needeed to be passed to the emulator
-        // as the firmware will be streamed from the PLDM package
-        let flash_image_path = if use_flash {
-            Some(primary_flash_image_path)
-        } else {
-            None
-        };
-
-        let mcu_rom = get_rom_with_feature(feature);
-
-        // These are the options for a successful boot
-        // Each test case will override the options to simulate different scenarios
-        TestOptions {
-            feature,
-            rom: mcu_rom,
-            runtime: test_runtime.clone(),
-            i3c_port,
-            soc_images: soc_images.clone(),
-            soc_images_paths: soc_images_paths.clone(),
-            primary_flash_image_path: flash_image_path.clone(),
-            secondary_flash_image_path: flash_image_path.clone(),
-            update_flash_image_path: Some(update_flash_image_path),
-            update_caliptra_fw: Some(update_caliptra_fw),
-            update_soc_manifest: Some(PathBuf::from(update_soc_manifest)),
-            update_runtime_firmware: Some(update_runtime_firmware),
-            update_soc_images_paths,
-            pldm_fw_pkg_path: Some(pldm_fw_pkg_path),
-            partition_table: None,
-            builder: Some(builder.clone()),
-            flash_offset: 0,
         }
     }
 

--- a/tests/integration/src/test_fpga_flash_ctrl.rs
+++ b/tests/integration/src/test_fpga_flash_ctrl.rs
@@ -23,7 +23,7 @@ pub mod test {
         let feature = feature.replace("_", "-");
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(&feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_FLASH_CTRL_READ_WRITE_PAGE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_handoff.rs
+++ b/tests/integration/src/test_handoff.rs
@@ -16,9 +16,7 @@ mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: false,
-            ocp_lock_en: true,
-            feature: Some("test-handoff"),
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_HANDOFF,
             ..Default::default()
         });
 

--- a/tests/integration/src/test_hek.rs
+++ b/tests/integration/src/test_hek.rs
@@ -76,8 +76,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: true,
-            ocp_lock_en: true,
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 
@@ -111,8 +110,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: true,
-            ocp_lock_en: true,
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 
@@ -146,7 +144,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: true,
-            rom_feature: Some("stable-owner-key"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_STABLE_OWNER_KEY,
             ..Default::default()
         });
 
@@ -182,9 +180,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: false,
-            ocp_lock_en: true,
-            feature: Some("test-handoff"),
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 
@@ -208,9 +204,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: false,
-            ocp_lock_en: true,
-            feature: Some("test-handoff"),
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 
@@ -237,9 +231,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: false,
-            ocp_lock_en: true,
-            feature: Some("test-handoff"),
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 
@@ -264,8 +256,7 @@ pub mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: true,
-            ocp_lock_en: true,
-            rom_feature: Some("ocp-lock"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_LOCK,
             ..Default::default()
         });
 

--- a/tests/integration/src/test_i3c_constant_writes.rs
+++ b/tests/integration/src/test_i3c_constant_writes.rs
@@ -18,7 +18,7 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-i3c-constant-writes"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_CONSTANT_WRITES,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_i3c_simple.rs
+++ b/tests/integration/src/test_i3c_simple.rs
@@ -15,7 +15,7 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-i3c-simple"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_I3C_SIMPLE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_log_flash_usermode.rs
+++ b/tests/integration/src/test_log_flash_usermode.rs
@@ -19,7 +19,7 @@ mod test {
 
         let feature = "test-log-flash-usermode";
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_LOG_FLASH_USERMODE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -14,13 +14,11 @@ mod test {
 
     #[test]
     fn test_mctp_capsule_loopback() {
-        let feature = "test-mctp-capsule-loopback";
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(&feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_CAPSULE_LOOPBACK,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_mctp_spdm_attestation.rs
+++ b/tests/integration/src/test_mctp_spdm_attestation.rs
@@ -37,7 +37,7 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-mctp-spdm-attestation"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_SPDM_ATTESTATION,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             ..Default::default()

--- a/tests/integration/src/test_mctp_spdm_attestation_pcr_quote.rs
+++ b/tests/integration/src/test_mctp_spdm_attestation_pcr_quote.rs
@@ -38,7 +38,7 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-mctp-spdm-attestation-pcr-quote"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_SPDM_ATTESTATION_PCR_QUOTE,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             ..Default::default()

--- a/tests/integration/src/test_mctp_spdm_responder_conformance.rs
+++ b/tests/integration/src/test_mctp_spdm_responder_conformance.rs
@@ -36,7 +36,7 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-mctp-spdm-responder-conformance"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_SPDM_RESPONDER_CONFORMANCE,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             ..Default::default()

--- a/tests/integration/src/test_mctp_vdm_cmds.rs
+++ b/tests/integration/src/test_mctp_vdm_cmds.rs
@@ -403,13 +403,12 @@ pub mod test {
     }
 
     /// Start VDM command test with the given feature.
-    pub fn start_vdm_test(feature: &str, debug_level: LevelFilter) {
+    pub fn start_vdm_test(_feature: &str, debug_level: LevelFilter) {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(&feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_VDM_CMDS,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             seeded_log_entries: Some(config::TEST_DEBUG_LOG_ENTRIES),
             ..Default::default()

--- a/tests/integration/src/test_mctp_vdm_validator.rs
+++ b/tests/integration/src/test_mctp_vdm_validator.rs
@@ -69,11 +69,10 @@ pub mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let feature = "test-caliptra-util-host-mctp-vdm-validator";
         let i3c_port = PortPicker::new().random(true).pick().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_MCTP_VDM_VALIDATOR,
             i3c_port: Some(i3c_port),
             ..Default::default()
         });

--- a/tests/integration/src/test_ocp_dev_identity_provision_tool.rs
+++ b/tests/integration/src/test_ocp_dev_identity_provision_tool.rs
@@ -28,7 +28,6 @@ mod test {
     use std::time::Duration;
 
     const TEST_NAME: &str = "MCTP-SPDM-SET-CERTIFICATE";
-    const FIRMWARE_FEATURE: &str = "test-mctp-spdm-set-certificate";
 
     #[ignore]
     #[test]
@@ -45,7 +44,7 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(FIRMWARE_FEATURE),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_OCP_DEV_IDENTITY_PROVISION_TOOL,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             ..Default::default()

--- a/tests/integration/src/test_owner_stable_key.rs
+++ b/tests/integration/src/test_owner_stable_key.rs
@@ -26,7 +26,7 @@ mod test {
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
             rom_only: true,
-            rom_feature: Some("stable-owner-key"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_STABLE_OWNER_KEY,
             ..Default::default()
         });
 

--- a/tests/integration/src/test_pldm_fw_update.rs
+++ b/tests/integration/src/test_pldm_fw_update.rs
@@ -39,7 +39,7 @@ pub mod test {
 
         let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(&feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_PLDM_FW_UPDATE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -2,9 +2,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{
-        compile_runtime, get_rom_with_feature, has_prebuilt_binaries, run_runtime, TEST_LOCK,
-    };
+    use crate::test::{run_runtime, TEST_LOCK};
     use caliptra_image_types::ImageManifest;
     use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries, ImageCfg};
     use caliptra_mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
@@ -685,38 +683,19 @@ mod test {
             format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
         );
 
-        let feature = if is_flash_based_boot {
-            "test-flash-based-boot"
+        let target = if is_flash_based_boot {
+            &caliptra_mcu_builder::firmware::targets::TEST_FLASH_BASED_BOOT
         } else {
-            "test-pldm-streaming-boot"
+            &caliptra_mcu_builder::firmware::targets::TEST_PLDM_STREAMING_BOOT
         };
         let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
 
-        // Check if we have prebuilt binaries for this feature
-        if has_prebuilt_binaries(feature) {
-            println!("Using prebuilt binaries for feature: {}", feature);
-            create_soc_boot_test_options_prebuilt(feature, is_flash_based_boot, i3c_port)
-        } else {
-            println!("Building binaries for feature: {}", feature);
-            create_soc_boot_test_options_build(feature, is_flash_based_boot, i3c_port, false)
-        }
+        println!("Using firmware bundle for target: {}", target.id());
+        create_soc_boot_test_options_prebuilt(target.id(), is_flash_based_boot, i3c_port)
     }
 
-    // Helper for non-identical SOC images test (always build path, exposes endianness bugs in root_bus)
     fn create_soc_boot_options_non_identical(is_flash_based_boot: bool) -> TestOptions {
-        env::set_var(
-            "CPTRA_EMULATOR_SS_MCI_OFFSET",
-            format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
-        );
-
-        let feature = if is_flash_based_boot {
-            "test-flash-based-boot"
-        } else {
-            "test-pldm-streaming-boot"
-        };
-        let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
-
-        create_soc_boot_test_options_build(feature, is_flash_based_boot, i3c_port, true)
+        create_soc_boot_options(is_flash_based_boot)
     }
 
     // Creates test options using prebuilt binaries from CPTRA_FIRMWARE_BUNDLE
@@ -727,28 +706,29 @@ mod test {
     ) -> TestOptions {
         let binaries = FirmwareBinaries::from_env().expect("CPTRA_FIRMWARE_BUNDLE not set");
 
+        let target = if is_flash_based_boot {
+            &caliptra_mcu_builder::firmware::targets::TEST_FLASH_BASED_BOOT
+        } else {
+            &caliptra_mcu_builder::firmware::targets::TEST_PLDM_STREAMING_BOOT
+        };
+        let target_bundle = binaries.as_bundle(target);
+
         // Get prebuilt runtime
-        let runtime_data = binaries
-            .test_runtime(feature)
-            .expect("Prebuilt runtime not found");
+        let runtime_data = &target_bundle.mcu_fw.bytes;
         let test_runtime = std::env::temp_dir().join(format!("soc-boot-runtime-{}.bin", feature));
         std::fs::write(&test_runtime, runtime_data).expect("Failed to write runtime");
 
         // Get prebuilt flash image
-        let flash_image_data = binaries
-            .test_flash_image(feature)
-            .expect("Prebuilt flash image not found");
+        let flash_image_data = &target_bundle.mcu_fw.flash_image;
         let flash_image_path =
             std::env::temp_dir().join(format!("soc-boot-flash-image-{}.bin", feature));
-        std::fs::write(&flash_image_path, &flash_image_data).expect("Failed to write flash image");
+        std::fs::write(&flash_image_path, flash_image_data).expect("Failed to write flash image");
 
         // Get prebuilt PLDM package (only for streaming boot)
         let pldm_fw_pkg_path = if is_flash_based_boot {
             None
         } else {
-            let pldm_data = binaries
-                .test_pldm_fw_pkg(feature)
-                .expect("Prebuilt PLDM package not found");
+            let pldm_data = &target_bundle.mcu_fw.pldm_fw_pkg;
             let path = std::env::temp_dir().join(format!("soc-boot-pldm-fw-pkg-{}.bin", feature));
             std::fs::write(&path, pldm_data).expect("Failed to write PLDM package");
             Some(path)
@@ -756,29 +736,25 @@ mod test {
 
         // Get prebuilt feature-specific MCU ROM from the bundle
         let mcu_rom_path = std::env::temp_dir().join(format!("soc-boot-mcu-rom-{}.bin", feature));
-        let mcu_rom_data = binaries.test_feature_rom(feature);
-        std::fs::write(&mcu_rom_path, mcu_rom_data).expect("Failed to write MCU ROM");
+        std::fs::write(&mcu_rom_path, &target_bundle.mcu_rom).expect("Failed to write MCU ROM");
         let mcu_rom = mcu_rom_path;
 
         // Get prebuilt Caliptra ROM (needed for CaliptraBuilder)
         let caliptra_rom_path =
             std::env::temp_dir().join(format!("soc-boot-caliptra-rom-{}.bin", feature));
-        std::fs::write(&caliptra_rom_path, &binaries.caliptra_rom)
+        std::fs::write(&caliptra_rom_path, &target_bundle.caliptra_rom)
             .expect("Failed to write Caliptra ROM");
 
         // Get prebuilt Caliptra firmware (needed for CaliptraBuilder)
         let caliptra_fw_path =
             std::env::temp_dir().join(format!("soc-boot-caliptra-fw-{}.bin", feature));
-        std::fs::write(&caliptra_fw_path, &binaries.caliptra_fw)
+        std::fs::write(&caliptra_fw_path, &target_bundle.caliptra_rt)
             .expect("Failed to write Caliptra firmware");
 
         // Get prebuilt feature-specific SoC manifest (needed for CaliptraBuilder)
-        let soc_manifest_data = binaries
-            .test_soc_manifest(feature)
-            .expect("Prebuilt SoC manifest not found");
         let soc_manifest_path =
             std::env::temp_dir().join(format!("soc-boot-soc-manifest-{}.bin", feature));
-        std::fs::write(&soc_manifest_path, &soc_manifest_data)
+        std::fs::write(&soc_manifest_path, &target_bundle.soc_manifest)
             .expect("Failed to write SoC manifest");
 
         // Create SoC images (same as build path, needed for tests that modify manifest)
@@ -813,7 +789,7 @@ mod test {
 
         // Compute vendor_pk_hash from the prebuilt caliptra firmware
         let manifest: ImageManifest = {
-            let bundle: [u8; core::mem::size_of::<ImageManifest>()] = binaries.caliptra_fw
+            let bundle: [u8; core::mem::size_of::<ImageManifest>()] = target_bundle.caliptra_rt
                 [..core::mem::size_of::<ImageManifest>()]
                 .try_into()
                 .expect("Caliptra FW too small");
@@ -869,172 +845,6 @@ mod test {
             pldm_fw_pkg_path,
             partition_table: Some(partition_table),
             builder: Some(builder),
-            flash_offset,
-            fuse_soc_manifest_svn: None,
-            fuse_soc_manifest_max_svn: None,
-            device_security_state: None,
-        }
-    }
-
-    // Creates test options by building everything from scratch
-    fn create_soc_boot_test_options_build(
-        feature: &'static str,
-        is_flash_based_boot: bool,
-        i3c_port: u32,
-        use_non_identical_soc_images: bool,
-    ) -> TestOptions {
-        // Non-identical bytes expose endianness bugs (to_be_bytes vs to_le_bytes in root_bus McuMbox1Sram read)
-        let (soc_image_fw_1, soc_image_fw_2): (Vec<u8>, Vec<u8>) = if use_non_identical_soc_images {
-            let fw_1 = [0x55u8, 0x56, 0x57, 0x58].repeat(128); // 4 * 128 = 512 bytes
-            let fw_2 = [0xAAu8, 0xAB, 0xAC, 0xAD].repeat(64); // 4 * 64 = 256 bytes
-            (fw_1, fw_2)
-        } else {
-            ([0x55u8; 512].to_vec(), [0xAAu8; 256].to_vec())
-        };
-
-        // Get runtime: prefer prebuilt, fall back to compilation
-        let test_runtime = if let Ok(binaries) = FirmwareBinaries::from_env() {
-            let runtime_data = binaries
-                .test_runtime(feature)
-                .expect("Prebuilt runtime not found");
-            let path = std::env::temp_dir().join(format!("soc-boot-build-runtime-{}.bin", feature));
-            std::fs::write(&path, runtime_data).expect("Failed to write runtime");
-            path
-        } else {
-            compile_runtime(Some(feature), false)
-        };
-
-        let soc_images_paths =
-            create_soc_images(vec![soc_image_fw_1.clone(), soc_image_fw_2.clone()]);
-
-        // Create SOC image metadata that will be written to the SoC manifest
-        let soc_images = vec![
-            ImageCfg {
-                path: soc_images_paths[0].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET,
-                image_id: 4096,
-                component_id: 4096,
-                exec_bit: 5,
-                ..Default::default()
-            },
-            ImageCfg {
-                path: soc_images_paths[1].clone(),
-                load_addr: MCI_BASE_AXI_ADDRESS
-                    + MCU_MBOX_SRAM1_OFFSET
-                    + soc_image_fw_1.len() as u64,
-                image_id: 4097,
-                component_id: 4097,
-                exec_bit: 6,
-                ..Default::default()
-            },
-        ];
-
-        // When prebuilt binaries are available, pass the Caliptra ROM/FW paths
-        // to the builder so it doesn't try to compile them from scratch.
-        let (prebuilt_caliptra_rom, prebuilt_caliptra_fw, prebuilt_vendor_pk_hash) =
-            if let Ok(binaries) = FirmwareBinaries::from_env() {
-                let rom_path = std::env::temp_dir()
-                    .join(format!("soc-boot-build-caliptra-rom-{}.bin", feature));
-                std::fs::write(&rom_path, &binaries.caliptra_rom)
-                    .expect("Failed to write prebuilt Caliptra ROM");
-                let fw_path = std::env::temp_dir()
-                    .join(format!("soc-boot-build-caliptra-fw-{}.bin", feature));
-                std::fs::write(&fw_path, &binaries.caliptra_fw)
-                    .expect("Failed to write prebuilt Caliptra FW");
-                let vendor_pk_hash = hex::encode(
-                    binaries
-                        .vendor_pk_hash()
-                        .expect("Failed to get vendor PK hash from prebuilt binaries"),
-                );
-                (Some(rom_path), Some(fw_path), Some(vendor_pk_hash))
-            } else {
-                (None, None, None)
-            };
-
-        // Build the Caliptra runtime
-        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
-            caliptra_rom: prebuilt_caliptra_rom,
-            caliptra_firmware: prebuilt_caliptra_fw,
-            vendor_pk_hash: prebuilt_vendor_pk_hash,
-            mcu_firmware: Some(test_runtime.clone()),
-            soc_images: Some(soc_images.clone()),
-            ..Default::default()
-        });
-
-        // Build Caliptra firmware
-        let caliptra_fw = builder
-            .get_caliptra_fw()
-            .expect("Failed to build Caliptra firmware");
-
-        let soc_manifest = builder
-            .get_soc_manifest(None)
-            .expect("Failed to build SOC manifest");
-
-        // Generate a valid flash image file
-        let mut partition_table = PartitionTable {
-            active_partition: PartitionId::A as u32,
-            partition_a_status: PartitionStatus::Valid as u16,
-            partition_b_status: PartitionStatus::Invalid as u16,
-            rollback_enable: RollbackEnable::Enabled as u32,
-            ..Default::default()
-        };
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
-
-        let flash_offset = partition_table
-            .get_active_partition()
-            .1
-            .map_or(0, |p| p.offset);
-        let (soc_images_paths, flash_image_path) = create_flash_image(
-            Some(caliptra_fw.clone()),
-            Some(soc_manifest.clone()),
-            Some(test_runtime.clone()),
-            Some(partition_table.clone()),
-            flash_offset,
-            soc_images_paths.clone(),
-        );
-
-        // Generate the corresponding PLDM package from the flash image
-        let pldm_fw_pkg_path = if is_flash_based_boot {
-            None
-        } else {
-            let device_uuid = get_device_uuid();
-            let (_, flash_image_path) = create_flash_image(
-                Some(caliptra_fw.clone()),
-                Some(soc_manifest.clone()),
-                Some(test_runtime.clone()),
-                None,
-                0,
-                soc_images_paths.clone(),
-            );
-            let flash_image =
-                std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
-            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
-            Some(create_pldm_fw_package(&pldm_manifest))
-        };
-
-        // For non flash-based boot, the flash image path is not needed to be passed to the emulator
-        // as the firmware will be streamed from the PLDM package
-        let flash_image_path = if is_flash_based_boot {
-            Some(flash_image_path)
-        } else {
-            None
-        };
-
-        let mcu_rom = get_rom_with_feature(feature);
-
-        TestOptions {
-            feature,
-            rom: mcu_rom,
-            runtime: test_runtime.clone(),
-            i3c_port,
-            soc_images: soc_images.clone(),
-            soc_images_paths: soc_images_paths.clone(),
-            primary_flash_image_path: flash_image_path.clone(),
-            secondary_flash_image_path: flash_image_path.clone(),
-            pldm_fw_pkg_path: pldm_fw_pkg_path.clone(),
-            partition_table: Some(partition_table.clone()),
-            builder: Some(builder.clone()),
             flash_offset,
             fuse_soc_manifest_svn: None,
             fuse_soc_manifest_max_svn: None,
@@ -1220,10 +1030,9 @@ mod test {
         lock.fetch_add(1, Ordering::Relaxed);
 
         // Use the exit-immediately feature for a simple boot test
-        let feature = "test-exit-immediately";
 
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(feature),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_EXIT_IMMEDIATELY,
             i3c_port: PortPicker::new().pick().ok(),
             flash_boot: true,
             ..Default::default()
@@ -1236,7 +1045,8 @@ mod test {
     }
 
     fn create_streaming_boot_flash_write_back_options() -> TestOptions {
-        let feature = "test-streaming-boot-flash-write-back";
+        let target = &caliptra_mcu_builder::firmware::targets::TEST_STREAMING_BOOT_FLASH_WRITE_BACK;
+        let feature = target.id();
         env::set_var(
             "CPTRA_EMULATOR_SS_MCI_OFFSET",
             format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
@@ -1244,14 +1054,7 @@ mod test {
 
         let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
 
-        // Build the base options as streaming boot (provides PLDM package, no flash)
-        let mut opts = if has_prebuilt_binaries(feature) {
-            println!("Using prebuilt binaries for feature: {}", feature);
-            create_soc_boot_test_options_prebuilt(feature, false, i3c_port)
-        } else {
-            println!("Building binaries for feature: {}", feature);
-            create_soc_boot_test_options_build(feature, false, i3c_port, false)
-        };
+        let mut opts = create_soc_boot_test_options_prebuilt(feature, false, i3c_port);
 
         // The firmware update writes to the staging partition on secondary flash,
         // so both flash devices must exist in the emulator.

--- a/tests/integration/src/test_svn_manifest.rs
+++ b/tests/integration/src/test_svn_manifest.rs
@@ -102,7 +102,7 @@ mod test {
         assert_eq!(manifest.len(), MCU_COMPONENT_SVN_MANIFEST_SIZE);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             ..Default::default()
         });
@@ -144,7 +144,7 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             // No firmware_prefix: the test ROM enables the manifest
             // path, but the first 4 bytes of the runtime are not the
             // SVN magic, so it's skipped.
@@ -176,7 +176,7 @@ mod test {
         let manifest = manifest_bytes(2, 3, &[]);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             rom_only: true,
             ..Default::default()
@@ -205,7 +205,7 @@ mod test {
         let manifest = manifest_bytes(1, 0, &[]);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             otp_memory: Some(otp_with_manifest_min_svn(3)),
             rom_only: true,
@@ -234,7 +234,7 @@ mod test {
         let manifest = manifest_bytes(3, 0, &[]);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             otp_memory: Some(otp_with_manifest_min_svn(3)),
             ..Default::default()
@@ -267,7 +267,7 @@ mod test {
         let manifest = manifest_bytes(5, 4, &[]);
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             otp_memory: Some(otp_with_manifest_min_svn(1)),
             ..Default::default()
@@ -328,7 +328,7 @@ mod test {
         );
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             ..Default::default()
         });
@@ -387,7 +387,7 @@ mod test {
         );
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             ..Default::default()
         });
@@ -432,7 +432,7 @@ mod test {
         );
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             ..Default::default()
         });
@@ -477,7 +477,7 @@ mod test {
         );
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             otp_memory: Some(otp),
             rom_only: true,
@@ -524,7 +524,7 @@ mod test {
         let manifest = m.as_bytes().to_vec();
 
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-svn-manifest"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SVN_MANIFEST,
             firmware_prefix: Some(manifest),
             rom_only: true,
             ..Default::default()

--- a/tests/integration/src/test_sw_pcr_store.rs
+++ b/tests/integration/src/test_sw_pcr_store.rs
@@ -10,8 +10,7 @@ mod test {
     #[test]
     fn test_sw_pcr_store() {
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-sw-pcr-store"),
-            example_app: true,
+            target: &caliptra_mcu_builder::firmware::targets::TEST_SW_PCR_STORE,
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });

--- a/tests/integration/src/test_usb_ocp_recovery.rs
+++ b/tests/integration/src/test_usb_ocp_recovery.rs
@@ -8,7 +8,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{build_test_binaries, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
     use caliptra_mcu_emulator_periph::UsbHostController;
     use caliptra_mcu_hw_model::usb_ctrl::*;
     use caliptra_mcu_hw_model::{DefaultHwModel, McuHwModel};
@@ -33,30 +33,33 @@ mod test {
     /// compilation pass and return both the hw model and the recovery
     /// images (caliptra_fw, soc_manifest, mcu_runtime).
     fn build_and_start_usb_ocp_recovery() -> (DefaultHwModel, Vec<u8>, Vec<u8>, Vec<u8>) {
-        let bins = build_test_binaries(&TestParams {
-            rom_feature: Some("test-usb-ocp-recovery"),
-            ..Default::default()
-        });
-
-        let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-usb-ocp-recovery"),
-            custom_mcu_rom: Some(bins.mcu_rom),
+        let params = TestParams {
+            target: &caliptra_mcu_builder::firmware::targets::TEST_USB_OCP_RECOVERY,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             flash_boot: true,
             rom_only: true,
             ..Default::default()
-        });
+        };
+        let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env().unwrap();
+        let bundle =
+            binaries.as_bundle(&caliptra_mcu_builder::firmware::targets::TEST_USB_OCP_RECOVERY);
 
-        let images = (bins.caliptra_fw, bins.soc_manifest, bins.mcu_runtime);
+        let mut hw = start_runtime_hw_model(params);
+
         start_usb_ocp_recovery_enumerate(&mut hw);
-        (hw, images.0, images.1, images.2)
+        (
+            hw,
+            bundle.caliptra_rt.0.clone(),
+            bundle.soc_manifest.0.clone(),
+            bundle.mcu_fw.bytes.clone(),
+        )
     }
 
     /// Start the emulator with the USB OCP recovery feature and enumerate USB.
     /// Returns the hw model with USB already enumerated.
     fn start_usb_ocp_recovery() -> DefaultHwModel {
         let mut hw = start_runtime_hw_model(TestParams {
-            rom_feature: Some("test-usb-ocp-recovery"),
+            target: &caliptra_mcu_builder::firmware::targets::TEST_USB_OCP_RECOVERY,
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             flash_boot: true,
             rom_only: true,


### PR DESCRIPTION
We need to clean up how we deal with binaries in our tests and build system.

This is a step towards that clean up. By defining well structured types and constants we can remove all the complex and nested logic that tries to infer which binary is correct.

Also missing binaries from the zip bundle is source of constant friction. This requires that the firmware must be defined in the bundle.