### PR TITLE
feat(cmd-auth): [A]widen authorization challenge/nonce to 48 bytes

### DIFF
--- a/caliptra-util-host/command-types/src/fuse.rs
+++ b/caliptra-util-host/command-types/src/fuse.rs
@@ -17,8 +17,11 @@ use crate::{CaliptraCommandId, CommandRequest, CommandResponse, CommonResponse};
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-/// Size of the authorization challenge nonce in bytes
-pub const AUTH_CMD_CHALLENGE_SIZE: usize = 48;
+/// Size of the authorization challenge nonce in bytes.
+///
+/// Re-exported from `caliptra-mcu-mbox-common`, the single source of truth for
+/// the nonce width, so the host and device never diverge.
+pub use caliptra_mcu_mbox_common::messages::AUTH_CMD_NONCE_LEN as AUTH_CMD_CHALLENGE_SIZE;
 
 /// Canonical command identifier for the GET_AUTH_CMD_CHALLENGE command used in sub-command dispatch.
 ///

--- a/caliptra-util-host/command-types/src/fuse.rs
+++ b/caliptra-util-host/command-types/src/fuse.rs
@@ -3,21 +3,22 @@
 //! Fuse Commands
 //!
 //! Command structures for fuse operations including authorized commands
-//! that require a challenge-response HMAC flow.
+//! that require a challenge-response dual-signature flow.
 //!
 //! ## Authorization Flow
 //!
 //! Authorized commands (e.g., `FeProg`) require the caller to:
 //! 1. Request a challenge nonce via `GetAuthCmdChallenge`
-//! 2. Compute HMAC-SHA384 over `cmd_id(BE) || cmd_body || challenge`
-//! 3. Send the command with the 48-byte MAC appended
+//! 2. Sign `cmd_id(BE) || cmd_body || challenge` with both ECDSA-P384 and
+//!    ML-DSA-87, producing a hybrid dual signature
+//! 3. Send the command with the hybrid ECDSA-P384 + ML-DSA-87 signature appended
 
 use crate::{CaliptraCommandId, CommandRequest, CommandResponse, CommonResponse};
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Size of the authorization challenge nonce in bytes
-pub const AUTH_CMD_CHALLENGE_SIZE: usize = 32;
+pub const AUTH_CMD_CHALLENGE_SIZE: usize = 48;
 
 /// Canonical command identifier for the GET_AUTH_CMD_CHALLENGE command used in sub-command dispatch.
 ///
@@ -36,8 +37,9 @@ pub const MC_FE_PROG_CANONICAL_CMD_ID: u32 = 0x4D43_4650;
 
 /// Request a challenge nonce for authorizing privileged commands.
 ///
