### PR TITLE
[update] rom: hand off stable owner key CMK to runtime

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
         - [DOT I3C Recovery Protocol](./dot_i3c.md)
     - [ROM Fuses](./rom-fuses.md)
     - [SVN Anti-Rollback](./svn.md)
+- [Firmware Handoff](./handoff.md)
 - [Runtime Specification](./runtime.md)
     - [Firmware Format](./firmware_format.md)
     - [PLDM Package](./pldm_package.md)

--- a/docs/src/handoff.md
+++ b/docs/src/handoff.md
@@ -1,0 +1,75 @@
+# Firmware Handoff
+
+MCU ROM passes boot state to MCU Runtime through `HandoffData`, a shared
+structure in a `NOLOAD` DCCM region. The platform reserves 1 KiB for this
+structure at a fixed address supplied to both ROM and Runtime linker scripts.
+The handoff is volatile: Runtime may use it after the ROM-to-Runtime reset, but
+software must not treat it as persistent storage across a power cycle.
+
+## Ownership
+
+`HandoffData` begins with two fixed-size tables:
+
+| Offset | Size | Owner | Purpose |
+|---:|---:|---|---|
+| 0 | 64 bytes | ROM | Data produced by ROM and consumed by Runtime |
+| 64 | 64 bytes | Runtime | Data produced or updated by Runtime |
+| 128 | 132 bytes | ROM | Stable owner key CMK extension |
+
+ROM initializes the complete defined structure during cold boot. Runtime must
+treat the ROM table and ROM extensions as read-only. Runtime may update the
+Runtime table only after ensuring that no conflicting references exist.
+
+The stable owner key extension is part of the shared layout regardless of
+whether a particular ROM build enables stable owner key derivation. This keeps
+the ROM and Runtime layouts identical across feature combinations.
+
+## Validation and Versioning
+
+Runtime accepts a handoff only when the marker and major version match. A
+consumer of a field added in a later minor version must also verify that the
+producer's minor version includes that field and validate any field-specific
+validity marker.
+
+Use the version numbers as follows:
+
+- Increment the minor version for an append-only, backward-compatible change.
+- Increment the major version for an incompatible change, including moving or
+  reinterpreting an existing field.
+- Never insert an extension before an existing field or change the size of one
+  of the original 64-byte tables.
+- Keep layout fields unconditional. If a feature is disabled, retain the same
+  bytes as reserved or invalid data.
+- Add compile-time size and offset assertions for every ABI change.
+
+This permits an older Runtime to ignore appended data from a newer ROM. A newer
+Runtime must use the minor version to avoid interpreting uninitialized bytes
+when booted by an older ROM. The complete structure must remain within the
+platform's 1 KiB reservation.
+
+## Stable Owner Key
+
+Handoff version 1.1 adds `StableOwnerKeyHandoff` at offset 128. It contains the
+128-byte encrypted Caliptra Cryptographic Manager key blob (CMK) followed by a
+32-bit validity marker. The CMK is an opaque capability; plaintext stable owner
+key material does not leave Caliptra.
+
+During cold boot, ROM:
+
+1. Initializes the CMK bytes to zero and the validity marker to invalid.
+2. Derives the stable owner key through `CM_DERIVE_STABLE_KEY`.
+3. Invalidates the marker, writes the complete encrypted CMK, and writes the
+   valid marker last.
+
+Runtime retrieves the CMK through `HandOff::stable_owner_key()`. The accessor
+returns `None` for handoff version 1.0, when derivation is disabled, or when the
+valid marker is absent. Runtime must keep the CMK in machine-mode-owned memory,
+must not log its contents, and must not expose it directly to userspace.
+
+## Adding Data
+
+Small fields may replace reserved bytes when doing so preserves the size and
+offset of every existing field. Larger fields must be added as fixed-layout
+extensions after the last defined block. Each extension that can be populated
+later than initial handoff creation should provide an explicit validity signal,
+which the producer publishes only after writing all associated data.

