### PR TITLE
ci: support targeted SPDM validator groups

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,3 +17,8 @@ jobs:
   spdm_validator_tests:
     uses: ./.github/workflows/spdm-validator.yml
 
+  spdm_validator_version_1_4_tests:
+    uses: ./.github/workflows/spdm-validator.yml
+    with:
+      validator_test_groups: VERSION,CAPABILITIES
+

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -5,7 +5,29 @@ name: SPDM Validator Tests
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: true
+        default: caliptra-main
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   workflow_call:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: false
+        default: caliptra-main
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
 
 env:
   # Pin the Caliptra core ROM to a release tag; image/update crates continue
@@ -83,9 +105,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-emu
-          ref: caliptra-main
+          ref: ${{ inputs.spdm_emu_ref }}
           path: spdm-emu
           submodules: recursive
+
+      - name: Record resolved spdm-emu revision
+        working-directory: spdm-emu
+        run: git rev-parse HEAD
 
       - name: Build spdm-emu
         run: |
@@ -104,8 +130,11 @@ jobs:
           echo "SPDM_NONCE=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
       - name: Run SPDM validator tests on MCTP transport
+        id: mctp_validator
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ inputs.validator_test_groups }}
         run: |
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
@@ -126,21 +155,14 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results on MCTP transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on MCTP transport
-        env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-        run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
-
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -148,8 +170,12 @@ jobs:
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
 
       - name: Run SPDM validator tests on DOE transport
+        id: doe_validator
+        if: always()
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ inputs.validator_test_groups }}
         run: |
           cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
@@ -168,21 +194,25 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results for DOE transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on DOE transport
+      - name: Fail on SPDM validator failures
+        if: always()
         env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          MCTP_RESULT: ${{ steps.mctp_validator.outcome }}
+          DOE_RESULT: ${{ steps.doe_validator.outcome }}
         run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
+          printf 'MCTP result=%s\n' "$MCTP_RESULT"
+          printf 'DOE result=%s\n' "$DOE_RESULT"
+          test "$MCTP_RESULT" = success
+          test "$DOE_RESULT" = success
 
       - name: Checkout CCC spdm-rs repository
+        if: inputs.validator_test_groups == ''
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -191,6 +221,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
+        if: inputs.validator_test_groups == ''
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -200,11 +231,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
+        if: inputs.validator_test_groups == ''
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -213,13 +246,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always()
+        if: always() && inputs.validator_test_groups == ''
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::spdm_responder_validator::transport::Transport;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -16,6 +16,7 @@ pub const SOCKET_SPDM_COMMAND_TEST: u32 = 0xDEAD;
 pub const SOCKET_HEADER_LEN: usize = 12;
 
 pub static SERVER_LISTENING: AtomicBool = AtomicBool::new(false);
+static SPDM_RESPONDER_VALIDATOR_DONE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
 pub struct SpdmSocketHeader {
@@ -312,7 +313,89 @@ pub fn execute_spdm_attestation(transport: &'static str) {
     });
 }
 
