### PR TITLE
[builder] support unsigned manifest generation and offline signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitflags 2.13.0",
  "caliptra-api-types",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -384,7 +384,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -505,7 +505,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -520,13 +520,13 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
  "caliptra-api",
  "caliptra-cfi-derive-git",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "caliptra-cfi-lib-git",
  "caliptra-cpu",
  "caliptra-drivers",
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -621,15 +621,15 @@ source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=cf3224c41b64789a
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "arrayvec",
  "bitfield",
  "bitflags 2.13.0",
  "caliptra-api",
  "caliptra-auth-man-types",
- "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "caliptra-dpe",
  "caliptra-dpe-crypto",
  "caliptra-error",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-emu-types",
  "caliptra-ureg",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "aes",
  "arrayref",
@@ -724,17 +724,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-common",
 ]
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -840,6 +840,7 @@ dependencies = [
  "caliptra-lms-types",
  "fips204",
  "memoffset 0.8.0",
+ "p384",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -849,10 +850,10 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
- "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "caliptra-error",
  "caliptra-lms-types",
  "memoffset 0.8.0",
@@ -865,11 +866,11 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitflags 2.13.0",
- "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "caliptra-drivers",
  "caliptra-image-types",
  "caliptra-registers",
@@ -880,7 +881,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -892,10 +893,10 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
- "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "serde",
  "serde_derive",
  "zerocopy",
@@ -963,6 +964,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "subst",
  "tempfile",
  "toml 0.8.23",
@@ -2275,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ocp-eat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "arrayvec",
 ]
@@ -2283,12 +2285,12 @@ dependencies = [
 [[package]]
 name = "caliptra-okref"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -2296,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -2304,15 +2306,15 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "arrayvec",
  "bitfield",
  "bitflags 2.13.0",
  "caliptra-api",
  "caliptra-auth-man-types",
- "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
- "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a)",
  "caliptra-common",
  "caliptra-cpu",
  "caliptra-dpe",
@@ -2354,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "anyhow",
  "asn1",
@@ -2386,12 +2388,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-util-host-commands"
@@ -2416,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "zeroize",
 ]
@@ -2729,7 +2731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2738,7 +2740,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3466,7 +3468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5485,7 +5487,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5794,7 +5796,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5807,7 +5809,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5866,7 +5868,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6417,7 +6419,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7339,7 +7341,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7412,15 +7414,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,30 +328,30 @@ caliptra-mcu-tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-infra", rev = "e061f229d5d284ce39387eb104f3022053c6c772" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278", default-features = false }
-caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278", default-features = false }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
-caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb46b49818666d31e95873539e7c6759acddf278" }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a", default-features = false }
+caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a", default-features = false }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
+caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a0bf91a33752368870000bf7255976452160db5a" }
 dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false, features =  ["p384", "arbitrary_max_handles"] }
 crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -28,6 +28,7 @@ p384.workspace = true
 rayon = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 semver.workspace = true
 subst.workspace = true
 caliptra-mcu-tbf-header.workspace = true

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -3,6 +3,7 @@
 //! Wrappers around the Caliptra builder library to make it easier to build
 //! the ROM, firwmare, and SoC manifest.
 