-/// The returned challenge must be included in the HMAC computation
-/// for the subsequent authorized command.
+/// The returned challenge must be included in the signed transcript
+/// (`cmd_id || cmd_body || challenge`) and signed with both ECDSA-P384
+/// and ML-DSA-87 for the subsequent authorized command.
 #[repr(C)]
 #[derive(Debug, Clone, Default, IntoBytes, FromBytes, Immutable)]
 pub struct GetAuthCmdChallengeRequest {

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -4,6 +4,8 @@
 //!
 //! Provides the [`CommandAuthChallengeSigner`] trait and one implementation:
 //! - [`AsymmetricCommandAuthorizer`]: Dual asymmetric verification using ECC P-384 and ML-DSA-87.
+//!
+//! The authorized-command challenge/nonce is 48 bytes wide.
 
 use anyhow::Result;
 use caliptra_image_types::MLDSA87_SIGNATURE_BYTE_SIZE;

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -14,8 +14,13 @@ use fips204::ml_dsa_87;
 use fips204::traits::{KeyGen, Signer as MldsaSigner};
 use p384::ecdsa::{signature::Signer, Signature, SigningKey};
 
-/// Width of the authorization challenge nonce in bytes.
-pub const AUTH_CMD_NONCE_LEN: usize = 48;
+/// Width of the authorization challenge nonce in bytes. Re-exported from
+/// `caliptra-mcu-mbox-common`, the single source of truth for this size.
+pub use caliptra_mcu_mbox_common::messages::AUTH_CMD_NONCE_LEN;
+
+// The signer's wire/signing logic assumes a 48-byte nonce; assert it near the
+// use site so a future change to the shared constant fails to compile here.
+const _: () = assert!(AUTH_CMD_NONCE_LEN == 48);
 
 /// Trait for authorizing Caliptra commands that require challenge-response signatures.
 pub trait CommandAuthChallengeSigner: Send + Sync {
@@ -93,6 +98,7 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
 mod tests {
     use super::*;
     use caliptra_image_types::MLDSA87_SIGNATURE_BYTE_SIZE;
+    use fips204::traits::Verifier as MldsaVerifier;
     use p384::ecdsa::{signature::Verifier, Signature as EcdsaSignature, VerifyingKey};
 
     /// Test vendor keypair (matches the integration-test vector).
@@ -103,17 +109,27 @@ mod tests {
     ];
     const TEST_MLDSA_SEED: [u8; 32] = *b"caliptra-mcu-testing-mldsa-seed-";
 
-    /// The authorization nonce is 48 bytes.
-    #[test]
-    fn nonce_width_is_48() {
-        assert_eq!(AUTH_CMD_NONCE_LEN, 48);
+    /// The signed message on this baseline is `cmd_id(BE) || payload || challenge`.
+    fn message(cmd_id: u32, payload: &[u8], nonce: &[u8]) -> Vec<u8> {
+        let mut m = Vec::new();
+        m.extend_from_slice(&cmd_id.to_be_bytes());
+        m.extend_from_slice(payload);
+        m.extend_from_slice(nonce);
+        m
+    }
+
+    /// Recreate the ML-DSA-87 public key from the test seed for verification.
+    fn mldsa_pubkey() -> ml_dsa_87::PublicKey {
+        let (pk, _sk) = ml_dsa_87::KG::keygen_from_seed(&TEST_MLDSA_SEED);
+        pk
     }
 
     /// `authorize` accepts a 48-byte challenge and produces a well-formed
-    /// `HybridSignature` (correct sizes, non-zero legs) whose ECDSA leg verifies
-    /// over the raw signed message `cmd_id(BE) || payload || challenge`.
+    /// `HybridSignature` whose BOTH legs verify over the signed message: the
+    /// ECDSA leg against the vendor P-384 key, and the ML-DSA-87 leg against the
+    /// vendor ML-DSA key.
     #[test]
-    fn authorize_round_trips_over_48_byte_nonce() {
+    fn authorize_round_trips_both_legs() {
         let signer =
             AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED).unwrap();
         let cmd_id: u32 = 0x4D43_4650; // MC_FE_PROG ("MCFP")
@@ -121,34 +137,30 @@ mod tests {
         let challenge = [0x11u8; AUTH_CMD_NONCE_LEN];
 
         let sig = signer.authorize(cmd_id, &payload, &challenge).unwrap();
-
-        // Sizes are locked by the wire contract.
         assert_eq!(sig.ecc_sig_r.len(), 48);
         assert_eq!(sig.ecc_sig_s.len(), 48);
         assert_eq!(sig.mldsa_sig.len(), MLDSA87_SIGNATURE_BYTE_SIZE);
-        // Signatures must not be all-zero.
-        assert!(sig.ecc_sig_r.iter().any(|&b| b != 0));
-        assert!(sig.mldsa_sig.iter().take(4627).any(|&b| b != 0));
 
-        // Reconstruct the raw signed message and verify the ECDSA leg against
-        // the vendor public key (proves the 48-byte nonce is what was signed).
-        let mut message = Vec::new();
-        message.extend_from_slice(&cmd_id.to_be_bytes());
-        message.extend_from_slice(&payload);
-        message.extend_from_slice(&challenge);
+        let msg = message(cmd_id, &payload, &challenge);
 
-        let signing_key = SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap();
-        let verifying_key = VerifyingKey::from(&signing_key);
-        let mut sig_bytes = [0u8; 96];
-        sig_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
-        sig_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
-        let ecdsa_sig = EcdsaSignature::from_slice(&sig_bytes).unwrap();
-        assert!(verifying_key.verify(&message, &ecdsa_sig).is_ok());
+        // ECDSA leg (p384 hashes the message with SHA-384 internally).
+        let vk = VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
+        let mut ecc_bytes = [0u8; 96];
+        ecc_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
+        ecc_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
+        assert!(vk
+            .verify(&msg, &EcdsaSignature::from_slice(&ecc_bytes).unwrap())
+            .is_ok());
+
+        // ML-DSA-87 leg: fips204 sig is the first 4627 bytes (the struct pads to 4628).
+        let mldsa_sig: [u8; 4627] = sig.mldsa_sig[..4627].try_into().unwrap();
+        assert!(mldsa_pubkey().verify(&msg, &mldsa_sig, &[]));
     }
 
-    /// A challenge that differs from the one signed must NOT verify (freshness).
+    /// A challenge that differs from the one signed must NOT verify on EITHER
+    /// leg (freshness) — checked for ECDSA and ML-DSA-87.
     #[test]
-    fn wrong_nonce_does_not_verify() {
+    fn wrong_nonce_does_not_verify_either_leg() {
         let signer =
             AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED).unwrap();
         let cmd_id: u32 = 0x4D43_4650;
@@ -157,18 +169,18 @@ mod tests {
             .authorize(cmd_id, &payload, &[0x11u8; AUTH_CMD_NONCE_LEN])
             .unwrap();
 
-        // Verify against a message built with a DIFFERENT nonce.
-        let mut message = Vec::new();
-        message.extend_from_slice(&cmd_id.to_be_bytes());
-        message.extend_from_slice(&payload);
-        message.extend_from_slice(&[0x22u8; AUTH_CMD_NONCE_LEN]);
+        // Message built with a DIFFERENT nonce.
+        let wrong = message(cmd_id, &payload, &[0x22u8; AUTH_CMD_NONCE_LEN]);
 
-        let verifying_key =
-            VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
-        let mut sig_bytes = [0u8; 96];
-        sig_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
-        sig_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
-        let ecdsa_sig = EcdsaSignature::from_slice(&sig_bytes).unwrap();
-        assert!(verifying_key.verify(&message, &ecdsa_sig).is_err());
+        let vk = VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
+        let mut ecc_bytes = [0u8; 96];
+        ecc_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
+        ecc_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
+        assert!(vk
+            .verify(&wrong, &EcdsaSignature::from_slice(&ecc_bytes).unwrap())
+            .is_err());
+
+        let mldsa_sig: [u8; 4627] = sig.mldsa_sig[..4627].try_into().unwrap();
+        assert!(!mldsa_pubkey().verify(&wrong, &mldsa_sig, &[]));
     }
 }

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -20,6 +20,7 @@ pub use caliptra_mcu_mbox_common::messages::AUTH_CMD_NONCE_LEN;
 
 // The signer's wire/signing logic assumes a 48-byte nonce; assert it near the
 // use site so a future change to the shared constant fails to compile here.
+// (Width is fixed by the Caliptra prod-debug-unlock challenge/nonce format.)
 const _: () = assert!(AUTH_CMD_NONCE_LEN == 48);
 
 /// Trait for authorizing Caliptra commands that require challenge-response signatures.

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -12,13 +12,16 @@ use fips204::ml_dsa_87;
 use fips204::traits::{KeyGen, Signer as MldsaSigner};
 use p384::ecdsa::{signature::Signer, Signature, SigningKey};
 
+/// Width of the authorization challenge nonce in bytes.
+pub const AUTH_CMD_NONCE_LEN: usize = 48;
+
 /// Trait for authorizing Caliptra commands that require challenge-response signatures.
 pub trait CommandAuthChallengeSigner: Send + Sync {
     fn authorize(
         &self,
         cmd_id: u32,
         payload: &[u8],
-        challenge: &[u8; 32],
+        challenge: &[u8; AUTH_CMD_NONCE_LEN],
     ) -> Result<HybridSignature>;
 }
 
@@ -49,9 +52,9 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
         &self,
         cmd_id: u32,
         payload: &[u8],
-        challenge: &[u8; 32],
+        challenge: &[u8; AUTH_CMD_NONCE_LEN],
     ) -> Result<HybridSignature> {
-        // Reconstruct the message: cmd_id(BE,4) || payload || challenge(32)
+        // Reconstruct the message: cmd_id(BE,4) || payload || challenge(48)
         let mut message = Vec::new();
         message.extend_from_slice(&cmd_id.to_be_bytes());
         message.extend_from_slice(payload);
@@ -81,5 +84,89 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("Failed to convert ML-DSA signature"))?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use caliptra_image_types::MLDSA87_SIGNATURE_BYTE_SIZE;
+    use p384::ecdsa::{signature::Verifier, Signature as EcdsaSignature, VerifyingKey};
+
+    /// Test vendor keypair (matches the integration-test vector).
+    const TEST_ECC_PRIV_KEY: [u8; 48] = [
+        61, 169, 230, 128, 175, 245, 161, 206, 169, 106, 62, 137, 129, 2, 134, 251, 59, 48, 48,
+        169, 201, 36, 173, 47, 32, 49, 160, 125, 41, 64, 82, 169, 124, 175, 161, 252, 110, 167, 96,
+        164, 61, 183, 99, 202, 159, 47, 112, 54,
+    ];
+    const TEST_MLDSA_SEED: [u8; 32] = *b"caliptra-mcu-testing-mldsa-seed-";
+
+    /// The authorization nonce is 48 bytes.
+    #[test]
+    fn nonce_width_is_48() {
+        assert_eq!(AUTH_CMD_NONCE_LEN, 48);
+    }
+
+    /// `authorize` accepts a 48-byte challenge and produces a well-formed
+    /// `HybridSignature` (correct sizes, non-zero legs) whose ECDSA leg verifies
+    /// over the raw signed message `cmd_id(BE) || payload || challenge`.
+    #[test]
+    fn authorize_round_trips_over_48_byte_nonce() {
+        let signer =
+            AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED).unwrap();
+        let cmd_id: u32 = 0x4D43_4650; // MC_FE_PROG ("MCFP")
+        let payload = [0xA5u8; 8];
+        let challenge = [0x11u8; AUTH_CMD_NONCE_LEN];
+
+        let sig = signer.authorize(cmd_id, &payload, &challenge).unwrap();
+
+        // Sizes are locked by the wire contract.
+        assert_eq!(sig.ecc_sig_r.len(), 48);
+        assert_eq!(sig.ecc_sig_s.len(), 48);
+        assert_eq!(sig.mldsa_sig.len(), MLDSA87_SIGNATURE_BYTE_SIZE);
+        // Signatures must not be all-zero.
+        assert!(sig.ecc_sig_r.iter().any(|&b| b != 0));
+        assert!(sig.mldsa_sig.iter().take(4627).any(|&b| b != 0));
+
+        // Reconstruct the raw signed message and verify the ECDSA leg against
+        // the vendor public key (proves the 48-byte nonce is what was signed).
+        let mut message = Vec::new();
+        message.extend_from_slice(&cmd_id.to_be_bytes());
+        message.extend_from_slice(&payload);
+        message.extend_from_slice(&challenge);
+
+        let signing_key = SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap();
+        let verifying_key = VerifyingKey::from(&signing_key);
+        let mut sig_bytes = [0u8; 96];
+        sig_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
+        sig_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
+        let ecdsa_sig = EcdsaSignature::from_slice(&sig_bytes).unwrap();
+        assert!(verifying_key.verify(&message, &ecdsa_sig).is_ok());
+    }
+
+    /// A challenge that differs from the one signed must NOT verify (freshness).
+    #[test]
+    fn wrong_nonce_does_not_verify() {
+        let signer =
+            AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED).unwrap();
+        let cmd_id: u32 = 0x4D43_4650;
+        let payload = [0xA5u8; 8];
+        let sig = signer
+            .authorize(cmd_id, &payload, &[0x11u8; AUTH_CMD_NONCE_LEN])
+            .unwrap();
+
+        // Verify against a message built with a DIFFERENT nonce.
+        let mut message = Vec::new();
+        message.extend_from_slice(&cmd_id.to_be_bytes());
+        message.extend_from_slice(&payload);
+        message.extend_from_slice(&[0x22u8; AUTH_CMD_NONCE_LEN]);
+
+        let verifying_key =
+            VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
+        let mut sig_bytes = [0u8; 96];
+        sig_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
+        sig_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
+        let ecdsa_sig = EcdsaSignature::from_slice(&sig_bytes).unwrap();
+        assert!(verifying_key.verify(&message, &ecdsa_sig).is_err());
     }
 }

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1396,6 +1396,13 @@ pub struct FuseLockPartitionResp {
 }
 impl Response for FuseLockPartitionResp {}
 
+/// Width, in bytes, of the authorized-command challenge nonce.
+///
+/// Single source of truth for the nonce size — every authorized-command site
+/// (challenge response, signer, device verifier, transports, tests) references
+/// this constant instead of a hard-coded `48`.
+pub const AUTH_CMD_NONCE_LEN: usize = 48;
+
 /// MC_GET_AUTH_CMD_CHALLENGE request: Get a challenge nonce to prove freshness in auth commands
 #[repr(C)]
 #[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
@@ -1415,15 +1422,15 @@ impl Request for GetAuthCmdChallengeReq {
 pub struct GetAuthCmdChallengeResp {
     pub hdr: MailboxRespHeader,
     pub reserved: u32,
-    pub challenge: [u8; 48],
+    pub challenge: [u8; AUTH_CMD_NONCE_LEN],
 }
-// `[u8; 48]` does not implement `Default` via derive, so provide it by hand.
+// `[u8; AUTH_CMD_NONCE_LEN]` does not implement `Default` via derive, so provide it by hand.
 impl Default for GetAuthCmdChallengeResp {
     fn default() -> Self {
         Self {
             hdr: MailboxRespHeader::default(),
             reserved: 0,
-            challenge: [0u8; 48],
+            challenge: [0u8; AUTH_CMD_NONCE_LEN],
         }
     }
 }

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1411,11 +1411,21 @@ impl Request for GetAuthCmdChallengeReq {
 
 /// MC_GET_AUTH_CMD_CHALLENGE response: Indicates success or failure.
 #[repr(C)]
-#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct GetAuthCmdChallengeResp {
     pub hdr: MailboxRespHeader,
     pub reserved: u32,
-    pub challenge: [u8; 32],
+    pub challenge: [u8; 48],
+}
+// `[u8; 48]` does not implement `Default` via derive, so provide it by hand.
+impl Default for GetAuthCmdChallengeResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            reserved: 0,
+            challenge: [0u8; 48],
+        }
+    }
 }
 impl Response for GetAuthCmdChallengeResp {}
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -11,7 +11,7 @@ use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
-use caliptra_mcu_mbox_common::messages::HybridSignature;
+use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use mcu_caliptra_api_lite::{
     fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
     request_debug_unlock_challenge, rng_generate, ApiAlloc, McuErrorCode,
@@ -91,8 +91,10 @@ pub async fn export_idevid_csr(algorithm: u32, out: &mut [u8]) -> CaliptraCmdRes
     }
 }
 
-pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResult<[u8; 48]> {
-    let mut challenge = [0u8; 48];
+pub async fn generate_auth_challenge<A: ApiAlloc>(
+    alloc: &A,
+) -> CaliptraCmdResult<[u8; AUTH_CMD_NONCE_LEN]> {
+    let mut challenge = [0u8; AUTH_CMD_NONCE_LEN];
     rng_generate(alloc, &mut challenge)
         .await
         .map_err(map_mcu_err)?;
@@ -102,7 +104,7 @@ pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResul
 pub async fn verify_authorized_signatures(
     cmd_id: u32,
     payload: &[u8],
-    challenge: &[u8; 48],
+    challenge: &[u8; AUTH_CMD_NONCE_LEN],
     ecc_pub_x: [u8; 48],
     ecc_pub_y: [u8; 48],
     mldsa_pub: [u8; 2592],

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -91,8 +91,8 @@ pub async fn export_idevid_csr(algorithm: u32, out: &mut [u8]) -> CaliptraCmdRes
     }
 }
 
-pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResult<[u8; 32]> {
-    let mut challenge = [0u8; 32];
+pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResult<[u8; 48]> {
+    let mut challenge = [0u8; 48];
     rng_generate(alloc, &mut challenge)
         .await
         .map_err(map_mcu_err)?;
@@ -102,7 +102,7 @@ pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResul
 pub async fn verify_authorized_signatures(
     cmd_id: u32,
     payload: &[u8],
-    challenge: &[u8; 32],
+    challenge: &[u8; 48],
     ecc_pub_x: [u8; 48],
     ecc_pub_y: [u8; 48],
     mldsa_pub: [u8; 2592],

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -14,13 +14,13 @@ use zerocopy::FromBytes;
 
 extern crate alloc;
 
-static CHALLENGE: Mutex<CriticalSectionRawMutex, RefCell<Option<[u8; 32]>>> =
+static CHALLENGE: Mutex<CriticalSectionRawMutex, RefCell<Option<[u8; 48]>>> =
     Mutex::new(RefCell::new(None));
 
 #[derive(Default)]
 pub struct MockCommandAuthorizer;
 
-fn set_challenge(challenge: [u8; 32]) {
+fn set_challenge(challenge: [u8; 48]) {
     CHALLENGE.lock(|state| *state.borrow_mut() = Some(challenge));
 }
 
@@ -78,11 +78,11 @@ impl CommandAuthorizer for MockCommandAuthorizer {
         .map_err(|_| AuthorizationError)
     }
 
-    fn take_challenge(&mut self) -> Option<[u8; 32]> {
+    fn take_challenge(&mut self) -> Option<[u8; 48]> {
         CHALLENGE.lock(|state| state.borrow_mut().take())
     }
 
-    fn set_challenge(&mut self, challenge: [u8; 32]) {
+    fn set_challenge(&mut self, challenge: [u8; 48]) {
         set_challenge(challenge);
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -4,7 +4,7 @@ use crate::auth_keys::{TEST_AUTH_ECC_PUB_KEY_X, TEST_AUTH_ECC_PUB_KEY_Y, TEST_AU
 use caliptra_mcu_common_commands::{AuthorizationError, CommandAuthorizer};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq,
-    HybridSignature, MailboxReqHeader, McuFeProgReq, ProvisionVendorPkHashReq,
+    HybridSignature, MailboxReqHeader, McuFeProgReq, ProvisionVendorPkHashReq, AUTH_CMD_NONCE_LEN,
 };
 use core::cell::RefCell;
 use core::mem::size_of;
@@ -14,13 +14,13 @@ use zerocopy::FromBytes;
 
 extern crate alloc;
 
-static CHALLENGE: Mutex<CriticalSectionRawMutex, RefCell<Option<[u8; 48]>>> =
+static CHALLENGE: Mutex<CriticalSectionRawMutex, RefCell<Option<[u8; AUTH_CMD_NONCE_LEN]>>> =
     Mutex::new(RefCell::new(None));
 
 #[derive(Default)]
 pub struct MockCommandAuthorizer;
 
-fn set_challenge(challenge: [u8; 48]) {
+fn set_challenge(challenge: [u8; AUTH_CMD_NONCE_LEN]) {
     CHALLENGE.lock(|state| *state.borrow_mut() = Some(challenge));
 }
 
@@ -78,11 +78,11 @@ impl CommandAuthorizer for MockCommandAuthorizer {
         .map_err(|_| AuthorizationError)
     }
 
-    fn take_challenge(&mut self) -> Option<[u8; 48]> {
+    fn take_challenge(&mut self) -> Option<[u8; AUTH_CMD_NONCE_LEN]> {
         CHALLENGE.lock(|state| state.borrow_mut().take())
     }
 
-    fn set_challenge(&mut self, challenge: [u8; 48]) {
+    fn set_challenge(&mut self, challenge: [u8; AUTH_CMD_NONCE_LEN]) {
         set_challenge(challenge);
     }
 }

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(target_arch = "riscv32", no_std)]
 #![allow(async_fn_in_trait)]
 
-use caliptra_mcu_mbox_common::messages::{CommandId, HybridSignature};
+use caliptra_mcu_mbox_common::messages::{CommandId, HybridSignature, AUTH_CMD_NONCE_LEN};
 use mcu_caliptra_api_lite::ApiAlloc;
 use zerocopy::{Immutable, IntoBytes};
 
@@ -331,8 +331,8 @@ pub trait CommandAuthorizer {
     /// Get the challenge from the last call to `MC_GET_AUTH_CMD_CHALLENGE`.
     ///
     /// This consumes the challenge so it can only be used once.
-    fn take_challenge(&mut self) -> Option<[u8; 48]>;
+    fn take_challenge(&mut self) -> Option<[u8; AUTH_CMD_NONCE_LEN]>;
 
     /// Set the challenge nonce to be used on the next authorized command.
-    fn set_challenge(&mut self, challenge: [u8; 48]);
+    fn set_challenge(&mut self, challenge: [u8; AUTH_CMD_NONCE_LEN]);
 }

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -331,8 +331,8 @@ pub trait CommandAuthorizer {
     /// Get the challenge from the last call to `MC_GET_AUTH_CMD_CHALLENGE`.
     ///
     /// This consumes the challenge so it can only be used once.
-    fn take_challenge(&mut self) -> Option<[u8; 32]>;
+    fn take_challenge(&mut self) -> Option<[u8; 48]>;
 
     /// Set the challenge nonce to be used on the next authorized command.
-    fn set_challenge(&mut self, challenge: [u8; 32]);
+    fn set_challenge(&mut self, challenge: [u8; 48]);
 }

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -16,13 +16,13 @@ mod test_increase_caliptra_svn;
 mod test_mcu_mailbox;
 mod test_revoke_vendor_pub_key;
 
-pub fn get_auth_cmd_challenge(hw: &mut impl McuHwModel) -> Result<[u8; 32]> {
+pub fn get_auth_cmd_challenge(hw: &mut impl McuHwModel) -> Result<[u8; 48]> {
     let cmd = GetAuthCmdChallengeReq::default();
     let resp = hw.mailbox_execute_req(cmd)?;
     Ok(resp.challenge)
 }
 
-pub fn sign_auth_cmd_challenge(challenge: &[u8; 32], cmd_id: u32, cmd: &[u8]) -> Result<Vec<u8>> {
+pub fn sign_auth_cmd_challenge(challenge: &[u8; 48], cmd_id: u32, cmd: &[u8]) -> Result<Vec<u8>> {
     let authorizer = AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED)?;
     let cmd_body = &cmd[size_of::<MailboxReqHeader>()..];
     let sigs = authorizer.authorize(cmd_id, cmd_body, challenge)?;

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -8,7 +8,9 @@ use caliptra_mcu_command_auth_challenge_signer::{
     AsymmetricCommandAuthorizer, CommandAuthChallengeSigner,
 };
 use caliptra_mcu_hw_model::McuHwModel;
-use caliptra_mcu_mbox_common::messages::{calc_checksum, GetAuthCmdChallengeReq, MailboxReqHeader};
+use caliptra_mcu_mbox_common::messages::{
+    calc_checksum, GetAuthCmdChallengeReq, MailboxReqHeader, AUTH_CMD_NONCE_LEN,
+};
 use core::mem::size_of;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -16,13 +18,17 @@ mod test_increase_caliptra_svn;
 mod test_mcu_mailbox;
 mod test_revoke_vendor_pub_key;
 
-pub fn get_auth_cmd_challenge(hw: &mut impl McuHwModel) -> Result<[u8; 48]> {
+pub fn get_auth_cmd_challenge(hw: &mut impl McuHwModel) -> Result<[u8; AUTH_CMD_NONCE_LEN]> {
     let cmd = GetAuthCmdChallengeReq::default();
     let resp = hw.mailbox_execute_req(cmd)?;
     Ok(resp.challenge)
 }
 
-pub fn sign_auth_cmd_challenge(challenge: &[u8; 48], cmd_id: u32, cmd: &[u8]) -> Result<Vec<u8>> {
+pub fn sign_auth_cmd_challenge(
+    challenge: &[u8; AUTH_CMD_NONCE_LEN],
+    cmd_id: u32,
+    cmd: &[u8],
+) -> Result<Vec<u8>> {
     let authorizer = AsymmetricCommandAuthorizer::new(&TEST_ECC_PRIV_KEY, &TEST_MLDSA_SEED)?;
     let cmd_body = &cmd[size_of::<MailboxReqHeader>()..];
     let sigs = authorizer.authorize(cmd_id, cmd_body, challenge)?;

--- a/tests/integration/src/runtime/test_mcu_mailbox.rs
+++ b/tests/integration/src/runtime/test_mcu_mailbox.rs
@@ -73,7 +73,10 @@ fn test_get_auth_cmd_challenge_cmd() -> Result<()> {
     let cmd = GetAuthCmdChallengeReq::default();
     let resp = hw.mailbox_execute_req(cmd)?;
 
-    assert_eq!(resp.challenge.len(), 32);
+    assert_eq!(
+        resp.challenge.len(),
+        caliptra_mcu_command_auth_challenge_signer::AUTH_CMD_NONCE_LEN
+    );
     assert!(
         resp.challenge
             .iter()


### PR DESCRIPTION
Widen the authorization-command challenge/nonce from 32 to 48 bytes end to end, routed through a single named constant AUTH_CMD_NONCE_LEN = 48. This matches the Caliptra prod-debug-unlock nonce width and gives the freshness challenge a larger security margin.

The change is limited to the authorization-command nonce. Signing stays the existing raw-message ECDSA-P384 + ML-DSA-87 scheme, the challenge remains device-stored (not traveling), and the vendor public keys stay as-is. The ML-DSA seed, CSR nonce, and debug-unlock sizes are unrelated 32-byte fields and are left unchanged.

- command-auth-challenge-signer: add AUTH_CMD_NONCE_LEN; authorize() takes a 48-byte challenge. Add unit tests (width, sign/verify round-trip over the 48-byte nonce, wrong-nonce rejection).
- mcu-mbox messages: GetAuthCmdChallengeResp.challenge -> [u8; 48] with a hand-written Default (arrays > 32 have no derived Default).
- caliptra-common-commands: CommandAuthorizer take/set_challenge -> 48.
- emulator user-app: stored CHALLENGE cell, generate_auth_challenge, and verify_authorized_signatures challenge param -> 48.
- command-types/fuse.rs: AUTH_CMD_CHALLENGE_SIZE -> 48; refresh the stale HMAC-era doc comments to the asymmetric dual-signature flow.
- integration tests: challenge helpers -> 48; assert challenge width against AUTH_CMD_NONCE_LEN.

Closes #1886