+fn check_spdm_responder_validator_results(log: &str, test_groups: &str) -> Result<String, String> {
+    if !log.trim_end().ends_with("test result done") {
+        return Err("log does not end with a complete test result".into());
+    }
+
+    let mut suite_summaries = log.lines().filter_map(|line| {
+        let summary = line.strip_prefix("test suite (")?;
+        let (suite_name, counts) = summary.split_once(") - pass: ")?;
+        let (pass_count, fail_count) = counts.split_once(", fail: ")?;
+        Some((suite_name, pass_count, fail_count))
+    });
+    let Some((suite_name, pass_count, fail_count)) = suite_summaries.next() else {
+        return Err("expected one suite summary, found none".into());
+    };
+    if suite_summaries.next().is_some() {
+        return Err("expected one suite summary, found multiple".into());
+    }
+
+    let pass_count = pass_count
+        .parse::<u32>()
+        .map_err(|_| "suite pass count is invalid")?;
+    let fail_count = fail_count
+        .parse::<u32>()
+        .map_err(|_| "suite fail count is invalid")?;
+    if pass_count == 0 {
+        return Err("suite executed zero passing assertions".into());
+    }
+    if fail_count != 0 {
+        return Err(format!("suite recorded {fail_count} failed assertions"));
+    }
+    if log.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("test assertion ") && line.contains(" - FAIL")
+    }) {
+        return Err("log contains a failed assertion".into());
+    }
+
+    let selected_groups: Vec<_> = test_groups
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .collect();
+    // CAPABILITIES is selected alongside VERSION so its existing cases run, but
+    // dedicated SPDM 1.4 capability assertions will be required separately as
+    // that validator coverage is added.
+    if selected_groups.contains(&"VERSION")
+        && !log.lines().any(|line| {
+            line.trim_start()
+                == "test assertion 1.1.5 - PASS response version_number_entry - 0x1400"
+        })
+    {
+        return Err("VERSION did not advertise a passing 0x1400 entry".into());
+    }
+
+    Ok(format!(
+        "SPDM validator suite {suite_name}: pass={pass_count}, fail={fail_count}; selected_groups={}",
+        if test_groups.is_empty() {
+            "ALL"
+        } else {
+            test_groups
+        }
+    ))
+}
+
+fn check_spdm_responder_validator_log() -> Result<String, String> {
+    let log_path = validator_dir()
+        .map_err(|error| format!("SPDM_VALIDATOR_DIR is unavailable: {error}"))?
+        .join("test.log");
+    let log = fs::read_to_string(&log_path)
+        .map_err(|error| format!("failed to read {}: {error}", log_path.display()))?;
+    let test_groups = std::env::var("SPDM_VALIDATOR_TEST_GROUPS").unwrap_or_default();
+    check_spdm_responder_validator_results(&log, &test_groups)
+}
+
+pub fn wait_for_spdm_responder_validator() -> bool {
+    while crate::is_emulator_running() && !SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire) {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire)
+}
+
 pub fn execute_spdm_responder_validator(transport: &'static str) {
+    SPDM_RESPONDER_VALIDATOR_DONE.store(false, Ordering::Release);
     crate::spawn_with_emulator_state(move || {
         println!(
             "Starting spdm_device_validator_sample process on transport: {}. Waiting for SPDM listener to start...",
@@ -331,6 +414,19 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                                 "spdm_device_validator_sample exited with status: {:?}",
                                 status
                             );
+                            if !status.success() {
+                                std::process::exit(1);
+                            }
+                            match check_spdm_responder_validator_log() {
+                                Ok(summary) => {
+                                    println!("{summary}");
+                                    SPDM_RESPONDER_VALIDATOR_DONE.store(true, Ordering::Release);
+                                }
+                                Err(error) => {
+                                    println!("SPDM validator result check failed: {error}");
+                                    std::process::exit(1);
+                                }
+                            }
                             break;
                         }
                         Ok(None) => {}
@@ -348,6 +444,7 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                     "Error: {:?} Failed to spawn spdm_device_validator_sample!!",
                     e
                 );
+                std::process::exit(1);
             }
         }
     });
@@ -366,6 +463,12 @@ pub fn start_spdm_responder_validator(transport: &'static str) -> io::Result<Chi
                 .arg(transport)
                 .arg("--pcap")
                 .arg("caliptra_spdm_validator.pcap");
+            if let Ok(test_groups) = std::env::var("SPDM_VALIDATOR_TEST_GROUPS") {
+                if !test_groups.is_empty() {
+                    println!("Selecting SPDM validator test groups: {test_groups}");
+                    cmd.arg("--test-groups").arg(test_groups);
+                }
+            }
         },
     )
 }
@@ -459,4 +562,50 @@ where
         .stderr(Stdio::from(output_file_clone))
         .current_dir(&dir_path)
         .spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_spdm_responder_validator_results;
