### PR TITLE
[OCP-LOCK]: Add MCU command to get DPE signer certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ name = "caliptra-mcu-mbox-lib"
 version = "0.1.0"
 dependencies = [
  "caliptra-mcu-common-commands",
+ "caliptra-mcu-libapi-caliptra",
  "caliptra-mcu-libsyscall-caliptra",
  "caliptra-mcu-libtock_alarm",
  "caliptra-mcu-libtock_console",
@@ -1889,6 +1890,7 @@ dependencies = [
  "caliptra-mcu-runtime-userspace-error",
  "caliptra-mcu-userlog",
  "defmt",
+ "dpe",
  "embassy-executor",
  "embassy-sync",
  "mcu-caliptra-api-lite",

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -138,6 +138,8 @@ impl CommandId {
 
     // Certificate commands
     pub const MC_EXPORT_ATTESTED_CSR: Self = Self(0x4D45_4143); // "MEAC"
+    pub const MC_DPE_SIGNER_CONTEXT_CERT: Self = Self(0x4D44_5343); // "MDSC"
+    pub const MC_GET_DPE_CERTIFICATE_CHAIN: Self = Self(0x4D44_4343); // "MDCC"
 
     // OCP Lock commands
     pub const MC_OCP_LOCK_ROTATE_HEK: Self = Self(0x4F4C_5248); // "OLRH"
@@ -215,6 +217,9 @@ pub enum McuMailboxReq {
     FuseRevokeVendorPkHash(FuseRevokeVendorPkHashReq),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrReq),
+    DpeSignerContextCert(DpeSignerContextCertReq),
+    GetDpeCertChain(GetDpeCertChainReq),
+
     // OCP Lock
     OcpLockSetPermaHek(OcpLockSetPermaHekReq),
     OcpLockRotateHek(OcpLockRotateHekReq),
@@ -276,6 +281,9 @@ impl McuMailboxReq {
             McuMailboxReq::ProvisionVendorPkHash(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseRevokeVendorPkHash(req) => Ok(req.as_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
+            McuMailboxReq::DpeSignerContextCert(req) => Ok(req.as_bytes()),
+            McuMailboxReq::GetDpeCertChain(req) => Ok(req.as_bytes()),
+
             McuMailboxReq::OcpLockSetPermaHek(req) => Ok(req.as_bytes()),
             McuMailboxReq::OcpLockRotateHek(req) => Ok(req.as_bytes()),
             McuMailboxReq::GetOcpLockEndorsementCert(req) => Ok(req.as_bytes()),
@@ -336,6 +344,9 @@ impl McuMailboxReq {
             McuMailboxReq::ProvisionVendorPkHash(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseRevokeVendorPkHash(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::DpeSignerContextCert(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::GetDpeCertChain(req) => Ok(req.as_mut_bytes()),
+
             McuMailboxReq::OcpLockSetPermaHek(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::OcpLockRotateHek(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::GetOcpLockEndorsementCert(req) => Ok(req.as_mut_bytes()),
@@ -398,6 +409,9 @@ impl McuMailboxReq {
             McuMailboxReq::ProvisionVendorPkHash(_) => CommandId::MC_PROVISION_VENDOR_PK_HASH,
             McuMailboxReq::FuseRevokeVendorPkHash(_) => CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH,
             McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
+            McuMailboxReq::DpeSignerContextCert(_) => CommandId::MC_DPE_SIGNER_CONTEXT_CERT,
+            McuMailboxReq::GetDpeCertChain(_) => CommandId::MC_GET_DPE_CERTIFICATE_CHAIN,
+
             McuMailboxReq::OcpLockSetPermaHek(_) => CommandId::MC_OCP_LOCK_SET_PERMA_HEK,
             McuMailboxReq::OcpLockRotateHek(_) => CommandId::MC_OCP_LOCK_ROTATE_HEK,
             McuMailboxReq::GetOcpLockEndorsementCert(_) => {
@@ -488,6 +502,9 @@ pub enum McuMailboxResp {
     FuseRevokeVendorPkHash(FuseRevokeVendorPkHashResp),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrResp),
+    DpeSignerContextCert(DpeSignerContextCertResp),
+    GetDpeCertChain(GetDpeCertChainResp),
+
     // OCP Lock
     OcpLockSetPermaHek(OcpLockSetPermaHekResp),
     OcpLockRotateHek(OcpLockRotateHekResp),
@@ -608,6 +625,9 @@ impl McuMailboxResp {
             McuMailboxResp::ProvisionVendorPkHash(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseRevokeVendorPkHash(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial(),
+            McuMailboxResp::DpeSignerContextCert(resp) => resp.as_bytes_partial(),
+            McuMailboxResp::GetDpeCertChain(resp) => resp.as_bytes_partial(),
+
             McuMailboxResp::OcpLockSetPermaHek(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::OcpLockRotateHek(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::GetOcpLockEndorsementCert(resp) => resp.as_bytes_partial(),
@@ -667,6 +687,9 @@ impl McuMailboxResp {
             McuMailboxResp::ProvisionVendorPkHash(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseRevokeVendorPkHash(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial_mut(),
+            McuMailboxResp::DpeSignerContextCert(resp) => resp.as_bytes_partial_mut(),
+            McuMailboxResp::GetDpeCertChain(resp) => resp.as_bytes_partial_mut(),
+
             McuMailboxResp::OcpLockSetPermaHek(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::OcpLockRotateHek(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::GetOcpLockEndorsementCert(resp) => resp.as_bytes_partial_mut(),
@@ -1611,6 +1634,67 @@ impl Default for ExportAttestedCsrResp {
 }
 impl McuResponseVarSize for ExportAttestedCsrResp {}
 
+/// MC_DPE_SIGNER_CONTEXT_CERT Command (0x4D44_5343 - "MDSC")
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Default)]
+pub struct DpeSignerContextCertReq {
+    pub hdr: MailboxReqHeader,
+}
+
+impl Request for DpeSignerContextCertReq {
+    const ID: CommandId = CommandId::MC_DPE_SIGNER_CONTEXT_CERT;
+    type Resp = DpeSignerContextCertResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct DpeSignerContextCertResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub cert_data: [u8; MAX_RESP_DATA_SIZE],
+}
+impl Default for DpeSignerContextCertResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            cert_data: [0u8; MAX_RESP_DATA_SIZE],
+        }
+    }
+}
+
+impl McuResponseVarSize for DpeSignerContextCertResp {}
+
+/// MC_GET_DPE_CERTIFICATE_CHAIN request: Retrieve DPE Certificate Chain
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Default)]
+pub struct GetDpeCertChainReq {
+    pub hdr: MailboxReqHeader,
+    pub offset: u32,
+    pub size: u32,
+}
+
+impl Request for GetDpeCertChainReq {
+    const ID: CommandId = CommandId::MC_GET_DPE_CERTIFICATE_CHAIN;
+    type Resp = GetDpeCertChainResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct GetDpeCertChainResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub cert_data: [u8; MAX_RESP_DATA_SIZE],
+}
+
+impl Default for GetDpeCertChainResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            cert_data: [0u8; MAX_RESP_DATA_SIZE],
+        }
+    }
+}
+
+impl McuResponseVarSize for GetDpeCertChainResp {}
+
 /// MC_PROVISION_VENDOR_PK_HASH request: Provision a new vendor PK hash
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
@@ -1918,6 +2002,58 @@ mod tests {
         assert_ne!(hdr.chksum, 0);
 
         // Verify checksum can be validated using verify_checksum
+        let payload = &bytes[core::mem::size_of::<u32>()..];
+        assert!(verify_checksum(hdr.chksum, 0, payload));
+    }
+
+    #[test]
+    fn test_dpe_signer_context_cert_command_id() {
+        assert_eq!(CommandId::MC_DPE_SIGNER_CONTEXT_CERT.0, 0x4D44_5343);
+        assert_eq!(CommandId::MC_GET_DPE_CERTIFICATE_CHAIN.0, 0x4D44_4343);
+    }
+
+    #[test]
+    fn test_get_dpe_cert_chain_req_serialization() {
+        let req = GetDpeCertChainReq {
+            hdr: MailboxReqHeader { chksum: 0x1234 },
+            offset: 0,
+            size: 1024,
+        };
+
+        let bytes = req.as_bytes();
+        assert_eq!(bytes.len(), core::mem::size_of::<GetDpeCertChainReq>());
+
+        let parsed = GetDpeCertChainReq::read_from_bytes(bytes).unwrap();
+        assert_eq!(parsed.hdr.chksum, 0x1234);
+        assert_eq!(parsed.size, 1024);
+    }
+
+    #[test]
+    fn test_dpe_signer_context_cert_req_serialization() {
+        let req = DpeSignerContextCertReq {
+            hdr: MailboxReqHeader { chksum: 0xABCD },
+        };
+
+        let bytes = req.as_bytes();
+        assert_eq!(bytes.len(), core::mem::size_of::<DpeSignerContextCertReq>());
+
+        let parsed = DpeSignerContextCertReq::read_from_bytes(bytes).unwrap();
+        assert_eq!(parsed.hdr.chksum, 0xABCD);
+    }
+
+    #[test]
+    fn test_dpe_signer_context_cert_resp_serialization() {
+        let mut resp = DpeSignerContextCertResp::default();
+        resp.hdr.data_len = 128;
+        resp.cert_data[..4].copy_from_slice(&[0x30, 0x82, 0x01, 0x00]);
+
+        let mut mbox_resp = McuMailboxResp::DpeSignerContextCert(resp);
+        mbox_resp.populate_chksum().unwrap();
+
+        let bytes = mbox_resp.as_bytes().unwrap();
+        let hdr = MailboxRespHeader::read_from_prefix(bytes).unwrap().0;
+        assert_ne!(hdr.chksum, 0);
+
         let payload = &bytes[core::mem::size_of::<u32>()..];
         assert!(verify_checksum(hdr.chksum, 0, payload));
     }

--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -36,6 +36,8 @@ These commands support common Caliptra management functions, including querying 
 | MC_FIRMWARE_VERSION           | 0x4D46_5756 ("MFWV") | Retrieves the version of the target firmware.                                         |
 | MC_DEVICE_CAPABILITIES        | 0x4D43_4150 ("MCAP") | Retrieve the device capabilities.                                                     |
 | MC_EXPORT_ATTESTED_CSR        | 0x4D45_4143 ("MEAC") | Exports an attested CSR for a specified device key, wrapped in a CoseSign1 structure. |
+| MC_DPE_SIGNER_CONTEXT_CERT    | 0x4D44_5343 ("MDSC") | Derives DPE signer context and returns the derived leaf certificate.                  |
+| MC_GET_DPE_CERTIFICATE_CHAIN  | 0x4D47_4343 ("MGCC") | Retrieves the DPE certificate chain.                                                  |
 | MC_GET_LOG                    | 0x4D47_4C47 ("MGLG") | Retrieves the debug log                                                               |
 | MC_CLEAR_LOG                  | 0x4D43_4C47 ("MCLG") | Clears the debug log                                                                  |
 | MC_FIPS_SELF_TEST_START       | 0x4D46_5354 ("MFST") | Starts the FIPS self-test to exercise the crypto engine.                              |

--- a/firmware-bundler/reference/emulator/user-app-devel.toml
+++ b/firmware-bundler/reference/emulator/user-app-devel.toml
@@ -40,6 +40,6 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x10000
-grant_space = 0x4000
+stack = 0xE000
+grant_space = 0x3000
 

--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -42,5 +42,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x10000
-grant_space = 0x4000
+stack = 0xE000
+grant_space = 0x3000

--- a/firmware-bundler/reference/fpga/user-app.toml
+++ b/firmware-bundler/reference/fpga/user-app.toml
@@ -34,5 +34,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x9e00
-grant_space = 0x4000
+stack = 0xE000
+grant_space = 0x3000

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -622,14 +622,18 @@ pub trait McuHwModel {
 
     /// Send a command to the mailbox but don't wait for the response
     fn start_mailbox_execute(&mut self, cmd: u32, buf: &[u8]) -> Result<()> {
-        // Read a 0 to get the lock
-        while !(self.mcu_manager().mbox0().mbox_lock().read().lock()) {
+        // Read to acquire the lock (true when lock is successfully acquired)
+        let mut acquired = false;
+        let start = std::time::Instant::now();
+        while start.elapsed() < std::time::Duration::from_secs(5) {
+            if self.mcu_manager().mbox0().mbox_lock().read().lock() {
+                acquired = true;
+                break;
+            }
             self.step();
         }
 
-        // Mailbox lock value should read 1 now
-        // If not, the reads are likely being blocked by the AXI_USER check or some other issue
-        if !(self.mcu_manager().mbox0().mbox_lock().read().lock()) {
+        if !acquired {
             bail!("Mailbox lock is not set");
         }
 

--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -18,11 +18,12 @@ use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError, PayloadSt
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use dpe::commands::{
-    CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, CommandHdr,
-    GetCertificateChainCmd, SignCommand, SignFlags, SignP384Cmd,
+    CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, CommandHdr, DeriveContextCmd,
+    DeriveContextFlags, GetCertificateChainCmd, SignCommand, SignFlags, SignP384Cmd,
 };
 use dpe::context::ContextHandle;
-use dpe::response::SignP384Resp;
+use dpe::response::{DeriveContextExportedCdiResp, SignP384Resp};
+use dpe::tci::TciMeasurement;
 use zerocopy::{FromBytes, FromZeros, IntoBytes, TryFromBytes};
 
 pub const IDEV_ECC_CSR_MAX_SIZE: usize = GetIdevCsrResp::DATA_MAX_SIZE;
@@ -188,6 +189,65 @@ impl CertContext {
                 self.get_attested_csr_inner(&mut req, csr_data).await
             }
         }
+    }
+
+    // TODO(clundin): Retain the exported_cdi handle.
+    pub async fn dpe_signer_context_cert(&mut self, cert: &mut [u8]) -> CaliptraApiResult<usize> {
+        let dpe_store = caliptra_mcu_libsyscall_caliptra::dpe_handle_store::DpeHandleStore::<
+            caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+        >::new(
+            caliptra_mcu_libsyscall_caliptra::dpe_handle_store::DPE_HANDLE_STORE_DRIVER_NUM,
+        );
+        let mut target =
+            caliptra_mcu_libsyscall_caliptra::dpe_handle_store::DpeHandleRecord::default();
+        dpe_store
+            .read_attestation_target(&mut target)
+            .map_err(|_| CaliptraApiError::InvalidResponse)?;
+
+        let cmd = DeriveContextCmd {
+            handle: ContextHandle(target.context_handle),
+            data: TciMeasurement([0u8; 48]),
+            flags: DeriveContextFlags::EXPORT_CDI
+                | DeriveContextFlags::CREATE_CERTIFICATE
+                | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+            tci_type: 0,
+            target_locality: 0,
+            svn: 0,
+        };
+
+        let mut cmd = Command::DeriveContext(&cmd);
+        let mut mbox_resp = InvokeDpeResp::default();
+        self.send_dpe_cmd(&mut cmd, &mut mbox_resp).await?;
+
+        let data_size = mbox_resp.data_size as usize;
+        if data_size > InvokeDpeResp::DATA_MAX_SIZE {
+            return Err(CaliptraApiError::InvalidResponse);
+        }
+
+        let (resp, _) = DeriveContextExportedCdiResp::try_read_from_prefix(&mbox_resp.data)
+            .map_err(|_| CaliptraApiError::InvalidResponse)?;
+
+        if resp.resp_hdr.status != 0 {
+            return Err(CaliptraApiError::InvalidResponse);
+        }
+
+        let cert_len = resp.certificate_size as usize;
+        if cert_len > cert.len() {
+            return Err(CaliptraApiError::InvalidResponse);
+        }
+
+        let cert_bytes = resp
+            .new_certificate
+            .get(..cert_len)
+            .ok_or(CaliptraApiError::InvalidResponse)?;
+
+        target.context_handle = resp.parent_handle.0;
+        dpe_store
+            .write_record(target.fw_id, &target)
+            .map_err(|_| CaliptraApiError::InvalidResponse)?;
+
+        cert[..cert_len].copy_from_slice(cert_bytes);
+        Ok(cert_len)
     }
 
     pub async fn certify_key(

--- a/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
+++ b/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
@@ -13,6 +13,8 @@ embassy-sync.workspace = true
 mcu-error.workspace = true
 caliptra-mcu-common-commands.workspace = true
 mcu-caliptra-api-lite = { workspace = true, features = ["mailbox-io"] }
+caliptra-mcu-libapi-caliptra.workspace = true
+dpe.workspace = true
 caliptra-mcu-libsyscall-caliptra.workspace = true
 caliptra-mcu-libtock_alarm.workspace = true
 caliptra-mcu-libtock_console.workspace = true

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -16,13 +16,14 @@ use caliptra_mcu_mbox_common::messages::{
     FuseIncreaseCaliptraMinSvnResp, FuseLockPartitionReq, FuseLockPartitionResp, FuseReadReq,
     FuseReadResp, FuseRevokeVendorPkHashReq, FuseRevokeVendorPkHashResp, FuseRevokeVendorPubKeyReq,
     FuseRevokeVendorPubKeyResp, FuseWriteReq, FuseWriteResp, GetAuthCmdChallengeReq,
-    GetAuthCmdChallengeResp, GetLogReq, LogType, MailboxReqHeader, MailboxRespHeader,
-    MailboxRespHeaderVarSize, McuFeProgReq, McuMailboxReq, McuMailboxResp,
+    GetAuthCmdChallengeResp, GetDpeCertChainReq, GetLogReq, LogType, MailboxReqHeader,
+    MailboxRespHeader, MailboxRespHeaderVarSize, McuFeProgReq, McuMailboxReq, McuMailboxResp,
     McuProdDebugUnlockReqReq, McuProdDebugUnlockReqResp, McuProdDebugUnlockTokenReq,
     McuResponseVarSize, ProvisionVendorPkHashReq, ProvisionVendorPkHashResp, DEVICE_CAPS_SIZE,
     MAX_FUSE_DATA_SIZE, MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
 };
 
+use caliptra_mcu_libtock_console::Console;
 #[cfg(feature = "ocp-lock")]
 use caliptra_mcu_mbox_common::messages::{
     GetOcpLockEndorsementCertReq, GetOcpLockEndorsementCertResp, GetOcpLockEpochKeyReportReq,
@@ -35,6 +36,10 @@ use caliptra_mcu_mbox_common::messages::{
     McuFipsPeriodicStatusResp,
 };
 use caliptra_mcu_romtime::{fuse_read_dai_params, PartitionId};
+use caliptra_mcu_userlog::{log_info, Hex32};
+
+#[allow(unused_imports)]
+use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
 use mcu_caliptra_api_lite::{raw, ApiAlloc, FwInfo};
 use mcu_error::McuResult;
@@ -188,6 +193,11 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
         self.busy.store(true, Ordering::SeqCst);
 
         let cmd_id = CommandId::from(cmd);
+        log_info!(
+            Console::<DefaultSyscalls>::writer(),
+            "MCU mailbox command called: 0x{}",
+            Hex32(cmd)
+        );
         let result = if let Some(caliptra_cmd) = caliptra_passthrough_cmd(cmd_id) {
             self.handle_crypto_passthrough(req_buf, req_len, caliptra_cmd, resp_buf)
                 .await
@@ -244,6 +254,12 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
                 }
                 CommandId::MC_PROD_DEBUG_UNLOCK_REQ => {
                     self.handle_prod_debug_unlock_req(req, resp_buf).await
+                }
+                CommandId::MC_DPE_SIGNER_CONTEXT_CERT => {
+                    self.handle_dpe_signer_context_cert(req, resp_buf).await
+                }
+                CommandId::MC_GET_DPE_CERTIFICATE_CHAIN => {
+                    self.handle_get_dpe_cert_chain(req, resp_buf).await
                 }
                 CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN => {
                     self.handle_prod_debug_unlock_token(req, resp_buf).await
@@ -528,6 +544,81 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
         Ok((&mut resp_buf[..resp_size], mbox_cmd_status))
     }
 
+    async fn handle_dpe_signer_context_cert<'r>(
+        &mut self,
+        _req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
+        let header_len = core::mem::size_of::<MailboxRespHeaderVarSize>();
+        if resp_buf.len() < header_len {
+            return Err(errors::INVALID_PARAMS);
+        }
+
+        let mut cert_ctx = caliptra_mcu_libapi_caliptra::certificate::CertContext::new();
+        let ret = cert_ctx
+            .dpe_signer_context_cert(&mut resp_buf[header_len..])
+            .await;
+
+        let (mbox_cmd_status, cert_len) = match ret {
+            Ok(len) => (MbxCmdStatus::Complete, len),
+            Err(_) => (MbxCmdStatus::Failure, 0),
+        };
+
+        let hdr = MailboxRespHeaderVarSize {
+            hdr: MailboxRespHeader {
+                chksum: 0,
+                fips_status: 0,
+            },
+            data_len: cert_len as u32,
+        };
+
+        resp_buf[..header_len].copy_from_slice(hdr.as_bytes());
+        let total_len = header_len + cert_len;
+        Ok((&mut resp_buf[..total_len], mbox_cmd_status))
+    }
+
+    async fn handle_get_dpe_cert_chain<'r>(
+        &mut self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
+        let req = GetDpeCertChainReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
+
+        let header_len = core::mem::size_of::<MailboxRespHeaderVarSize>();
+        if resp_buf.len() < header_len {
+            return Err(errors::INVALID_PARAMS);
+        }
+
+        let requested_size = req.size as usize;
+        if requested_size > MAX_RESP_DATA_SIZE || resp_buf.len() < header_len + requested_size {
+            return Err(errors::INVALID_PARAMS);
+        }
+
+        let mut cert_ctx = caliptra_mcu_libapi_caliptra::certificate::CertContext::new();
+        let ret = cert_ctx
+            .cert_chain_chunk(
+                req.offset as usize,
+                &mut resp_buf[header_len..header_len + requested_size],
+            )
+            .await;
+
+        let (mbox_cmd_status, cert_len) = match ret {
+            Ok(len) => (MbxCmdStatus::Complete, len),
+            Err(_) => (MbxCmdStatus::Failure, 0),
+        };
+
+        let hdr = MailboxRespHeaderVarSize {
+            hdr: MailboxRespHeader {
+                chksum: 0,
+                fips_status: 0,
+            },
+            data_len: cert_len as u32,
+        };
+
+        resp_buf[..header_len].copy_from_slice(hdr.as_bytes());
+        let total_len = header_len + cert_len;
+        Ok((&mut resp_buf[..total_len], mbox_cmd_status))
+    }
     async fn handle_prod_debug_unlock_token<'r>(
         &self,
         req: &[u8],

--- a/tests/integration/src/runtime/test_mcu_mailbox.rs
+++ b/tests/integration/src/runtime/test_mcu_mailbox.rs
@@ -4,7 +4,8 @@ use crate::test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, Tes
 use anyhow::Result;
 use caliptra_mcu_hw_model::{LifecycleControllerState, McuHwModel};
 use caliptra_mcu_mbox_common::messages::{
-    FirmwareVersionReq, GetAuthCmdChallengeReq, McuFeProgReq,
+    DpeSignerContextCertReq, FirmwareVersionReq, GetAuthCmdChallengeReq, GetDpeCertChainReq,
+    McuFeProgReq,
 };
 use caliptra_mcu_romtime::McuBootMilestones;
 
@@ -139,6 +140,140 @@ fn test_fe_prog_authorized_req() -> Result<()> {
         result.is_ok(),
         "FE_PROG authorized request failed: {result:?}"
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_dpe_signer_context_cert_cmd() -> Result<()> {
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // 1. Fetch DPE Certificate Chain via MC_GET_DPE_CERTIFICATE_CHAIN (looping across chunks)
+    let mut chain_der = Vec::new();
+    let mut offset = 0u32;
+    loop {
+        let chain_req = GetDpeCertChainReq {
+            offset,
+            size: 1024,
+            ..Default::default()
+        };
+        let chain_resp = hw.mailbox_execute_req(chain_req)?;
+        let chunk_len = chain_resp.hdr.data_len as usize;
+        if chunk_len == 0 {
+            break;
+        }
+        chain_der.extend_from_slice(&chain_resp.cert_data[..chunk_len]);
+        offset += chunk_len as u32;
+        if chunk_len < 1024 {
+            break;
+        }
+    }
+    assert!(
+        !chain_der.is_empty(),
+        "DPE Certificate Chain response data length should be non-zero"
+    );
+    assert_eq!(
+        chain_der[0], 0x30,
+        "DPE Cert Chain should start with ASN.1 SEQUENCE tag 0x30"
+    );
+
+    let mut chain_certs = Vec::new();
+    let mut remaining: &[u8] = &chain_der;
+    while !remaining.is_empty() && remaining[0] == 0x30 {
+        if let Ok(c) = openssl::x509::X509::from_der(remaining) {
+            if let Ok(der_bytes) = c.to_der() {
+                let der_len = der_bytes.len();
+                chain_certs.push(c);
+                if remaining.len() >= der_len {
+                    remaining = &remaining[der_len..];
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+    assert!(
+        !chain_certs.is_empty(),
+        "Parsed DPE certificate chain should not be empty"
+    );
+
+    // 2. Fetch DPE Signer Context Certificate via MC_DPE_SIGNER_CONTEXT_CERT
+    let req = DpeSignerContextCertReq::default();
+    let resp = hw.mailbox_execute_req(req)?;
+    let cert_len = resp.hdr.data_len as usize;
+    assert!(cert_len > 0, "Response data length should be non-zero");
+
+    let cert_der = &resp.cert_data[..cert_len];
+    assert_eq!(
+        cert_der[0], 0x30,
+        "Certificate should start with ASN.1 SEQUENCE tag 0x30"
+    );
+
+    let cert = openssl::x509::X509::from_der(cert_der)
+        .expect("Failed to parse DPE derived leaf certificate as DER");
+
+    // Validate Serial Number (SN)
+    let serial_bn = cert
+        .serial_number()
+        .to_bn()
+        .expect("Failed to get serial number BigNum");
+    let serial_hex = serial_bn
+        .to_hex_str()
+        .expect("Failed to convert serial number to hex");
+    assert!(!serial_hex.is_empty(), "Serial number should not be empty");
+
+    // Validate Subject CN
+    let subject_cn = cert
+        .subject_name()
+        .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+        .next()
+        .expect("DPE leaf certificate must have a Common Name entry in Subject");
+    let subject_cn_str = std::str::from_utf8(subject_cn.data().as_slice())
+        .expect("Subject Common Name should be valid UTF-8");
+    assert_eq!(
+        subject_cn_str, "DPE Exported CDI",
+        "DPE leaf certificate Subject CN should match expected 'DPE Exported CDI'"
+    );
+
+    let expected_issuer_cn = "Caliptra 2.1 Ecc384 Rt Alias";
+
+    // Validate Issuer CN
+    let issuer_cn = cert
+        .issuer_name()
+        .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+        .next()
+        .expect("DPE leaf certificate must have a Common Name entry in Issuer");
+    let issuer_cn_str = std::str::from_utf8(issuer_cn.data().as_slice())
+        .expect("Issuer Common Name should be valid UTF-8");
+
+    assert_eq!(issuer_cn_str, expected_issuer_cn,);
+
+    // Verify leaf certificate was signed by the runtime alias key
+    let expected_signer = chain_certs
+        .iter()
+        .find(|cert| {
+            let sn = cert
+                .subject_name()
+                .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+                .last()
+                .unwrap();
+
+            let sn = std::str::from_utf8(sn.data().as_slice()).unwrap();
+            sn == expected_issuer_cn
+        })
+        .unwrap();
+
+    let pubkey = expected_signer.public_key().unwrap();
+    assert!(cert.verify(&pubkey).is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
This is needed to verify the signature on the endorsement certificate and the epoch key report.

This resolves: https://github.com/chipsalliance/caliptra-mcu-sw/issues/1825