+use crate::offline_signing::{create_signing_request, SigningRequestJson};
 use crate::target_dir;
 use anyhow::{bail, Context, Result};
 use caliptra_auth_man_gen::{
@@ -69,6 +70,25 @@ impl ImageGeneratorExecutable for RawExecutable {
 pub struct AuthManifestOwnerConfig {
     pub pub_keys: AuthManifestPubKeysConfig,
     pub priv_keys: Option<AuthManifestPrivKeysConfig>,
+}
+
+/// Paths to public key files used for generating unsigned authorization manifests.
+#[derive(Default, Clone, Debug)]
+pub struct AuthManifestPubKeysPaths<'a> {
+    pub vendor_fw_ecc_pub_key: Option<&'a Path>,
+    pub vendor_fw_lms_pub_key: Option<&'a Path>,
+    pub vendor_fw_mldsa_pub_key: Option<&'a Path>,
+    pub vendor_man_ecc_pub_key: Option<&'a Path>,
+    pub vendor_man_lms_pub_key: Option<&'a Path>,
+    pub vendor_man_mldsa_pub_key: Option<&'a Path>,
+    pub owner_fw_ecc_pub_key: Option<&'a Path>,
+    pub owner_fw_lms_pub_key: Option<&'a Path>,
+    pub owner_fw_mldsa_pub_key: Option<&'a Path>,
+    pub owner_man_ecc_pub_key: Option<&'a Path>,
+    pub owner_man_lms_pub_key: Option<&'a Path>,
+    pub owner_man_mldsa_pub_key: Option<&'a Path>,
+    /// Optional PQC key type for the manifest (defaults to LMS if not specified).
+    pub pqc_key_type: Option<FwVerificationPqcKeyType>,
 }
 
 #[derive(Clone)]
@@ -893,6 +913,181 @@ fn main() -> Result<()> {
         let gen = AuthManifestGenerator::new(Crypto::default());
         gen.generate(&gen_config).unwrap()
     }
+
+    /// Generates an unsigned authorization manifest and exports a `SigningRequestJson` for offline signing.
+    pub fn get_unsigned_auth_manifest(
+        &mut self,
+        name: Option<&str>,
+        pub_key_paths: Option<&AuthManifestPubKeysPaths>,
+    ) -> Result<(PathBuf, SigningRequestJson)> {
+        if self.mcu_firmware.is_none() {
+            bail!("MCU firmware is required to build auth manifest");
+        }
+        let mcu_fw_metadata =
+            self.get_mcu_manifest_metadata(self.mcu_firmware.as_ref().unwrap())?;
+        let soc_images_metadata = self.get_soc_images_metadata()?;
+        let mut metadata = vec![mcu_fw_metadata];
+        metadata.extend(soc_images_metadata);
+
+        let manifest = Self::create_unsigned_auth_manifest_with_metadata(
+            metadata,
+            self.soc_manifest_svn.unwrap_or(0),
+            pub_key_paths,
+        )?;
+
+        let signing_request = create_signing_request(&manifest)?;
+
+        let path = name
+            .map(PathBuf::from)
+            .unwrap_or_else(|| target_dir().join("soc-manifest"));
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, manifest.as_bytes())?;
+        self.write_attestation_manifest_config(self.soc_images.as_deref().unwrap_or(&[]))?;
+        self.soc_manifest = Some(path.clone());
+
+        Ok((path, signing_request))
+    }
+
+    /// Creates an unsigned `AuthorizationManifest` with the specified image metadata list and public key paths.
+    fn create_unsigned_auth_manifest_with_metadata(
+        image_metadata_list: Vec<AuthManifestImageMetadata>,
+        svn: u32,
+        pub_key_paths: Option<&AuthManifestPubKeysPaths>,
+    ) -> Result<AuthorizationManifest> {
+        use zerocopy::FromBytes;
+
+        let empty_paths = AuthManifestPubKeysPaths::default();
+        let keys = pub_key_paths.unwrap_or(&empty_paths);
+
+        let vendor_fw_ecc_pub = if let Some(path) = keys.vendor_fw_ecc_pub_key {
+            Crypto::ecc_pub_key_from_pem(path)?
+        } else {
+            VENDOR_ECC_KEY_0_PUBLIC
+        };
+        let vendor_fw_lms_pub = if let Some(path) = keys.vendor_fw_lms_pub_key {
+            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
+                .map_err(|_| {
+                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
+                })?
+        } else {
+            VENDOR_LMS_KEY_0_PUBLIC
+        };
+        let vendor_fw_mldsa_pub = if let Some(path) = keys.vendor_fw_mldsa_pub_key {
+            Crypto::mldsa_pub_key_from_file(path)?
+        } else {
+            VENDOR_MLDSA_KEY_0_PUBLIC
+        };
+
+        let vendor_man_ecc_pub = if let Some(path) = keys.vendor_man_ecc_pub_key {
+            Crypto::ecc_pub_key_from_pem(path)?
+        } else {
+            VENDOR_ECC_KEY_1_PUBLIC
+        };
+        let vendor_man_lms_pub = if let Some(path) = keys.vendor_man_lms_pub_key {
+            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
+                .map_err(|_| {
+                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
+                })?
+        } else {
+            VENDOR_LMS_KEY_1_PUBLIC
+        };
+        let vendor_man_mldsa_pub = if let Some(path) = keys.vendor_man_mldsa_pub_key {
+            Crypto::mldsa_pub_key_from_file(path)?
+        } else {
+            VENDOR_MLDSA_KEY_0_PUBLIC
+        };
+
+        let owner_fw_ecc_pub = if let Some(path) = keys.owner_fw_ecc_pub_key {
+            Crypto::ecc_pub_key_from_pem(path)?
+        } else {
+            OWNER_ECC_KEY_PUBLIC
+        };
+        let owner_fw_lms_pub = if let Some(path) = keys.owner_fw_lms_pub_key {
+            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
+                .map_err(|_| {
+                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
+                })?
+        } else {
+            OWNER_LMS_KEY_PUBLIC
+        };
+        let owner_fw_mldsa_pub = if let Some(path) = keys.owner_fw_mldsa_pub_key {
+            Crypto::mldsa_pub_key_from_file(path)?
+        } else {
+            OWNER_MLDSA_KEY_PUBLIC
+        };
+
+        let owner_man_ecc_pub = if let Some(path) = keys.owner_man_ecc_pub_key {
+            Crypto::ecc_pub_key_from_pem(path)?
+        } else {
+            OWNER_ECC_KEY_PUBLIC
+        };
+        let owner_man_lms_pub = if let Some(path) = keys.owner_man_lms_pub_key {
+            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
+                .map_err(|_| {
+                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
+                })?
+        } else {
+            OWNER_LMS_KEY_PUBLIC
+        };
+        let owner_man_mldsa_pub = if let Some(path) = keys.owner_man_mldsa_pub_key {
+            Crypto::mldsa_pub_key_from_file(path)?
+        } else {
+            OWNER_MLDSA_KEY_PUBLIC
+        };
+
+        let vendor_fw_key_info = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeysConfig {
+                ecc_pub_key: vendor_fw_ecc_pub,
+                lms_pub_key: vendor_fw_lms_pub,
+                mldsa_pub_key: vendor_fw_mldsa_pub,
+            },
+            priv_keys: None,
+        };
+
+        let vendor_man_key_info = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeysConfig {
+                ecc_pub_key: vendor_man_ecc_pub,
+                lms_pub_key: vendor_man_lms_pub,
+                mldsa_pub_key: vendor_man_mldsa_pub,
+            },
+            priv_keys: None,
+        };
+
+        let owner_fw_key_info = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeysConfig {
+                ecc_pub_key: owner_fw_ecc_pub,
+                lms_pub_key: owner_fw_lms_pub,
+                mldsa_pub_key: owner_fw_mldsa_pub,
+            },
+            priv_keys: None,
+        };
+
+        let owner_man_key_info = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeysConfig {
+                ecc_pub_key: owner_man_ecc_pub,
+                lms_pub_key: owner_man_lms_pub,
+                mldsa_pub_key: owner_man_mldsa_pub,
+            },
+            priv_keys: None,
+        };
+
+        let gen_config = AuthManifestGeneratorConfig {
+            vendor_fw_key_info: Some(vendor_fw_key_info),
+            vendor_man_key_info: Some(vendor_man_key_info),
+            owner_fw_key_info: Some(owner_fw_key_info),
+            owner_man_key_info: Some(owner_man_key_info),
+            image_metadata_list,
+            version: 1,
+            flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+            pqc_key_type: keys.pqc_key_type.unwrap_or(FwVerificationPqcKeyType::LMS),
+            svn,
+        };
+
+        let gen = AuthManifestGenerator::new(Crypto::default());
+        gen.generate(&gen_config)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -966,5 +1161,96 @@ impl FromStr for ImageCfg {
             is_ak_target,
             feature,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_unsigned_auth_manifest_and_request() {
+        let sw_root = crate::caliptra_sw_workspace_root();
+        let vendor_fw_pub_pem = sw_root.join("image/fake-keys/keys/vendor_ecc_0_pub.pem");
+        let owner_fw_pub_pem = sw_root.join("image/fake-keys/keys/owner_ecc_pub.pem");
+        let vendor_man_pub_pem = sw_root.join("image/fake-keys/keys/vendor_ecc_1_pub.pem");
+        let owner_man_pub_pem = sw_root.join("image/fake-keys/keys/owner_ecc_pub.pem");
+
+        let metadata = vec![AuthManifestImageMetadata {
+            fw_id: 1,
+            component_id: 2,
+            ..Default::default()
+        }];
+
+        let key_paths = AuthManifestPubKeysPaths {
+            vendor_fw_ecc_pub_key: Some(&vendor_fw_pub_pem),
+            owner_fw_ecc_pub_key: Some(&owner_fw_pub_pem),
+            vendor_man_ecc_pub_key: Some(&vendor_man_pub_pem),
+            owner_man_ecc_pub_key: Some(&owner_man_pub_pem),
+            ..Default::default()
+        };
+
+        let manifest = CaliptraBuilder::create_unsigned_auth_manifest_with_metadata(
+            metadata,
+            10,
+            Some(&key_paths),
+        )
+        .unwrap();
+
+        assert_eq!(manifest.preamble.version, 1);
+        assert_eq!(manifest.preamble.svn, 10);
+        assert_eq!(
+            manifest.preamble.vendor_pub_keys_signatures.ecc_sig.r,
+            [0u32; 12]
+        );
+        assert_eq!(
+            manifest.preamble.owner_pub_keys_signatures.ecc_sig.r,
+            [0u32; 12]
+        );
+
+        let req = create_signing_request(&manifest).unwrap();
+        assert_eq!(req.version, 1);
+        assert_eq!(
+            req.requests.vendor_pub_keys_signatures.digest_sha384.len(),
+            96
+        );
+        assert_eq!(
+            req.requests.owner_pub_keys_signatures.digest_sha384.len(),
+            96
+        );
+        assert_eq!(req.requests.vendor_imc_signatures.digest_sha384.len(), 96);
+        assert_eq!(req.requests.owner_imc_signatures.digest_sha384.len(), 96);
+    }
+
+    #[test]
+    fn test_create_unsigned_auth_manifest_mldsa() {
+        let sw_root = crate::caliptra_sw_workspace_root();
+        let vendor_fw_pub_pem = sw_root.join("image/fake-keys/keys/vendor_ecc_0_pub.pem");
+        let owner_fw_pub_pem = sw_root.join("image/fake-keys/keys/owner_ecc_pub.pem");
+
+        let metadata = vec![AuthManifestImageMetadata {
+            fw_id: 1,
+            component_id: 2,
+            ..Default::default()
+        }];
+
+        let key_paths = AuthManifestPubKeysPaths {
+            vendor_fw_ecc_pub_key: Some(&vendor_fw_pub_pem),
+            owner_fw_ecc_pub_key: Some(&owner_fw_pub_pem),
+            pqc_key_type: Some(FwVerificationPqcKeyType::MLDSA),
+            ..Default::default()
+        };
+
+        let manifest = CaliptraBuilder::create_unsigned_auth_manifest_with_metadata(
+            metadata,
+            1,
+            Some(&key_paths),
+        )
+        .unwrap();
+
+        assert_eq!(manifest.preamble.version, 1);
+
+        let req = create_signing_request(&manifest).unwrap();
+        assert_eq!(req.version, 1);
     }
 }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -14,7 +14,7 @@ mod utils;
 pub use all::{
     all_build, emulator_build, AllBuildArgs, EmulatorBinaries, EmulatorBuildArgs, FirmwareBinaries,
 };