+
+    const COMPLETE_LOG: &str = "\
+    test assertion 1.1.5 - PASS response version_number_entry - 0x1400
+test suite (spdm_responder_conformance_test) - pass: 1, fail: 0
+test result done
+";
+
+    #[test]
+    fn accepts_complete_selected_group_results() {
+        let result = check_spdm_responder_validator_results(COMPLETE_LOG, "VERSION,CAPABILITIES");
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn rejects_incomplete_results() {
+        let result = check_spdm_responder_validator_results(
+            COMPLETE_LOG.trim_end_matches("test result done\n"),
+            "",
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            "log does not end with a complete test result"
+        );
+    }
+
+    #[test]
+    fn rejects_failed_suite() {
+        let log = COMPLETE_LOG.replace("pass: 1, fail: 0", "pass: 1, fail: 1");
+        let result = check_spdm_responder_validator_results(&log, "");
+        assert_eq!(result.unwrap_err(), "suite recorded 1 failed assertions");
+    }
+
+    #[test]
+    fn rejects_missing_spdm_1_4_version() {
+        let log = COMPLETE_LOG.replace("0x1400", "0x1300");
+        let result = check_spdm_responder_validator_results(&log, "VERSION");
+        assert_eq!(
+            result.unwrap_err(),
+            "VERSION did not advertise a passing 0x1400 entry"
+        );
+    }
 }

--- a/common/testing/src/spdm_responder_validator/doe.rs
+++ b/common/testing/src/spdm_responder_validator/doe.rs
@@ -3,7 +3,7 @@
 use crate::doe_util::common::DoeUtil;
 use crate::spdm_responder_validator::common::{
     execute_spdm_attestation, execute_spdm_responder_validator, execute_spdm_tee_io_validator,
-    SpdmValidatorRunner, SERVER_LISTENING,
+    wait_for_spdm_responder_validator, SpdmValidatorRunner, SERVER_LISTENING,
 };
 use crate::spdm_responder_validator::transport::{Transport, SOCKET_TRANSPORT_TYPE_PCI_DOE};
 use crate::spdm_responder_validator::SpdmTestType;
@@ -113,6 +113,7 @@ pub fn run_doe_spdm_conformance_test(
     test_timeout_seconds: Duration,
 ) {
     let transport = DoeTransport::new(tx, rx, 1);
+    let check_responder_results = matches!(&test_type, SpdmTestType::SpdmResponderConformance);
     // Spawn a thread to handle the timeout for the test
     crate::spawn_with_emulator_state(move || {
         std::thread::sleep(test_timeout_seconds);
@@ -147,9 +148,12 @@ pub fn run_doe_spdm_conformance_test(
             if !test.is_passed() {
                 println!("[{}]: Spdm Responder Conformance Test Failed", TEST_NAME);
                 exit(-1);
-            } else {
+            } else if !check_responder_results || wait_for_spdm_responder_validator() {
                 println!("[{}]: Spdm Responder Conformance Test Passed", TEST_NAME);
                 exit(0);
+            } else {
+                println!("[{}]: Spdm Validator Result Check Failed", TEST_NAME);
+                exit(-1);
             }
         }
     });

--- a/common/testing/src/spdm_responder_validator/mod.rs
+++ b/common/testing/src/spdm_responder_validator/mod.rs
@@ -12,6 +12,6 @@ pub enum SpdmTestType {
 }
 
 pub use common::{
-    execute_spdm_attestation, execute_spdm_responder_validator, SpdmValidatorRunner,
-    SERVER_LISTENING,
+    execute_spdm_attestation, execute_spdm_responder_validator, wait_for_spdm_responder_validator,
+    SpdmValidatorRunner, SERVER_LISTENING,
 };

--- a/tests/integration/src/test_mctp_spdm_responder_conformance.rs
+++ b/tests/integration/src/test_mctp_spdm_responder_conformance.rs
@@ -13,7 +13,8 @@ mod test {
     use caliptra_mcu_testing_common::i3c_socket::BufferedStream;
     use caliptra_mcu_testing_common::spdm_responder_validator::mctp::MctpTransport;
     use caliptra_mcu_testing_common::spdm_responder_validator::{
-        execute_spdm_responder_validator, SpdmValidatorRunner, SERVER_LISTENING,
+        execute_spdm_responder_validator, wait_for_spdm_responder_validator, SpdmValidatorRunner,
+        SERVER_LISTENING,
     };
     use caliptra_mcu_testing_common::wait_for_runtime_start;
     use random_port::PortPicker;
@@ -102,9 +103,12 @@ mod test {
                 if !test.is_passed() {
                     println!("[{}]: Spdm Responder Conformance Test Failed", TEST_NAME);
                     exit(-1);
-                } else {
+                } else if wait_for_spdm_responder_validator() {
                     println!("[{}]: Spdm Responder Conformance Test Passed", TEST_NAME);
                     exit(0);
+                } else {
+                    println!("[{}]: Spdm Validator Result Check Failed", TEST_NAME);
+                    exit(-1);
                 }
             }
         });


