### PR TITLE
fix(size): reduce .bss by moving MldsaVerifyReq to shared static

### DIFF
--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -638,9 +638,9 @@ version = "0.1.0"
 name = "caliptra-mcu-mbox-common"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
  "caliptra-image-types",
  "caliptra-mcu-registers-generated",
+ "mcu-caliptra-api-lite",
  "zerocopy",
 ]
 
@@ -747,6 +747,7 @@ dependencies = [
  "caliptra-mcu-core-util-host-command-types",
  "caliptra-mcu-core-util-host-transport",
  "caliptra-mcu-debug-unlock-signer",
+ "caliptra-mcu-mbox-common",
  "caliptra-spdm-requester",
  "caliptra-util-host-commands",
  "caliptra-util-host-session",
@@ -1964,6 +1965,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mcu-caliptra-api-lite"
+version = "0.1.0"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]

--- a/caliptra-util-host/apps/spdm/client/Cargo.toml
+++ b/caliptra-util-host/apps/spdm/client/Cargo.toml
@@ -24,6 +24,7 @@ caliptra-mcu-core-util-host-transport.workspace = true
 caliptra-mcu-core-util-host-command-types.workspace = true
 caliptra-mcu-debug-unlock-signer.workspace = true
 caliptra-mcu-command-auth-challenge-signer.workspace = true
+caliptra-mcu-mbox-common.workspace = true
 caliptra-util-host-commands.workspace = true
 caliptra-util-host-session.workspace = true
 anyhow.workspace = true