-pub use caliptra::{AuthManifestOwnerConfig, CaliptraBuilder, ImageCfg};
+pub use caliptra::{AuthManifestOwnerConfig, AuthManifestPubKeysPaths, CaliptraBuilder, ImageCfg};
 pub use offline_signing::*;
 pub use rom::{append_rom_digest, rom_build, rom_size_for_platform, test_rom_build};
 pub use runtime::{bare_metal_build, runtime_build_with_apps};
@@ -82,6 +82,23 @@ pub fn target_dir() -> PathBuf {
     std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PROJECT_ROOT.join("target"))
+}
+
+/// Returns the Path to the caliptra-sw workspace root.
+pub fn caliptra_sw_workspace_root() -> PathBuf {
+    let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
+    let package = metadata
+        .packages
+        .iter()
+        .find(|p| {
+            p.name.as_ref() == "caliptra-image-fake-keys" || p.name.as_ref() == "caliptra-api-types"
+        })
+        .map(|p| p.manifest_path.clone())
+        .and_then(|p| p.ancestors().nth(3).map(|p| p.to_path_buf()));
+    match package {
+        Some(path) => path.into(),
+        None => panic!("Could not determine caliptra-sw path"),
+    }
 }
 
 pub(crate) static SYSROOT: LazyLock<String> = LazyLock::new(|| {

--- a/builder/src/offline_signing.rs
+++ b/builder/src/offline_signing.rs
@@ -1,10 +1,12 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, Context, Result};
+use caliptra_auth_man_types::AuthManifestPreamble;
 use caliptra_image_gen::to_hw_format;
 use caliptra_image_types::{ImageEccSignature, ImagePqcSignature};
 use p384::ecdsa::Signature;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha384};
 use zerocopy::IntoBytes;
 
 /// Request payload containing signature targets to be signed offline.
