### PR TITLE
feat(cmd-auth): [B] sign authorized-command pre-image (ECDSA/SHA-384 + ML-DSA/SHA-512)

### DIFF
--- a/caliptra-util-host/command-types/src/fuse.rs
+++ b/caliptra-util-host/command-types/src/fuse.rs
@@ -9,8 +9,9 @@
 //!
 //! Authorized commands (e.g., `FeProg`) require the caller to:
 //! 1. Request a challenge nonce via `GetAuthCmdChallenge`
-//! 2. Sign `cmd_id(BE) || cmd_body || challenge` with both ECDSA-P384 and
-//!    ML-DSA-87, producing a hybrid dual signature
+//! 2. Build the pre-image `cmd_id(BE) || cmd_body || nonce` and sign it with both
+//!    ECC P-384 (over `SHA-384(pre-image)`) and ML-DSA-87 (over
+//!    `SHA-512(pre-image)`), mirroring the prod-debug-unlock idiom
 //! 3. Send the command with the hybrid ECDSA-P384 + ML-DSA-87 signature appended
 
 use crate::{CaliptraCommandId, CommandRequest, CommandResponse, CommonResponse};
@@ -40,9 +41,9 @@ pub const MC_FE_PROG_CANONICAL_CMD_ID: u32 = 0x4D43_4650;
 
 /// Request a challenge nonce for authorizing privileged commands.
 ///
