### PR TITLE
fix: align user-app stack budget across emulator and fpga bundles

### DIFF
--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -38,5 +38,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x9e00
+stack = 0xae80
 grant_space = 0x4000


### PR DESCRIPTION
Set the user-app stack to a common 0xae80 (44672) on both reference bundles so the emulator and fpga platforms share one budget with margin over the observed peak:
  fpga:     0x9e80 -> 0xae80
  emulator: 0x8e00 -> 0xae80

Sizing only; no logic change. Local runtime integration suite passes.

Closes #1889