@@ -49,6 +51,64 @@ pub struct SignatureEntry {
     pub ecc_sig: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pqc_sig: Option<String>,
+}
+
+fn sha384_hex(data: &[u8]) -> String {
+    let mut hasher = Sha384::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+/// Generate a `SigningRequestJson` containing SHA-384 targets and hex payloads from an unsigned `AuthorizationManifest`.
+pub fn create_signing_request(
+    manifest: &caliptra_auth_man_types::AuthorizationManifest,
+) -> Result<SigningRequestJson> {
+    let preamble_bytes = manifest.preamble.as_bytes();
+
+    let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+    let vendor_payload = preamble_bytes
+        .get(vendor_range.start as usize..vendor_range.end as usize)
+        .ok_or_else(|| anyhow!("Invalid vendor signed data range"))?;
+    let vendor_digest = sha384_hex(vendor_payload);
+
+    let owner_range = AuthManifestPreamble::owner_pub_keys_range();
+    let owner_payload = preamble_bytes
+        .get(owner_range.start as usize..owner_range.end as usize)
+        .ok_or_else(|| anyhow!("Invalid owner pub keys range"))?;
+    let owner_digest = sha384_hex(owner_payload);
+
+    let imc_payload = manifest.image_metadata_col.as_bytes();
+    let imc_digest = sha384_hex(imc_payload);
+
+    Ok(SigningRequestJson {
+        version: 1,
+        requests: SigningRequests {
+            vendor_pub_keys_signatures: SignatureRequestEntry {
+                ecc_key: "vendor_fw_ecc_key".to_string(),
+                pqc_key: "vendor_fw_pqc_key".to_string(),
+                digest_sha384: vendor_digest,
+                payload_hex: hex::encode(vendor_payload),
+            },
+            owner_pub_keys_signatures: SignatureRequestEntry {
+                ecc_key: "owner_fw_ecc_key".to_string(),
+                pqc_key: "owner_fw_pqc_key".to_string(),
+                digest_sha384: owner_digest,
+                payload_hex: hex::encode(owner_payload),
+            },
+            vendor_imc_signatures: SignatureRequestEntry {
+                ecc_key: "vendor_man_ecc_key".to_string(),
+                pqc_key: "vendor_man_pqc_key".to_string(),
+                digest_sha384: imc_digest.clone(),
+                payload_hex: hex::encode(imc_payload),
+            },
+            owner_imc_signatures: SignatureRequestEntry {
+                ecc_key: "owner_man_ecc_key".to_string(),
+                pqc_key: "owner_man_pqc_key".to_string(),
+                digest_sha384: imc_digest,
+                payload_hex: hex::encode(imc_payload),
+            },
+        },
+    })
 }
 
 pub trait ImageEccSignatureExt: Sized {


### PR DESCRIPTION
Extend CaliptraBuilder to support loading public keys (ECC, LMS, and ML-DSA) via AuthManifestPubKeysPaths and generating unsigned authorization manifest templates with fallback key warnings.

Also add caliptra_sw_workspace_root helper in builder/src/lib.rs to locate test keys checked into caliptra-sw for unit testing.

This partially addresses #1833.