-/// The returned challenge must be included in the signed transcript
-/// (`cmd_id || cmd_body || challenge`) and signed with both ECDSA-P384
-/// and ML-DSA-87 for the subsequent authorized command.
+/// The returned challenge must be bound into the signed pre-image
+/// (`cmd_id || cmd_body || nonce`), signed with both ECDSA-P384
+/// (over SHA-384) and ML-DSA-87 (over SHA-512) for the subsequent command.
 #[repr(C)]
 #[derive(Debug, Clone, Default, IntoBytes, FromBytes, Immutable)]
 pub struct GetAuthCmdChallengeRequest {
@@ -81,9 +82,9 @@ impl CommandResponse for GetAuthCmdChallengeResponse {}
 /// Request to program field entropy for a given OTP partition.
 ///
 /// This is an authorized command — the caller must first obtain a challenge
-/// via `GetAuthCmdChallenge`, compute ECC and ML-DSA signatures over
-/// `cmd_id(BE) || partition(LE) || challenge`, and place the resulting
-/// signatures in the `sig` field.
+/// via `GetAuthCmdChallenge`, build the pre-image `cmd_id(BE) || partition(LE)
+/// || nonce`, sign it with ECC P-384 (over `SHA-384(pre-image)`) and ML-DSA-87
+/// (over `SHA-512(pre-image)`), and place the resulting signatures in `sig`.
 #[repr(C)]
 #[derive(Debug, Default, Clone, IntoBytes, FromBytes, Immutable)]
 pub struct FeProgRequest {

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -13,6 +13,7 @@ use caliptra_mcu_mbox_common::messages::HybridSignature;
 use fips204::ml_dsa_87;
 use fips204::traits::{KeyGen, Signer as MldsaSigner};
 use p384::ecdsa::{signature::Signer, Signature, SigningKey};
+use sha2::{Digest, Sha512};
 
 /// Width of the authorization challenge nonce in bytes. Re-exported from
 /// `caliptra-mcu-mbox-common`, the single source of truth for this size.
@@ -62,20 +63,26 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
         payload: &[u8],
         challenge: &[u8; AUTH_CMD_NONCE_LEN],
     ) -> Result<HybridSignature> {
-        // Reconstruct the message: cmd_id(BE,4) || payload || challenge(48)
-        let mut message = Vec::new();
-        message.extend_from_slice(&cmd_id.to_be_bytes());
-        message.extend_from_slice(payload);
-        message.extend_from_slice(challenge);
+        // Build the pre-image: cmd_id(BE,4) || payload || challenge(48). This mirrors the
+        // prod-debug-unlock authorization idiom: each leg signs a digest of the raw
+        // pre-image (ECDSA over SHA-384, ML-DSA over SHA-512), rather than signing an
+        // inner-hashed transcript.
+        let mut pre_image = Vec::with_capacity(4 + payload.len() + challenge.len());
+        pre_image.extend_from_slice(&cmd_id.to_be_bytes());
+        pre_image.extend_from_slice(payload);
+        pre_image.extend_from_slice(challenge);
 
-        // 1. Sign with ECC P-384
-        let ecc_sig: Signature = self.ecc_key.sign(&message);
+        // 1. ECC P-384 over SHA-384(pre-image). `sign` hashes the pre-image with the
+        //    curve's SHA-384 digest internally, matching the device's ECDSA verify.
+        let ecc_sig: Signature = self.ecc_key.sign(&pre_image);
         let ecc_sig_bytes = ecc_sig.to_bytes(); // 96 bytes
 
-        // 2. Sign with ML-DSA-87
+        // 2. ML-DSA-87 over SHA-512(pre-image): sign the 64-byte SHA-512 digest as the
+        //    message (external pre-hash), matching the device's verify over that digest.
+        let mldsa_msg: [u8; 64] = Sha512::digest(&pre_image).into();
         let mldsa_sig = self
             .mldsa_key
-            .try_sign(&message, &[])
+            .try_sign(&mldsa_msg, &[])
             .map_err(|e| anyhow::anyhow!("ML-DSA signing failed: {:?}", e))?; // returns [u8; 4627]
 
         let mut padded_mldsa_sig = mldsa_sig.to_vec();
@@ -110,8 +117,9 @@ mod tests {
     ];
     const TEST_MLDSA_SEED: [u8; 32] = *b"caliptra-mcu-testing-mldsa-seed-";
 
-    /// The signed message on this baseline is `cmd_id(BE) || payload || challenge`.
-    fn message(cmd_id: u32, payload: &[u8], nonce: &[u8]) -> Vec<u8> {
+    /// Rebuild the pre-image exactly as `authorize` does:
+    /// `cmd_id(BE) || payload || nonce`.
+    fn pre_image(cmd_id: u32, payload: &[u8], nonce: &[u8]) -> Vec<u8> {
         let mut m = Vec::new();
         m.extend_from_slice(&cmd_id.to_be_bytes());
         m.extend_from_slice(payload);
@@ -126,9 +134,9 @@ mod tests {
     }
 
     /// `authorize` accepts a 48-byte challenge and produces a well-formed
-    /// `HybridSignature` whose BOTH legs verify over the signed message: the
-    /// ECDSA leg against the vendor P-384 key, and the ML-DSA-87 leg against the
-    /// vendor ML-DSA key.
+    /// `HybridSignature` whose BOTH legs verify over the pre-image
+    /// `cmd_id(BE) || payload || nonce`: the ECDSA-P384 leg over SHA-384(pre-image)
+    /// and the ML-DSA-87 leg over SHA-512(pre-image) (prod-debug-unlock idiom).
     #[test]
     fn authorize_round_trips_both_legs() {
         let signer =
@@ -142,24 +150,26 @@ mod tests {
         assert_eq!(sig.ecc_sig_s.len(), 48);
         assert_eq!(sig.mldsa_sig.len(), MLDSA87_SIGNATURE_BYTE_SIZE);
 
-        let msg = message(cmd_id, &payload, &challenge);
+        let pi = pre_image(cmd_id, &payload, &challenge);
 
-        // ECDSA leg (p384 hashes the message with SHA-384 internally).
+        // ECDSA leg: p384 hashes the pre-image with SHA-384 internally.
         let vk = VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
         let mut ecc_bytes = [0u8; 96];
         ecc_bytes[..48].copy_from_slice(&sig.ecc_sig_r);
         ecc_bytes[48..].copy_from_slice(&sig.ecc_sig_s);
         assert!(vk
-            .verify(&msg, &EcdsaSignature::from_slice(&ecc_bytes).unwrap())
+            .verify(&pi, &EcdsaSignature::from_slice(&ecc_bytes).unwrap())
             .is_ok());
 
-        // ML-DSA-87 leg: fips204 sig is the first 4627 bytes (the struct pads to 4628).
+        // ML-DSA-87 leg verifies over SHA-512(pre-image); fips204 sig is the first
+        // 4627 bytes (the HybridSignature struct pads to 4628).
+        let mldsa_msg: [u8; 64] = Sha512::digest(&pi).into();
         let mldsa_sig: [u8; 4627] = sig.mldsa_sig[..4627].try_into().unwrap();
-        assert!(mldsa_pubkey().verify(&msg, &mldsa_sig, &[]));
+        assert!(mldsa_pubkey().verify(&mldsa_msg, &mldsa_sig, &[]));
     }
 
     /// A challenge that differs from the one signed must NOT verify on EITHER
-    /// leg (freshness) — checked for ECDSA and ML-DSA-87.
+    /// leg (freshness) — checked for ECDSA-P384 and ML-DSA-87.
     #[test]
     fn wrong_nonce_does_not_verify_either_leg() {
         let signer =
@@ -170,8 +180,8 @@ mod tests {
             .authorize(cmd_id, &payload, &[0x11u8; AUTH_CMD_NONCE_LEN])
             .unwrap();
 
-        // Message built with a DIFFERENT nonce.
-        let wrong = message(cmd_id, &payload, &[0x22u8; AUTH_CMD_NONCE_LEN]);
+        // Pre-image built with a DIFFERENT nonce.
+        let wrong = pre_image(cmd_id, &payload, &[0x22u8; AUTH_CMD_NONCE_LEN]);
 
         let vk = VerifyingKey::from(&SigningKey::from_slice(&TEST_ECC_PRIV_KEY).unwrap());
         let mut ecc_bytes = [0u8; 96];
@@ -181,7 +191,8 @@ mod tests {
             .verify(&wrong, &EcdsaSignature::from_slice(&ecc_bytes).unwrap())
             .is_err());
 
+        let mldsa_msg: [u8; 64] = Sha512::digest(&wrong).into();
         let mldsa_sig: [u8; 4627] = sig.mldsa_sig[..4627].try_into().unwrap();
-        assert!(!mldsa_pubkey().verify(&wrong, &mldsa_sig, &[]));
+        assert!(!mldsa_pubkey().verify(&mldsa_msg, &mldsa_sig, &[]));
     }
 }

--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -38,5 +38,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x8e00
+stack = 0x9e00
 grant_space = 0x4000

--- a/firmware-bundler/reference/fpga/user-app.toml
+++ b/firmware-bundler/reference/fpga/user-app.toml
@@ -30,5 +30,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x9e80
+stack = 0xae80
 grant_space = 0x4000

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -110,22 +110,25 @@ pub async fn verify_authorized_signatures(
     mldsa_pub: [u8; 2592],
     sig: &HybridSignature,
 ) -> CaliptraCmdResult<()> {
-    let mut message = ArrayVec::<u8, 256>::new();
-    message
+    // Pre-image = cmd_id(BE,4) || payload || challenge(48), built from the raw
+    // payload (no inner hash), mirroring prod-debug-unlock. Each leg verifies a
+    // digest of it: ECDSA over SHA-384(pre-image), ML-DSA over SHA-512(pre-image).
+    let mut pre_image = ArrayVec::<u8, 256>::new();
+    pre_image
         .try_extend_from_slice(&cmd_id.to_be_bytes())
         .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
-    message
+    pre_image
         .try_extend_from_slice(payload)
         .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
-    message
+    pre_image
         .try_extend_from_slice(challenge)
         .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
 
     let mailbox = Mailbox::new();
 
-    // 1. Verify ECC P-384 Signature using Caliptra Mailbox
+    // 1. Verify ECC P-384 Signature using Caliptra Mailbox (over SHA-384(pre-image)).
     let mut hash = [0u8; 48];
-    HashContext::hash_all(HashAlgoType::SHA384, message.as_slice(), &mut hash)
+    HashContext::hash_all(HashAlgoType::SHA384, pre_image.as_slice(), &mut hash)
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
@@ -149,15 +152,20 @@ pub async fn verify_authorized_signatures(
         .await
         .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
 
-    // 2. Verify ML-DSA-87 Signature using Caliptra Mailbox
+    // 2. Verify ML-DSA-87 Signature using Caliptra Mailbox (over SHA-512(pre-image)).
+    let mut mldsa_msg = [0u8; 64];
+    HashContext::hash_all(HashAlgoType::SHA512, pre_image.as_slice(), &mut mldsa_msg)
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
     let mut mldsa_req = MldsaVerifyReq {
         hdr: MailboxReqHeader::default(),
         pub_key: mldsa_pub,
         signature: sig.mldsa_sig,
-        message_size: message.len() as u32,
+        message_size: mldsa_msg.len() as u32,
         message: [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE],
     };
-    mldsa_req.message[..message.len()].copy_from_slice(message.as_slice());
+    mldsa_req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
 
     let mut mldsa_resp = MailboxRespHeader::default();
 


### PR DESCRIPTION
## Sign the authorized-command pre-image (ECDSA/SHA-384 + ML-DSA/SHA-512)

Binds the command body and freshness nonce into a signed pre-image, mirroring
the prod-debug-unlock authorization idiom:

    pre-image = cmd_id(BE,4) || cmd_body || nonce(48)
    ECC P-384 : sign/verify over SHA-384(pre-image)
    ML-DSA-87 : sign/verify over SHA-512(pre-image)

Each leg signs a digest of the same raw pre-image (no inner payload hash, no
combined-transcript fold), byte-identical on the host signer and the device
verifier. Builds on the 48-byte nonce PR; the authorization model is otherwise
unchanged (device-stored nonce, hardcoded vendor keys).

**Stacked on** `raunakgupta/cmd-auth-nonce-48` (PR-A). Review/merge A first, or set
this PR's base to that branch to see only this delta.

### Tests
Signer KATs verify the ECDSA leg over SHA-384(pre-image) and nonce binding.
Emulator auth e2e (fe_prog / SVN / revoke / challenge) pass; `cargo xtask precheckin` exit 0.

Closes #1887