### PR DESCRIPTION
## Summary

- add deterministic `spdm_emu_ref` workflow input
- add optional `validator_test_groups` input and pass it to both MCTP and DOE validators
- preserve the existing complete-suite default when no group selection is supplied
- validate the authoritative `test.log` in the Rust integration-test harness
- require a completed suite, zero failed assertions, and a passing VERSION `0x1400` entry when VERSION is selected
- run `VERSION,CAPABILITIES` nightly alongside the existing full-suite job

The validator result check follows the existing validator pattern: the Rust integration test owns pass/fail propagation through `cargo test`; the workflow only preserves artifacts and combines the MCTP/DOE outcomes. No standalone Python checker is used.

CAPABILITIES is selected in the targeted run so its available cases execute, but dedicated SPDM 1.4 capability-case assertions are intentionally deferred until that validator coverage is added.

This is validator infrastructure only. Runtime SPDM 1.4 behavior remains in #1857.

## Dependencies / use

Targeted SPDM 1.4 validation uses:
- chipsalliance/caliptra-SPDM-Responder-Validator#2 (`faab178b`)
- chipsalliance/caliptra-spdm-emu#2 (`a786d4d2`)

The workflow default remains compatible with the currently pinned emulator and runs the full suite. The dependency merge order is validator, emulator, then this PR so the nightly targeted job has `--test-groups` support.

## Validation

- `cargo test -p caliptra-mcu-testing-common --lib`: 13 passed
- `cargo clippy -p caliptra-mcu-testing-common --lib -- -D warnings`: PASS on the validation stack
- targeted MCTP integration test with in-harness log validation: 108 pass, 0 fail
- targeted DOE integration test with in-harness log validation: 117 pass, 0 fail
- `cargo xtask all-build`: PASS on the #1857 validation stack
- invalid group `VERSION,UNKNOWN`: exit 2 and accepted groups printed

`actionlint` reports only the workflow's pre-existing unquoted-variable findings.

Targeted results against #1857 commit `e8585408`:

| transport | process | suite pass | suite fail | VERSION 0x1400 |
|---|---:|---:|---:|---|
| MCTP | 0 | 108 | 0 | PASS |
| DOE | 0 | 117 | 0 | PASS |

Updated-validator V1.3 full-suite regression baseline at `f845faf9`:

| transport | process | suite pass | suite fail |
|---|---:|---:|---:|
| MCTP | 0 | 671 | 0 |
| DOE | 0 | 961 | 0 |

Historical baseline before enabling the additional validator cases was MCTP 655/0 and DOE 942/0.

This validation checks SPDM 1.4 VERSION advertisement and does not claim full SPDM 1.4 conformance.

Refs #1785
Refs #1787