--- a/platforms/common/src/handoff.rs
+++ b/platforms/common/src/handoff.rs
@@ -78,6 +78,13 @@ impl HandOff<ReadWrite> {
 }
 
 impl<Access> HandOff<Access> {
+    /// Return the stable owner CMK produced by ROM when this handoff version supports it.
+    pub fn stable_owner_key(
+        &self,
+    ) -> Option<&[u8; caliptra_mcu_romtime::handoff::STABLE_OWNER_KEY_CMK_SIZE]> {
+        self.deref().stable_owner_key()
+    }
+
     /// Get the address of the handoff table.
     pub fn addr(&self) -> *const HandoffData {
         // Safety: Linker MUST place this static object in the `.handoff` section.

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -347,6 +347,11 @@ pub unsafe fn main() {
     let handoff = HandOff::new();
     if let Some(ref ho) = handoff {
         caliptra_mcu_romtime::println!("[mcu-runtime] HandOff marker: 0x{:08x}", ho.rom.fht_marker);
+        if ho.stable_owner_key().is_some() {
+            caliptra_mcu_romtime::println!(
+                "[mcu-runtime] Stable owner key CMK available from handoff"
+            );
+        }
         #[cfg(feature = "ocp-lock")]
         caliptra_mcu_romtime::println!(
             "[mcu-runtime] HEK state from handoff: active_state={:?}, active_slot={}, total_slots={}",

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -367,6 +367,11 @@ pub unsafe fn main() {
     let handoff = HandOff::new();
     if let Some(ref ho) = handoff {
         caliptra_mcu_romtime::println!("[mcu-runtime] HandOff marker: 0x{:08x}", ho.rom.fht_marker);
+        if ho.stable_owner_key().is_some() {
+            caliptra_mcu_romtime::println!(
+                "[mcu-runtime] Stable owner key CMK available from handoff"
+            );
+        }
         #[cfg(feature = "ocp-lock")]
         caliptra_mcu_romtime::println!(
             "[mcu-runtime] HEK state from handoff: active_state={:?}, active_slot={}, total_slots={}",

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -40,6 +40,8 @@ use caliptra_mcu_registers_generated::fuses;
 use caliptra_mcu_registers_generated::i3c::bits::RecIntfCfg;
 use caliptra_mcu_registers_generated::mci::bits::SecurityState::DeviceLifecycle as MciDeviceLifecycle;
 use caliptra_mcu_registers_generated::mci::bits::{MboxExecute, MboxLock};
+#[cfg(feature = "stable-owner-key")]
+use caliptra_mcu_romtime::handoff::{HandoffData, STABLE_OWNER_KEY_CMK_SIZE};
 #[cfg(feature = "ocp-lock")]
 use caliptra_mcu_romtime::ocp_lock::HekState;
 use caliptra_mcu_romtime::{
@@ -1491,13 +1493,17 @@ impl BootFlow for ColdBoot {
         {
             // Derive stable owner key using the OTP personalization seed.
             crate::call_hook(params.hooks, |h| h.pre_stable_owner_key_derivation());
-            if let Err(err) = crate::stable_owner_key::derive_stable_owner_key(env) {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom] Stable owner key derivation failed: {}",
-                    HexWord(err.into())
-                );
-                fatal_error(err);
-            }
+            let stable_owner_key = crate::stable_owner_key::derive_stable_owner_key(env)
+                .unwrap_or_else(|err| {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom] Stable owner key derivation failed: {}",
+                        HexWord(err.into())
+                    );
+                    fatal_error(err);
+                });
+            let stable_owner_key_cmk: [u8; STABLE_OWNER_KEY_CMK_SIZE] =
+                transmute!(stable_owner_key.0);
+            HandoffData::write_stable_owner_key(&stable_owner_key_cmk);
             crate::call_hook(params.hooks, |h| h.post_stable_owner_key_derivation());
         }
 

--- a/romtime/src/handoff.rs
+++ b/romtime/src/handoff.rs
@@ -12,7 +12,16 @@ pub const FHT_MARKER: u32 = 0x4855434D;
 pub const FHT_MAJOR_VERSION: u16 = 1;
 
 /// Minor version of the handoff table.
-pub const FHT_MINOR_VERSION: u16 = 0;
+pub const FHT_MINOR_VERSION: u16 = 1;
+
+/// Minor version that introduced the stable owner key handoff.
+pub const STABLE_OWNER_KEY_FHT_MINOR_VERSION: u16 = 1;
+
+/// Size of an encrypted Caliptra Cryptographic Manager key blob.
+pub const STABLE_OWNER_KEY_CMK_SIZE: usize = caliptra_api::mailbox::CMK_SIZE_BYTES;
+
+/// Valid marker for a stable owner key handoff ("SOKV" in little-endian).
+pub const STABLE_OWNER_KEY_VALID_MARKER: u32 = 0x564B4F53;
 
 /// Handoff data produced by ROM.
 #[derive(Debug, TryFromBytes, IntoBytes, KnownLayout, Immutable, Clone)]
@@ -66,6 +75,43 @@ impl Default for RuntimeHandoffTable {
     }
 }
 
+/// Stable owner key data produced by ROM for Runtime.
+#[derive(TryFromBytes, IntoBytes, KnownLayout, Immutable, Clone)]
+#[repr(C)]
+pub struct StableOwnerKeyHandoff {
+    /// Opaque encrypted CMK returned by Caliptra.
+    pub cmk: [u8; STABLE_OWNER_KEY_CMK_SIZE],
+
+    /// Written after `cmk` to indicate that the complete blob is available.
+    pub valid_marker: u32,
+}
+
+impl Default for StableOwnerKeyHandoff {
+    fn default() -> Self {
+        Self {
+            cmk: [0; STABLE_OWNER_KEY_CMK_SIZE],
+            valid_marker: 0,
+        }
+    }
+}
+
+impl core::fmt::Debug for StableOwnerKeyHandoff {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("StableOwnerKeyHandoff")
+            .field("cmk", &"<redacted>")
+            .field("valid", &self.cmk().is_some())
+            .finish()
+    }
+}
+
+impl StableOwnerKeyHandoff {
+    /// Return the encrypted CMK when ROM completed the handoff.
+    pub fn cmk(&self) -> Option<&[u8; STABLE_OWNER_KEY_CMK_SIZE]> {
+        (self.valid_marker == STABLE_OWNER_KEY_VALID_MARKER).then_some(&self.cmk)
+    }
+}
+
 /// Top-level handoff structure stored in DCCM.
 /// Resident at a well-known location in DCCM.
 ///
@@ -82,7 +128,22 @@ pub struct HandoffData {
 
     /// Runtime handoff table.
     pub runtime: RuntimeHandoffTable,
+
+    /// Stable owner key handoff produced by ROM.
+    ///
+    /// This field is appended after the original 128-byte layout so the ROM and
+    /// Runtime table offsets remain compatible with handoff version 1.0.
+    pub rom_stable_owner_key: StableOwnerKeyHandoff,
 }
+
+// Keep the original tables fixed so append-only extensions do not move either ABI.
+const _: () = assert!(core::mem::size_of::<RomHandoffTable>() == 64);
+const _: () = assert!(core::mem::size_of::<RuntimeHandoffTable>() == 64);
+const _: () = assert!(core::mem::size_of::<StableOwnerKeyHandoff>() == 132);
+const _: () = assert!(core::mem::offset_of!(HandoffData, rom) == 0);
+const _: () = assert!(core::mem::offset_of!(HandoffData, runtime) == 64);
+const _: () = assert!(core::mem::offset_of!(HandoffData, rom_stable_owner_key) == 128);
+const _: () = assert!(core::mem::size_of::<HandoffData>() == 260);
 
 // Enforce that the handoff data structure fits within the reserved 1KB region.
 const _: () = assert!(core::mem::size_of::<HandoffData>() <= 1024);
@@ -101,6 +162,14 @@ pub struct HandoffArgs {
 impl HandoffData {
     /// Size of the handoff data structure.
     pub const SIZE: usize = core::mem::size_of::<Self>();
+
+    /// Return the stable owner CMK when this handoff version supports it.
+    pub fn stable_owner_key(&self) -> Option<&[u8; STABLE_OWNER_KEY_CMK_SIZE]> {
+        if self.rom.fht_minor_ver < STABLE_OWNER_KEY_FHT_MINOR_VERSION {
+            return None;
+        }
+        self.rom_stable_owner_key.cmk()
+    }
 
     /// Persist handoff data structure from the given arguments.
     pub fn write(_args: HandoffArgs) {
@@ -123,7 +192,20 @@ impl HandoffData {
                     ..Default::default()
                 },
                 runtime: RuntimeHandoffTable::default(),
+                rom_stable_owner_key: StableOwnerKeyHandoff::default(),
             }
+        }
+    }
+
+    /// Persist an encrypted stable owner CMK for Runtime.
+    pub fn write_stable_owner_key(cmk: &[u8; STABLE_OWNER_KEY_CMK_SIZE]) {
+        // Safety: ROM owns the handoff table while constructing data for Runtime.
+        // Invalidate first and publish the marker only after the full CMK is present.
+        unsafe {
+            let handoff = &raw mut HANDOFF;
+            (*handoff).rom_stable_owner_key.valid_marker = 0;
+            (*handoff).rom_stable_owner_key.cmk = *cmk;
+            (*handoff).rom_stable_owner_key.valid_marker = STABLE_OWNER_KEY_VALID_MARKER;
         }
     }
 }
@@ -148,4 +230,43 @@ pub static mut HANDOFF: HandoffData = HandoffData {
         padding: [0; 44],
     },
     runtime: RuntimeHandoffTable { reserved: [0; 64] },
+    rom_stable_owner_key: StableOwnerKeyHandoff {
+        cmk: [0; STABLE_OWNER_KEY_CMK_SIZE],
+        valid_marker: 0,
+    },
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{offset_of, size_of};
+
+    #[test]
+    fn handoff_layout_is_append_only() {
+        assert_eq!(size_of::<RomHandoffTable>(), 64);
+        assert_eq!(size_of::<RuntimeHandoffTable>(), 64);
+        assert_eq!(size_of::<StableOwnerKeyHandoff>(), 132);
+        assert_eq!(offset_of!(HandoffData, rom), 0);
+        assert_eq!(offset_of!(HandoffData, runtime), 64);
+        assert_eq!(offset_of!(HandoffData, rom_stable_owner_key), 128);
+        assert_eq!(size_of::<HandoffData>(), 260);
+    }
+
+    #[test]
+    fn stable_owner_key_requires_valid_marker() {
+        let mut handoff = HandoffData::default();
+        assert!(handoff.stable_owner_key().is_none());
+
+        handoff.rom_stable_owner_key.cmk = [0x5a; STABLE_OWNER_KEY_CMK_SIZE];
+        assert!(handoff.stable_owner_key().is_none());
+
+        handoff.rom_stable_owner_key.valid_marker = STABLE_OWNER_KEY_VALID_MARKER;
+        assert_eq!(
+            handoff.stable_owner_key(),
+            Some(&[0x5a; STABLE_OWNER_KEY_CMK_SIZE])
+        );
+
+        handoff.rom.fht_minor_ver = STABLE_OWNER_KEY_FHT_MINOR_VERSION - 1;
+        assert!(handoff.stable_owner_key().is_none());
+    }
+}

--- a/tests/integration/src/test_owner_stable_key.rs
+++ b/tests/integration/src/test_owner_stable_key.rs
@@ -25,7 +25,7 @@ mod test {
 
         let mut hw = start_runtime_hw_model(TestParams {
             otp_memory: Some(otp),
-            rom_only: true,
+            feature: Some("test-exit-immediately"),
             rom_feature: Some("stable-owner-key"),
             ..Default::default()
         });
@@ -53,7 +53,16 @@ mod test {
             checkpoint
         );
 
-        println!("[TEST] Stable owner key derivation path succeeded");
+        hw.step_until_exit_success()
+            .expect("Runtime failed to retrieve stable owner key handoff");
+        assert!(
+            hw.output()
+                .peek()
+                .contains("[mcu-runtime] Stable owner key CMK available from handoff"),
+            "Runtime did not report a valid stable owner key handoff"
+        );
+
+        println!("[TEST] Stable owner key derivation and handoff succeeded");
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
Store the derived encrypted CMK in an append-only ROM-owned handoff extension and publish it with a validity marker. Add version-aware Runtime access, ABI layout checks, integration coverage, and handoff documentation.