### PR TITLE
[update] rom: recover locked DOT blob from backup before reset

### DIFF
--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -426,7 +426,10 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
-            dot_recovery_handler: if cfg!(feature = "test-dot-recovery") {
+            dot_recovery_handler: if cfg!(any(
+                feature = "test-dot-recovery",
+                feature = "test-dot-recovery-reset-flow"
+            )) {
                 Some(&*recovery_handler)
             } else {
                 None

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -80,6 +80,91 @@ fn maybe_enter_dot_recovery_reset_failure_flow(
     fatal_error(err);
 }
 
+/// Attempts a configured, noninteractive backup-blob recovery.
+///
+/// On success, re-reads the active copy and runs the normal DOT flow so the
+/// current cold boot can continue with the recovered owner.
+fn attempt_dot_backup_recovery(
+    env: &mut RomEnv,
+    dot_fuses: &crate::DotFuses,
+    params: &RomParameters,
+    dot_flash: &dyn crate::hil::FlashStorage,
+    key_type: CmStableKeyType,
+) -> Option<caliptra_mcu_error::McuResult<Option<OwnerPkHash>>> {
+    if params.dot_recovery_policy != crate::DotRecoveryPolicy::BackupBlob {
+        return None;
+    }
+    let recovery_handler = params.dot_recovery_handler?;
+
+    Some(
+        device_ownership_transfer::dot_recovery_flow(
+            env,
+            dot_fuses,
+            recovery_handler,
+            dot_flash,
+            key_type,
+        )
+        .and_then(|()| {
+            let mut blob_bytes = [0u8; device_ownership_transfer::DOT_BLOB_SIZE];
+            dot_flash
+                .read(&mut blob_bytes, 0)
+                .map_err(|_| McuError::ROM_COLD_BOOT_DOT_ERROR)?;
+            let blob: DotBlob = transmute!(blob_bytes);
+            device_ownership_transfer::dot_flow(env, dot_fuses, &blob, key_type)
+        }),
+    )
+}
+
+/// Handles an empty or corrupt DOT blob while the device is locked.
+///
+/// With reset recovery enabled, a configured local backup is attempted first.
+/// If it cannot restore a valid active blob, ROM reports the failure to the BMC
+/// through the reset-recovery flow. Platforms using the legacy handler chain
+/// retain their existing behavior when reset recovery is disabled.
+fn recover_locked_dot_or_fail(
+    env: &mut RomEnv,
+    dot_fuses: &crate::DotFuses,
+    params: &RomParameters,
+    dot_flash: &dyn crate::hil::FlashStorage,
+    i3c_base: I3cRegs,
+    original_err: McuError,
+) -> Option<OwnerPkHash> {
+    let key_type = params
+        .dot_stable_key_type
+        .unwrap_or(CmStableKeyType::IDevId);
+
+    if params.dot_recovery_reset_flow {
+        if let Some(result) =
+            attempt_dot_backup_recovery(env, dot_fuses, params, dot_flash, key_type)
+        {
+            match result {
+                Ok(owner) => {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom] DOT backup recovery succeeded, continuing cold boot"
+                    );
+                    return owner;
+                }
+                Err(err) => {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom] DOT backup recovery failed: {}",
+                        HexWord(err.into())
+                    );
+                }
+            }
+        }
+    }
+
+    maybe_enter_dot_recovery_reset_failure_flow(
+        &env.mci,
+        i3c_base,
+        params.dot_recovery_reset_flow,
+        original_err,
+    );
+
+    let err = attempt_dot_locked_recovery(env, dot_fuses, params, dot_flash, key_type);
+    fatal_error(err)
+}
+
 impl ColdBoot {
     fn program_field_entropy(
         program_field_entropy: &[bool; 4],
@@ -737,21 +822,18 @@ impl BootFlow for ColdBoot {
 
             if dot_blob.iter().all(|&b| b == 0) || dot_blob.iter().all(|&b| b == 0xFF) {
                 if dot_fuses.enabled && dot_fuses.is_locked() {
-                    maybe_enter_dot_recovery_reset_failure_flow(
-                        &env.mci,
+                    recover_locked_dot_or_fail(
+                        env,
+                        &dot_fuses,
+                        &params,
+                        dot_flash,
                         i3c_base,
-                        params.dot_recovery_reset_flow,
                         McuError::ROM_COLD_BOOT_DOT_ERROR,
-                    );
-                    let key_type = params
-                        .dot_stable_key_type
-                        .unwrap_or(CmStableKeyType::IDevId);
-                    let err =
-                        attempt_dot_locked_recovery(env, &dot_fuses, &params, dot_flash, key_type);
-                    fatal_error(err);
+                    )
+                } else {
+                    caliptra_mcu_romtime::println!("[mcu-rom] DOT empty");
+                    device_ownership_transfer::load_owner_pkhash(&env.otp)
                 }
-                caliptra_mcu_romtime::println!("[mcu-rom] DOT empty");
-                device_ownership_transfer::load_owner_pkhash(&env.otp)
             } else {
                 let dot_blob: DotBlob = transmute!(dot_blob);
                 match device_ownership_transfer::dot_flow(
@@ -765,26 +847,16 @@ impl BootFlow for ColdBoot {
                     Ok(owner) => owner,
                     Err(err) => {
                         if dot_fuses.is_locked() {
-                            maybe_enter_dot_recovery_reset_failure_flow(
-                                &env.mci,
-                                i3c_base,
-                                params.dot_recovery_reset_flow,
-                                err,
+                            recover_locked_dot_or_fail(
+                                env, &dot_fuses, &params, dot_flash, i3c_base, err,
+                            )
+                        } else {
+                            caliptra_mcu_romtime::println!(
+                                "[mcu-rom] DOT err: {}",
+                                HexWord(err.into())
                             );
-                            let key_type = params
-                                .dot_stable_key_type
-                                .unwrap_or(CmStableKeyType::IDevId);
-                            // Try locked-state recovery; if it succeeds it
-                            // resets and never returns.
-                            let _recovery_err = attempt_dot_locked_recovery(
-                                env, &dot_fuses, &params, dot_flash, key_type,
-                            );
+                            fatal_error(err)
                         }
-                        caliptra_mcu_romtime::println!(
-                            "[mcu-rom] DOT err: {}",
-                            HexWord(err.into())
-                        );
-                        fatal_error(err);
                     }
                 }
             }

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -128,6 +128,7 @@ fn recover_locked_dot_or_fail(
     dot_flash: &dyn crate::hil::FlashStorage,
     i3c_base: I3cRegs,
     original_err: McuError,
+    preserve_original_err: bool,
 ) -> Option<OwnerPkHash> {
     let key_type = params
         .dot_stable_key_type
@@ -161,8 +162,12 @@ fn recover_locked_dot_or_fail(
         original_err,
     );
 
-    let err = attempt_dot_locked_recovery(env, dot_fuses, params, dot_flash, key_type);
-    fatal_error(err)
+    let recovery_err = attempt_dot_locked_recovery(env, dot_fuses, params, dot_flash, key_type);
+    fatal_error(if preserve_original_err {
+        original_err
+    } else {
+        recovery_err
+    })
 }
 
 impl ColdBoot {
@@ -829,6 +834,7 @@ impl BootFlow for ColdBoot {
                         dot_flash,
                         i3c_base,
                         McuError::ROM_COLD_BOOT_DOT_ERROR,
+                        false,
                     )
                 } else {
                     caliptra_mcu_romtime::println!("[mcu-rom] DOT empty");
@@ -848,7 +854,7 @@ impl BootFlow for ColdBoot {
                     Err(err) => {
                         if dot_fuses.is_locked() {
                             recover_locked_dot_or_fail(
-                                env, &dot_fuses, &params, dot_flash, i3c_base, err,
+                                env, &dot_fuses, &params, dot_flash, i3c_base, err, true,
                             )
                         } else {
                             caliptra_mcu_romtime::println!(

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -879,6 +879,75 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// A valid local backup takes precedence over BMC reset recovery. ROM
+    /// restores the active copy and completes the current cold boot without
+    /// publishing the DOT failure status or requesting an intermediate reset.
+    #[test]
+    fn test_dot_recovery_reset_flow_restores_backup_and_continues_boot() {
+        const DEVICE_RESET_CTRL_PREVIOUS_DOT_SUCCEEDED: u32 = 0x11;
+        const DOT_RECOVERY_DEVICE_STATUS: u32 = 0x0094_000E;
+        const RECOVERY_BLOB_OFFSET: usize = 2048;
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let blob = create_valid_dot_blob(get_owner_pk_hash(), test_lak());
+        let mut flash_contents = vec![0u8; 4096];
+        flash_contents[RECOVERY_BLOB_OFFSET..RECOVERY_BLOB_OFFSET + DOT_BLOB_SIZE]
+            .copy_from_slice(blob.as_bytes());
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            dot_flash_initial_contents: Some(flash_contents),
+            rom_only: true,
+            otp_memory: Some(create_locked_otp_memory()),
+            rom_feature: Some("test-dot-recovery-reset-flow"),
+            ..Default::default()
+        });
+
+        let i3c_initialized = u16::from(McuRomBootStatus::I3cInitialized);
+        hw.step_until(|m| {
+            m.mci_boot_checkpoint() >= i3c_initialized
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 50_000_000
+        });
+        assert!(
+            hw.mci_fw_fatal_error().is_none(),
+            "ROM failed before I3C initialization"
+        );
+
+        hw.set_i3c_recovery_device_reset_ctrl(DEVICE_RESET_CTRL_PREVIOUS_DOT_SUCCEEDED);
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 150_000_000
+        });
+
+        assert!(
+            hw.mci_fw_fatal_error().is_none(),
+            "Cold boot after DOT backup recovery failed: 0x{:x}",
+            hw.mci_fw_fatal_error().unwrap_or(0)
+        );
+        assert!(
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE),
+            "Cold boot did not complete after DOT backup recovery"
+        );
+        assert_ne!(
+            hw.i3c_recovery_device_status_0(),
+            DOT_RECOVERY_DEVICE_STATUS,
+            "Successful local backup recovery must not signal BMC reset recovery"
+        );
+        assert_eq!(
+            &hw.read_dot_flash()[..DOT_BLOB_SIZE],
+            blob.as_bytes(),
+            "Backup blob was not restored to the active DOT slot"
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Test that a corrupt DOT blob in ODD state (locked) with no recovery handler fails
     /// with the BLOB_CORRUPT error.
     #[test]


### PR DESCRIPTION
Attempt local backup recovery before entering the BMC reset flow for an empty or corrupt locked DOT blob. Revalidate the restored active blob and continue the current cold boot on success, while preserving failure status reporting when recovery fails.