### PR TITLE
ci(size-history): add App .bss and SRAM overflow to size report

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -10,7 +10,7 @@ use size_history::{
 use std::path::{Path, PathBuf};
 use std::{env, error::Error, fs, io};
 
-const CACHE_FORMAT_VERSION: &str = "v4";
+const CACHE_FORMAT_VERSION: &str = "v5";
 
 pub const MCU_KERNEL_FPGA: FwId = FwId {
     crate_name: "mcu-runtime-fpga",
@@ -73,6 +73,13 @@ pub(crate) fn size_history() -> Result<(), anyhow::Error> {
             SizeType::Stack,
             false,
         )))
+        .add_builder(Box::new(CaliptraElfSizeGenerator::new(
+            "App .bss size",
+            MCU_USER_FPGA,
+            SizeType::Bss,
+            false,
+        )))
+        .add_builder(Box::new(SramOverflowGenerator))
         .run()
         .map_err(|e| anyhow::anyhow!("{}", e))
 }
@@ -119,9 +126,17 @@ fn other_err(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Erro
 }
 
 pub fn elf_stack_size(elf_bytes: &[u8]) -> io::Result<u64> {
+    elf_section_size(elf_bytes, ".stack")
+}
+
+pub fn elf_bss_size(elf_bytes: &[u8]) -> io::Result<u64> {
+    elf_section_size(elf_bytes, ".bss")
+}
+
+fn elf_section_size(elf_bytes: &[u8], section_name: &str) -> io::Result<u64> {
     let elf = elf::ElfBytes::<LittleEndian>::minimal_parse(elf_bytes).map_err(other_err)?;
-    let Ok(Some(section)) = elf.section_header_by_name(".stack") else {
-        return Err(other_err("ELF file has no .stack section"));
+    let Ok(Some(section)) = elf.section_header_by_name(section_name) else {
+        return Err(other_err(format!("ELF file has no {section_name} section")));
     };
 
     let mut min_addr = u64::MAX;
@@ -137,6 +152,7 @@ pub fn elf_stack_size(elf_bytes: &[u8]) -> io::Result<u64> {
 enum SizeType {
     Instruction,
     Stack,
+    Bss,
 }
 
 /// Builds Caliptra firmware using runtime_build_with_apps and measures ELF size.
@@ -168,6 +184,8 @@ impl CaliptraElfSizeGenerator {
 
         if self.size_type == SizeType::Stack {
             elf_stack_size(&elf_bytes)
+        } else if self.size_type == SizeType::Bss {
+            elf_bss_size(&elf_bytes)
         } else {
             elf_size(&elf_bytes)
         }
@@ -187,5 +205,58 @@ impl ArtifactBuilder for CaliptraElfSizeGenerator {
                 None
             }
         }
+    }
+}
+
+/// Reports how many bytes the combined kernel + user-app exceeds the FPGA SRAM
+/// budget.  Returns 0 when everything fits.
+struct SramOverflowGenerator;
+
+impl SramOverflowGenerator {
+    /// Run the bundler build and either:
+    /// - Return 0 if it succeeds (everything fits)
+    /// - Parse the overflow from the error message if it fails with
+    ///   "Bytes X would exceed remaining memory space Y" → overflow = X - Y
+    /// - Return None if the build fails for an unrelated reason
+    fn measure(&self, workspace: &Path) -> Option<u64> {
+        let target_dir = workspace.join("target");
+
+        match build_runtime(&target_dir) {
+            Ok(_) => Some(0), // Fits in SRAM
+            Err(e) => {
+                let msg = format!("{:?}", e);
+                // Parse "Bytes <needed> would exceed remaining memory space <available>"
+                parse_overflow_from_error(&msg)
+            }
+        }
+    }
+}
+
+/// Parse the SRAM overflow from the bundler's error message.
+/// Expected format: "Bytes <needed> would exceed remaining memory space <available>"
+fn parse_overflow_from_error(msg: &str) -> Option<u64> {
+    let bytes_prefix = "Bytes ";
+    let middle = " would exceed remaining memory space ";
+    let bytes_idx = msg.find(bytes_prefix)?;
+    let after_bytes = &msg[bytes_idx + bytes_prefix.len()..];
+    let middle_idx = after_bytes.find(middle)?;
+    let needed: u64 = after_bytes[..middle_idx].trim().parse().ok()?;
+    let after_middle = &after_bytes[middle_idx + middle.len()..];
+    // Take digits only (stop at any non-digit)
+    let available_str: String = after_middle
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let available: u64 = available_str.parse().ok()?;
+    Some(needed.saturating_sub(available))
+}
+
+impl ArtifactBuilder for SramOverflowGenerator {
+    fn name(&self) -> &str {
+        "SRAM overflow"
+    }
+
+    fn build_and_measure(&self, workspace: &Path) -> Option<u64> {
+        self.measure(workspace)
     }
 }


### PR DESCRIPTION
Add two new columns to the size-history CI report:

- App .bss size: tracks the .bss section of user-app, which contains static buffers (SPDM scratch, async task futures, crypto key storage) that are the main contributor to SRAM pressure.

- SRAM overflow: reports how many bytes the combined kernel + user-app exceeds the 512 KB FPGA SRAM budget (0 when it fits). This makes it immediately visible whether a PR pushes the binary over budget.

Bump CACHE_FORMAT_VERSION to v5 so historical commits are re-measured with the new metrics.