--- a/caliptra-util-host/apps/spdm/client/src/bin/ocp_dev_identity_provision_tool.rs
+++ b/caliptra-util-host/apps/spdm/client/src/bin/ocp_dev_identity_provision_tool.rs
@@ -30,7 +30,6 @@ struct Args {
     #[arg(long, default_value_t = DEFAULT_LDEVID_KEY_PAIR_ID)]
     key_pair_id: u8,
 
-
     /// DER X.509 root certificate used to authenticate the initial Vendor slot.
     #[arg(long, default_value_os_t = default_vendor_trust_anchor_path())]
     vendor_trust_anchor: PathBuf,

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -26,7 +26,7 @@ pub use validator::{all_passed, print_summary, run_all, ValidationResult, Valida
 
 // Re-export the command authorizer trait and types from the common crate
 pub use caliptra_mcu_command_auth_challenge_signer::{
-    CommandAuthChallengeSigner, AsymmetricCommandAuthorizer,
+    AsymmetricCommandAuthorizer, CommandAuthChallengeSigner,
 };
 
 // Re-export the debug unlock signer trait and types from the common crate
@@ -46,6 +46,7 @@ use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
     SpdmVdmDriver, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
+use caliptra_mcu_mbox_common::messages::HybridSignature;
 use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_csr;
 use caliptra_util_host_commands::api::debug_unlock::{
     caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
@@ -138,12 +139,12 @@ impl<'a> SpdmVdmClient<'a> {
     ///
     /// # Parameters
     /// - `partition`: OTP partition to program (0-3)
-    /// - `mac`: 48-byte HMAC-SHA384 authorization token
-    pub fn fe_prog(&mut self, partition: u32, mac: &[u8; 48]) -> Result<FeProgResponse> {
+    /// - `sig`: Hybrid (ECC + ML-DSA) authorization signature
+    pub fn fe_prog(&mut self, partition: u32, sig: &HybridSignature) -> Result<FeProgResponse> {
         use caliptra_mcu_core_util_host_command_types::fuse::FeProgRequest;
         let request = FeProgRequest {
             partition,
-            mac: *mac,
+            sig: sig.clone(),
         };
         let mut session = self.create_session()?;
         caliptra_cmd_fe_prog(&mut session, &request)

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -11,8 +11,8 @@ use anyhow::Result;
 use caliptra_spdm_requester::{SpdmConfig, SpdmRequester, SpdmSocketDeviceIo, SpdmVdmDriverImpl};
 use caliptra_spdm_vdm_client::config::{self, TestConfig};
 use caliptra_spdm_vdm_client::{
-    validator, CommandAuthChallengeSigner, DebugUnlockKeys, DebugUnlockSigner,
-    AsymmetricCommandAuthorizer, LocalDebugUnlockSigner, SpdmVdmClient,
+    validator, AsymmetricCommandAuthorizer, CommandAuthChallengeSigner, DebugUnlockKeys,
+    DebugUnlockSigner, LocalDebugUnlockSigner, SpdmVdmClient,
 };
 use clap::Parser;
 
@@ -103,18 +103,22 @@ fn main() -> Result<()> {
         };
     let config = args.into_config()?;
 
-    let fe_prog_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> =
-        match (&config.fe_prog.ecc_auth_key, &config.fe_prog.mldsa_auth_key) {
-            (Some(hex_ecc), Some(hex_mldsa)) => {
-                let ecc_key = hex::decode(hex_ecc)?;
-                let mldsa_key = hex::decode(hex_mldsa)?;
-                Some(Box::new(AsymmetricCommandAuthorizer::new(&ecc_key, &mldsa_key)?))
-            }
-            (None, None) => None,
-            _ => {
-                anyhow::bail!("Both ecc_auth_key and mldsa_auth_key must be provided for asymmetric authorization");
-            }
-        };
+    let fe_prog_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> = match (
+        &config.fe_prog.ecc_auth_key,
+        &config.fe_prog.mldsa_auth_key,
+    ) {
+        (Some(hex_ecc), Some(hex_mldsa)) => {
+            let ecc_key = hex::decode(hex_ecc)?;
+            let mldsa_key = hex::decode(hex_mldsa)?;
+            Some(Box::new(AsymmetricCommandAuthorizer::new(
+                &ecc_key, &mldsa_key,
+            )?))
+        }
+        (None, None) => None,
+        _ => {
+            anyhow::bail!("Both ecc_auth_key and mldsa_auth_key must be provided for asymmetric authorization");
+        }
+    };
 
     println!(
         "[caliptra-spdm-validator] Connecting to bridge at {}",

--- a/caliptra-util-host/apps/spdm/client/src/ocp_dev_identity_provision.rs
+++ b/caliptra-util-host/apps/spdm/client/src/ocp_dev_identity_provision.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use caliptra_mcu_core_util_host_command_types::certificate::ExportAttestedCsrResponse;
 use caliptra_spdm_requester::{
-    split_der_certificates, verify_x509_certificate_chain, PeerRootCert, SpdmConfig,
-    SpdmRequester, SpdmSocketDeviceIo, SpdmVdmDriverImpl,
+    split_der_certificates, verify_x509_certificate_chain, PeerRootCert, SpdmConfig, SpdmRequester,
+    SpdmSocketDeviceIo, SpdmVdmDriverImpl,
 };
 use coset::{cbor::value::Value, iana::Algorithm, AsCborValue, CoseSign1};
 use p384::ecdsa::signature::Verifier;
@@ -112,9 +112,9 @@ pub fn provision_device_identity(options: &ProvisionOptions) -> Result<()> {
         VENDOR_SLOT_ID
     );
 
-    let vendor_spdm_chain = requester
-        .get_certificate(None, VENDOR_SLOT_ID)
-        .context("failed to read authenticated Vendor slot certificate chain for CSR attestation")?;
+    let vendor_spdm_chain = requester.get_certificate(None, VENDOR_SLOT_ID).context(
+        "failed to read authenticated Vendor slot certificate chain for CSR attestation",
+    )?;
     let vendor_chain = parse_spdm_cert_chain(&vendor_spdm_chain)
         .context("failed to parse Vendor slot SPDM certificate chain")?;
     let vendor_certs = split_der_certificates(vendor_chain.der)
@@ -152,10 +152,9 @@ pub fn provision_device_identity(options: &ProvisionOptions) -> Result<()> {
     );
 
     println!(
-        "[ocp_dev_identity_provision_tool] SET_CERTIFICATE slot_id={} key_pair_id={} cert_chain={} ({} bytes)",
+        "[ocp_dev_identity_provision_tool] SET_CERTIFICATE slot_id={} key_pair_id={} cert_chain=attested CSR ({} bytes)",
         options.slot_id,
         options.key_pair_id,
-        "attested CSR",
         cert_chain.len()
     );
     requester.set_certificate(
@@ -167,12 +166,7 @@ pub fn provision_device_identity(options: &ProvisionOptions) -> Result<()> {
     )?;
 
     let provisioned = requester.get_certificate(None, options.slot_id)?;
-    verify_returned_owner_chain(
-        options.slot_id,
-        &cert_chain,
-        &vendor_certs,
-        &provisioned,
-    )?;
+    verify_returned_owner_chain(options.slot_id, &cert_chain, &vendor_certs, &provisioned)?;
 
     println!(
         "[ocp_dev_identity_provision_tool] Provisioning verified (GET_CERTIFICATE returned {} bytes)",
@@ -360,8 +354,8 @@ struct AttestedCsrClaims {
 }
 
 fn parse_cose_sign1(data: &[u8]) -> Result<CoseSign1> {
-    let mut value: Value = ciborium::from_reader(data)
-        .context("attested CSR payload is not valid CBOR")?;
+    let mut value: Value =
+        ciborium::from_reader(data).context("attested CSR payload is not valid CBOR")?;
     if matches!(value, Value::Tag(55799, _)) {
         value = unwrap_cbor_tag(value, 55799)?;
     }
@@ -379,13 +373,12 @@ fn unwrap_cbor_tag(value: Value, expected: u64) -> Result<Value> {
     }
 }
 
-fn verify_attested_csr_cose(
-    cose: &CoseSign1,
-    rt_alias_cert: &[u8],
-) -> Result<AttestedCsrClaims> {
+fn verify_attested_csr_cose(cose: &CoseSign1, rt_alias_cert: &[u8]) -> Result<AttestedCsrClaims> {
     if !matches!(
         cose.protected.header.alg,
-        Some(coset::RegisteredLabelWithPrivate::Assigned(Algorithm::ES384 | Algorithm::ESP384))
+        Some(coset::RegisteredLabelWithPrivate::Assigned(
+            Algorithm::ES384 | Algorithm::ESP384
+        ))
     ) {
         bail!("unsupported attested CSR COSE algorithm, expected ES384/ESP384");
     }
@@ -414,8 +407,8 @@ fn rt_alias_signing_cert<'a>(attestation_certs: &'a [&'a [u8]]) -> Result<&'a [u
 }
 
 fn parse_attested_csr_claims(payload: &[u8]) -> Result<AttestedCsrClaims> {
-    let value: Value = ciborium::from_reader(payload)
-        .context("attested CSR COSE payload is not valid CBOR")?;
+    let value: Value =
+        ciborium::from_reader(payload).context("attested CSR COSE payload is not valid CBOR")?;
     let Value::Map(entries) = value else {
         bail!("attested CSR COSE payload is not a map");
     };
@@ -433,7 +426,10 @@ fn parse_attested_csr_claims(payload: &[u8]) -> Result<AttestedCsrClaims> {
     let nonce = nonce.ok_or_else(|| anyhow!("attested CSR COSE payload missing nonce claim"))?;
     let csr = csr.ok_or_else(|| anyhow!("attested CSR COSE payload missing CSR claim"))?;
     if nonce.len() != 32 {
-        bail!("attested CSR COSE nonce is {} bytes, expected 32", nonce.len());
+        bail!(
+            "attested CSR COSE nonce is {} bytes, expected 32",
+            nonce.len()
+        );
     }
     Ok(AttestedCsrClaims { nonce, csr })
 }
@@ -491,7 +487,11 @@ fn certificate_matches_cose_kid(cert_der: &[u8], kid: &[u8]) -> Result<bool> {
 
 fn parse_certificate_public_key_sec1(cert_der: &[u8]) -> Result<Vec<u8>> {
     let cert = Certificate::from_der(cert_der).context("failed to parse X.509 certificate DER")?;
-    let public_key = cert.tbs_certificate.subject_public_key_info.subject_public_key.raw_bytes();
+    let public_key = cert
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .raw_bytes();
     if public_key.first() != Some(&0x04) {
         bail!("attestation certificate public key is not an uncompressed P-384 point");
     }
@@ -543,9 +543,12 @@ fn verify_returned_owner_chain(
     let installed_certs = split_der_certificates(installed_der)?;
     let returned_certs = split_der_certificates(returned.der)?;
     if returned_certs.is_empty() {
-        bail!("GET_CERTIFICATE slot {} returned an empty DER chain", slot_id);
+        bail!(
+            "GET_CERTIFICATE slot {} returned an empty DER chain",
+            slot_id
+        );
     }
-    verify_spdm_root_hash(&returned.root_hash, returned_certs[0])?;
+    verify_spdm_root_hash(returned.root_hash, returned_certs[0])?;
 
     let expected_count = installed_certs.len() + OWNER_SLOT_DYNAMIC_TAIL_CERTS;
     if returned_certs.len() != expected_count {
@@ -575,9 +578,9 @@ fn verify_returned_owner_chain(
         );
     }
     if tail.iter().any(|cert| installed_certs.contains(cert))
-        || tail[..2]
-            .iter()
-            .any(|cert| vendor_certs[..vendor_certs.len() - OWNER_SLOT_DYNAMIC_TAIL_CERTS].contains(cert))
+        || tail[..2].iter().any(|cert| {
+            vendor_certs[..vendor_certs.len() - OWNER_SLOT_DYNAMIC_TAIL_CERTS].contains(cert)
+        })
     {
         bail!(
             "GET_CERTIFICATE slot {} duplicated Owner, Caliptra IDevID, or Caliptra LDevID certificates in the dynamic tail",
@@ -612,7 +615,8 @@ fn parse_spdm_cert_chain(chain: &[u8]) -> Result<SpdmCertChain<'_>> {
         bail!("SPDM certificate chain reserved field is non-zero: {reserved:#x}");
     }
     Ok(SpdmCertChain {
-        root_hash: &chain[SPDM_CERT_CHAIN_HEADER_LEN..SPDM_CERT_CHAIN_HEADER_LEN + SHA384_DIGEST_LEN],
+        root_hash: &chain
+            [SPDM_CERT_CHAIN_HEADER_LEN..SPDM_CERT_CHAIN_HEADER_LEN + SHA384_DIGEST_LEN],
         der: &chain[SPDM_CERT_CHAIN_HEADER_LEN + SHA384_DIGEST_LEN..],
     })
 }
@@ -630,9 +634,9 @@ mod tests {
     use super::*;
     use caliptra_mcu_core_util_host_command_types::certificate::MAX_CSR_DATA_SIZE;
     use caliptra_mcu_core_util_host_command_types::CommonResponse;
+    use coset::{CborSerializable, CoseSign1Builder, HeaderBuilder, TaggedCborSerializable};
     use p384::ecdsa::signature::Signer;
     use p384::ecdsa::{Signature, SigningKey};
-    use coset::{CborSerializable, CoseSign1Builder, HeaderBuilder, TaggedCborSerializable};
     use x509_cert::builder::RequestBuilder;
 
     fn test_owner_chain() -> Vec<u8> {
@@ -643,7 +647,6 @@ mod tests {
         )
         .unwrap()
     }
-
 
     #[test]
     fn test_verify_csr_matches_owner_leaf_rejects_mismatched_spki() {
@@ -661,11 +664,9 @@ mod tests {
         let signing_key = SigningKey::from_bytes((&[0x07u8; 48]).into()).unwrap();
         let csr = test_csr(&signing_key, "CN=Caliptra LDevID");
 
-        let chain = issue_test_owner_ldev_id_chain_from_csr(
-            &csr,
-            &test_owner_root_cert_der().unwrap(),
-        )
-        .unwrap();
+        let chain =
+            issue_test_owner_ldev_id_chain_from_csr(&csr, &test_owner_root_cert_der().unwrap())
+                .unwrap();
         let certs = split_der_certificates(&chain).unwrap();
 
         assert_eq!(certs.len(), 2);
@@ -683,11 +684,9 @@ mod tests {
             .to_der()
             .unwrap();
 
-        let err = issue_test_owner_ldev_id_chain_from_csr(
-            &csr,
-            &test_owner_root_cert_der().unwrap(),
-        )
-        .unwrap_err();
+        let err =
+            issue_test_owner_ldev_id_chain_from_csr(&csr, &test_owner_root_cert_der().unwrap())
+                .unwrap_err();
         assert!(err.to_string().contains("subject is empty"));
     }
 
@@ -749,11 +748,11 @@ mod tests {
 
         let vendor_root = signer_cert.clone();
         let dpe_leaf = signer_cert.clone();
-        let err = validate_attested_csr(&response, &nonce, &[&vendor_root, &signer_cert, &dpe_leaf])
-            .unwrap_err();
+        let err =
+            validate_attested_csr(&response, &nonce, &[&vendor_root, &signer_cert, &dpe_leaf])
+                .unwrap_err();
         assert!(err.to_string().contains("COSE signature"));
     }
-
 
     #[test]
     fn test_verify_returned_owner_chain_rejects_suffix_only_match() {
@@ -765,13 +764,8 @@ mod tests {
         returned_der.extend_from_slice(certs[0]);
 
         let returned = spdm_chain(&returned_der);
-        let err = verify_returned_owner_chain(
-            DEFAULT_OWNER_SLOT_ID,
-            &chain,
-            &certs,
-            &returned,
-        )
-        .unwrap_err();
+        let err = verify_returned_owner_chain(DEFAULT_OWNER_SLOT_ID, &chain, &certs, &returned)
+            .unwrap_err();
         assert!(err.to_string().contains("exact installed"));
     }
 
@@ -786,16 +780,11 @@ mod tests {
         returned_der.extend_from_slice(vendor_certs[2]);
 
         let returned = spdm_chain(&returned_der);
-        let err = verify_returned_owner_chain(
-            DEFAULT_OWNER_SLOT_ID,
-            &chain,
-            &vendor_certs,
-            &returned,
-        )
-        .unwrap_err();
+        let err =
+            verify_returned_owner_chain(DEFAULT_OWNER_SLOT_ID, &chain, &vendor_certs, &returned)
+                .unwrap_err();
         assert!(err.to_string().contains("duplicated"));
     }
-
 
     #[test]
     fn test_parse_spdm_cert_chain_rejects_bad_root_hash() {
@@ -808,13 +797,8 @@ mod tests {
         let mut returned = spdm_chain(&returned_der);
         returned[SPDM_CERT_CHAIN_HEADER_LEN] ^= 0x01;
 
-        let err = verify_returned_owner_chain(
-            DEFAULT_OWNER_SLOT_ID,
-            &chain,
-            &certs,
-            &returned,
-        )
-        .unwrap_err();
+        let err = verify_returned_owner_chain(DEFAULT_OWNER_SLOT_ID, &chain, &certs, &returned)
+            .unwrap_err();
         assert!(err.to_string().contains("root hash"));
     }
 
@@ -849,7 +833,6 @@ mod tests {
             .to_der()
             .unwrap()
     }
-
 
     fn signed_cose_attested_csr(signing_key: &SigningKey, nonce: &[u8; 32], csr: &[u8]) -> Vec<u8> {
         let public_key = signing_key.verifying_key().to_encoded_point(false);
@@ -887,6 +870,4 @@ mod tests {
         let name = Name::from_str("CN=COSE signer").unwrap();
         build_test_ca_certificate(1, name.clone(), name, None, 0, signing_key).unwrap()
     }
-
-
 }

--- a/caliptra-util-host/apps/spdm/requester/src/requester.rs
+++ b/caliptra-util-host/apps/spdm/requester/src/requester.rs
@@ -69,9 +69,9 @@ unsafe extern "C" fn verify_peer_cert_chain_trust_anchor(
     _trust_anchor: *mut *const c_void,
     _trust_anchor_size: *mut usize,
 ) -> bool {
-    let Some(chain) = (unsafe { cert_chain.as_ref() }).map(|_| unsafe {
-        core::slice::from_raw_parts(cert_chain as *const u8, cert_chain_size)
-    }) else {
+    let Some(chain) = (unsafe { cert_chain.as_ref() })
+        .map(|_| unsafe { core::slice::from_raw_parts(cert_chain as *const u8, cert_chain_size) })
+    else {
         log::error!("SPDM cert-chain verifier received null chain for slot {slot_id}");
         return false;
     };
@@ -98,7 +98,9 @@ fn verify_spdm_cert_chain_root_against_roots(
     trusted_roots: &[PeerRootCert],
 ) -> anyhow::Result<()> {
     if chain.len() < SPDM_CERT_CHAIN_HEADER_LEN {
-        return Err(anyhow::anyhow!("SPDM certificate chain header is truncated"));
+        return Err(anyhow::anyhow!(
+            "SPDM certificate chain header is truncated"
+        ));
     }
     let declared_len = u16::from_le_bytes([chain[0], chain[1]]) as usize;
     if declared_len != chain.len() {
@@ -108,7 +110,9 @@ fn verify_spdm_cert_chain_root_against_roots(
         ));
     }
     if chain[2..SPDM_CERT_CHAIN_HEADER_LEN] != [0, 0] {
-        return Err(anyhow::anyhow!("SPDM certificate chain reserved field is non-zero"));
+        return Err(anyhow::anyhow!(
+            "SPDM certificate chain reserved field is non-zero"
+        ));
     }
     verify_spdm_cert_chain_payload_root(
         slot_id,
@@ -199,13 +203,17 @@ pub fn verify_x509_certificate_chain(certs: &[&[u8]]) -> anyhow::Result<()> {
                 idx + 1
             ));
         }
-        child.verify_signature(Some(parent.public_key())).map_err(|e| {
-            anyhow::anyhow!("X.509 cert {} signature verification failed: {e:?}", idx + 1)
-        })?;
+        child
+            .verify_signature(Some(parent.public_key()))
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "X.509 cert {} signature verification failed: {e:?}",
+                    idx + 1
+                )
+            })?;
     }
     Ok(())
 }
-
 
 /// SPDM requester wrapping a libspdm context.
 ///
@@ -364,7 +372,11 @@ impl SpdmRequester {
         }
 
         self.get_certificate_large_buffer(None, slot_id)
-            .map_err(|err| anyhow::anyhow!("SPDM authenticated GET_CERTIFICATE failed for slot {slot_id}: {err}"))?;
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "SPDM authenticated GET_CERTIFICATE failed for slot {slot_id}: {err}"
+                )
+            })?;
 
         let mut measurement_hash = [0u8; libspdm_rs::LIBSPDM_MAX_HASH_SIZE as usize];
         let ret = unsafe {
@@ -837,7 +849,6 @@ mod tests {
         chain
     }
 
-
     #[test]
     fn verifier_accepts_libspdm_root_hash_der_payload() {
         let root = trusted_vendor_root();
@@ -845,7 +856,6 @@ mod tests {
 
         verify_spdm_cert_chain_root_against_roots(0, &chain, &[peer_root(0, root)]).unwrap();
     }
-
 
     #[test]
     fn verifier_rejects_bad_root_hash() {

--- a/caliptra-util-host/tests/src/common/mod.rs
+++ b/caliptra-util-host/tests/src/common/mod.rs
@@ -6,7 +6,6 @@
 //! implementations and common test data structures.
 
 use caliptra_mcu_core_util_host_transport::{MailboxDriver, MailboxError};
-use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 // Buffer length constants
 const RESPONSE_BUFFER_SIZE: usize = 1024; // Increased for SHA context (200 bytes) + overhead
@@ -36,7 +35,7 @@ pub struct MockMailbox {
 
 impl MockMailbox {
     /// Create a new MockMailbox with specified device characteristics
-    pub fn new(device_id: u16) -> Self {
+    pub fn new(_device_id: u16) -> Self {
         Self {
             connected: false,
             ready: true,

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -12,6 +12,8 @@ use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
+use core::cell::RefCell;
+use critical_section::Mutex;
 use mcu_caliptra_api_lite::{
     fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
     request_debug_unlock_challenge, rng_generate, ApiAlloc, McuErrorCode,
@@ -107,7 +109,7 @@ pub async fn verify_authorized_signatures(
     challenge: &[u8; AUTH_CMD_NONCE_LEN],
     ecc_pub_x: [u8; 48],
     ecc_pub_y: [u8; 48],
-    mldsa_pub: [u8; 2592],
+    mldsa_pub: &[u8; 2592],
     sig: &HybridSignature,
 ) -> CaliptraCmdResult<()> {
     // Pre-image = cmd_id(BE,4) || payload || challenge(48), built from the raw
@@ -158,20 +160,39 @@ pub async fn verify_authorized_signatures(
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
-    let mut mldsa_req = MldsaVerifyReq {
-        hdr: MailboxReqHeader::default(),
-        pub_key: mldsa_pub,
-        signature: sig.mldsa_sig,
-        message_size: mldsa_msg.len() as u32,
-        message: [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE],
+    // Use a shared static buffer to avoid inflating the async task future
+    // by ~11 KB (MldsaVerifyReq contains a 4 KB message + 2.6 KB pub_key +
+    // 4.6 KB signature).
+    // SAFETY: MldsaVerifyReq derives FromBytes, so all-zeros is a valid repr.
+    static MLDSA_REQ: Mutex<RefCell<core::mem::MaybeUninit<MldsaVerifyReq>>> =
+        Mutex::new(RefCell::new(core::mem::MaybeUninit::zeroed()));
+
+    let mldsa_req_bytes = critical_section::with(|cs| {
+        let mut cell = MLDSA_REQ.borrow_ref_mut(cs);
+        // SAFETY: MldsaVerifyReq derives FromBytes — all-zeros (from the static
+        // initializer) and any byte pattern we write are valid representations.
+        let req: &mut MldsaVerifyReq = unsafe { cell.assume_init_mut() };
+        req.hdr = MailboxReqHeader::default();
+        req.pub_key = *mldsa_pub;
+        req.signature = sig.mldsa_sig;
+        req.message_size = mldsa_msg.len() as u32;
+        req.message = [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE];
+        req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
+        req.as_bytes_partial_mut()
+            .map(|b| b.as_ptr() as usize..b.as_ptr() as usize + b.len())
+    });
+    let mldsa_req_range = mldsa_req_bytes.map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    // SAFETY: the static buffer is not mutated while we hold this slice —
+    // cooperative executor ensures no re-entrancy between the critical
+    // section above and the await below.
+    let mldsa_req_slice = unsafe {
+        core::slice::from_raw_parts_mut(
+            mldsa_req_range.start as *mut u8,
+            mldsa_req_range.end - mldsa_req_range.start,
+        )
     };
-    mldsa_req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
 
     let mut mldsa_resp = MailboxRespHeader::default();
-
-    let mldsa_req_bytes = mldsa_req
-        .as_bytes_partial_mut()
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
     let mldsa_resp_bytes = mldsa_resp.as_mut_bytes();
 
     let cmd_mldsa_verify: u32 = caliptra_api::mailbox::CommandId::MLDSA87_SIGNATURE_VERIFY.into();
@@ -179,7 +200,7 @@ pub async fn verify_authorized_signatures(
     execute_mailbox_cmd(
         &mailbox,
         cmd_mldsa_verify,
-        mldsa_req_bytes,
+        mldsa_req_slice,
         mldsa_resp_bytes,
     )
     .await

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -12,8 +12,8 @@ use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
-use core::cell::RefCell;
-use critical_section::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
 use mcu_caliptra_api_lite::{
     fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
     request_debug_unlock_challenge, rng_generate, ApiAlloc, McuErrorCode,
@@ -160,37 +160,26 @@ pub async fn verify_authorized_signatures(
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
-    // Use a shared static buffer to avoid inflating the async task future
-    // by ~11 KB (MldsaVerifyReq contains a 4 KB message + 2.6 KB pub_key +
-    // 4.6 KB signature).
+    // Use a shared static buffer behind an async Mutex to avoid inflating
+    // the async task future by ~11 KB.  The guard is held across `.await`.
     // SAFETY: MldsaVerifyReq derives FromBytes, so all-zeros is a valid repr.
-    static MLDSA_REQ: Mutex<RefCell<core::mem::MaybeUninit<MldsaVerifyReq>>> =
-        Mutex::new(RefCell::new(core::mem::MaybeUninit::zeroed()));
+    static MLDSA_REQ: Mutex<CriticalSectionRawMutex, core::mem::MaybeUninit<MldsaVerifyReq>> =
+        Mutex::new(core::mem::MaybeUninit::zeroed());
 
-    let mldsa_req_bytes = critical_section::with(|cs| {
-        let mut cell = MLDSA_REQ.borrow_ref_mut(cs);
-        // SAFETY: MldsaVerifyReq derives FromBytes — all-zeros (from the static
-        // initializer) and any byte pattern we write are valid representations.
-        let req: &mut MldsaVerifyReq = unsafe { cell.assume_init_mut() };
-        req.hdr = MailboxReqHeader::default();
-        req.pub_key = *mldsa_pub;
-        req.signature = sig.mldsa_sig;
-        req.message_size = mldsa_msg.len() as u32;
-        req.message = [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE];
-        req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
-        req.as_bytes_partial_mut()
-            .map(|b| b.as_ptr() as usize..b.as_ptr() as usize + b.len())
-    });
-    let mldsa_req_range = mldsa_req_bytes.map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-    // SAFETY: the static buffer is not mutated while we hold this slice —
-    // cooperative executor ensures no re-entrancy between the critical
-    // section above and the await below.
-    let mldsa_req_slice = unsafe {
-        core::slice::from_raw_parts_mut(
-            mldsa_req_range.start as *mut u8,
-            mldsa_req_range.end - mldsa_req_range.start,
-        )
-    };
+    let mut guard = MLDSA_REQ.lock().await;
+    // SAFETY: MldsaVerifyReq derives FromBytes — all-zeros (from the static
+    // initializer) and any byte pattern we write are valid representations.
+    let req: &mut MldsaVerifyReq = unsafe { guard.assume_init_mut() };
+    req.hdr = MailboxReqHeader::default();
+    req.pub_key = *mldsa_pub;
+    req.signature = sig.mldsa_sig;
+    req.message_size = mldsa_msg.len() as u32;
+    req.message = [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE];
+    req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
+
+    let mldsa_req_bytes = req
+        .as_bytes_partial_mut()
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
     let mut mldsa_resp = MailboxRespHeader::default();
     let mldsa_resp_bytes = mldsa_resp.as_mut_bytes();
@@ -200,7 +189,7 @@ pub async fn verify_authorized_signatures(
     execute_mailbox_cmd(
         &mailbox,
         cmd_mldsa_verify,
-        mldsa_req_slice,
+        mldsa_req_bytes,
         mldsa_resp_bytes,
     )
     .await

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -71,7 +71,7 @@ impl CommandAuthorizer for MockCommandAuthorizer {
             &challenge,
             TEST_AUTH_ECC_PUB_KEY_X,
             TEST_AUTH_ECC_PUB_KEY_Y,
-            TEST_AUTH_MLDSA_PUB_KEY,
+            &TEST_AUTH_MLDSA_PUB_KEY,
             sig,
         )
         .await


### PR DESCRIPTION
The MldsaVerifyReq struct (~11 KB) was previously a local variable in the async verify_authorized_signatures() function. Embassy stores async task futures as static allocations, causing this buffer to be duplicated in every task that calls it (MCU mailbox + SPDM VDM), inflating .bss by ~18 KB.

Move MldsaVerifyReq to a shared static Mutex<RefCell<MaybeUninit<...>>> that is populated inside a critical section and referenced across the await point. This is safe because the cooperative single-threaded executor guarantees no re-entrancy between the fill and the send.

Also pass mldsa_pub key by reference (&[u8; 2592]) instead of by value to avoid copying 2.6 KB into the async future state.

Additionally fix caliptra-util-host build: update fe_prog() to accept &HybridSignature (matching the FeProgRequest struct change from #1744) and add the caliptra-mcu-mbox-common dependency.

Measured .bss reduction: 126,228 -> 107,604 bytes (-18.2 KB). All-features release overflow reduced from 44 KB to 24 KB.