### PR TITLE
mctp-vdm: enable service by default

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -67,7 +67,15 @@ toml.workspace = true
 [features]
 default = ["all-features"]
 # Caliptra MCU features
-all-features = ["spdm", "streaming-boot", "flash-boot", "firmware-update", "doe", "userspace-log"]
+all-features = [
+  "spdm",
+  "streaming-boot",
+  "flash-boot",
+  "firmware-update",
+  "doe",
+  "userspace-log",
+  "mctp-vdm-service",
+]
 spdm = ["mcu-mbox-service"]
 streaming-boot = []
 flash-boot = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
@@ -13,16 +13,22 @@ use caliptra_mcu_libtock_console::Console;
 use caliptra_mcu_libtock_platform::ErrorCode;
 #[allow(unused_imports)]
 use core::fmt::Write;
-#[allow(unused)]
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-#[allow(unused)]
 use embassy_sync::signal::Signal;
+use static_cell::StaticCell;
+
+#[cfg(not(any(
+    feature = "test-mctp-vdm-cmds",
+    feature = "test-caliptra-util-host-mctp-vdm-validator",
+    feature = "test-defmt-logging-vdm"
+)))]
+use crate::caliptra_cmd_handler::CaliptraCmdBackend as VdmHandler;
 #[cfg(any(
     feature = "test-mctp-vdm-cmds",
     feature = "test-caliptra-util-host-mctp-vdm-validator",
     feature = "test-defmt-logging-vdm"
 ))]
-use static_cell::StaticCell;
+use cmd_handler_mock::NonCryptoCmdHandlerMock as VdmHandler;
 
 #[embassy_executor::task]
 pub async fn vdm_task() {
@@ -32,60 +38,44 @@ pub async fn vdm_task() {
     }
 }
 
-#[allow(dead_code)]
-#[allow(unused_variables)]
 async fn start_vdm_service() -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
     crate::log_info!(console_writer, "Starting MCTP VDM task...");
 
-    #[cfg(any(
-        feature = "test-mctp-vdm-cmds",
-        feature = "test-caliptra-util-host-mctp-vdm-validator",
-        feature = "test-defmt-logging-vdm"
-    ))]
-    {
-        // Use static storage to ensure 'static lifetime for handler, transport, and cmd_interface.
-        static HANDLER: StaticCell<cmd_handler_mock::NonCryptoCmdHandlerMock> = StaticCell::new();
-        static TRANSPORT: StaticCell<caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport> =
-            StaticCell::new();
-        static CMD_INTERFACE: StaticCell<
-            caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<
-                'static,
-                cmd_handler_mock::NonCryptoCmdHandlerMock,
-            >,
-        > = StaticCell::new();
+    // Use static storage to ensure 'static lifetime for handler, transport, and cmd_interface.
+    static HANDLER: StaticCell<VdmHandler> = StaticCell::new();
+    static TRANSPORT: StaticCell<caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport> =
+        StaticCell::new();
+    static CMD_INTERFACE: StaticCell<
+        caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<'static, VdmHandler>,
+    > = StaticCell::new();
 
-        let handler: &'static cmd_handler_mock::NonCryptoCmdHandlerMock =
-            HANDLER.init(cmd_handler_mock::NonCryptoCmdHandlerMock::default());
-        let transport: &'static mut caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport =
-            TRANSPORT.init(caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport::default());
+    let handler: &'static VdmHandler = HANDLER.init(VdmHandler);
+    let transport: &'static mut caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport =
+        TRANSPORT.init(caliptra_mcu_mctp_vdm_lib::transport::MctpVdmTransport::default());
 
-        // Check if the transport driver exists
-        if !transport.exists() {
-            crate::log_warn!(
-                console_writer,
-                "USER_APP: MCTP VDM driver not found, skipping VDM service"
-            );
-            return Ok(());
-        }
-
-        // Create the command interface with static storage
-        let cmd_interface: &'static mut caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<
-            'static,
-            cmd_handler_mock::NonCryptoCmdHandlerMock,
-        > = CMD_INTERFACE.init(caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface::new(
-            transport, handler,
-        ));
-
-        crate::log_info!(
+    // Check if the transport driver exists
+    if !transport.exists() {
+        crate::log_warn!(
             console_writer,
-            "Starting MCTP VDM service for integration tests..."
+            "USER_APP: MCTP VDM driver not found, skipping VDM service"
         );
-
-        caliptra_mcu_mctp_vdm_lib::daemon::vdm_responder(cmd_interface).await;
-        let suspend_signal: Signal<CriticalSectionRawMutex, ()> = Signal::new();
-        suspend_signal.wait().await;
+        return Ok(());
     }
+
+    // Create the command interface with static storage
+    let cmd_interface: &'static mut caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface<
+        'static,
+        VdmHandler,
+    > = CMD_INTERFACE.init(caliptra_mcu_mctp_vdm_lib::cmd_interface::CmdInterface::new(
+        transport, handler,
+    ));
+
+    crate::log_info!(console_writer, "Starting MCTP VDM service...");
+
+    caliptra_mcu_mctp_vdm_lib::daemon::vdm_responder(cmd_interface).await;
+    let suspend_signal: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+    suspend_signal.wait().await;
 
     Ok(())
 }

--- a/tests/integration/src/test_defmt_logging_vdm.rs
+++ b/tests/integration/src/test_defmt_logging_vdm.rs
@@ -168,7 +168,7 @@ mod test {
                 Some(seeded),
             );
 
-            hw.step_until_output_contains("Starting MCTP VDM service for integration tests")
+            hw.step_until_output_contains("Starting MCTP VDM service")
                 .expect("MCU did not enter MCTP VDM service");
             std::thread::sleep(std::time::Duration::from_millis(200));
         }

--- a/tests/integration/src/test_mctp_vdm_cmds.rs
+++ b/tests/integration/src/test_mctp_vdm_cmds.rs
@@ -360,7 +360,7 @@ pub mod test {
                 Some(seeded),
             );
 
-            hw.step_until_output_contains("Starting MCTP VDM service for integration tests")
+            hw.step_until_output_contains("Starting MCTP VDM service")
                 .expect("MCU did not enter MCTP VDM service");
             // Let the executor schedule the responder and subscribe.
             std::thread::sleep(std::time::Duration::from_millis(200));


### PR DESCRIPTION
## Summary

- enable the MCTP VDM service in the default user-app feature set
- use the production Caliptra command backend outside integration-test configurations
- retain the mock command handler for VDM integration tests
- update integration tests for the shared service startup message

## Testing

- `cargo check -p user-app`
- `cargo check -p user-app --no-default-features --features mctp-vdm-service`
- `cargo check -p user-app --no-default-features --features test-mctp-vdm-cmds`
- `cargo check -p user-app --no-default-features --features test-defmt-logging-vdm`
- `cargo fmt --all -- --check`
