### PR TITLE
[ROM]: Reset boot milestones on warm reset

### DIFF
--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -29,6 +29,8 @@ impl BootFlow for WarmBoot {
     fn run(env: &mut RomEnv, params: RomParameters) -> ! {
         crate::call_hook(params.hooks, |h| h.pre_warm_boot());
         env.mci
+            .reset_flow_milestones(McuBootMilestones::ROM_STARTED.into());
+        env.mci
             .set_flow_checkpoint(McuRomBootStatus::WarmResetFlowStarted.into());
         caliptra_mcu_romtime::println!("[mcu-rom] Starting warm boot flow");
 

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -83,6 +83,13 @@ impl Mci {
         self.set_flow_status(milestone | self.flow_status());
     }
 
+    /// Reset flow milestones (clears upper 16 bits of flow_status) and sets new milestone
+    pub fn reset_flow_milestones(&self, milestone: u16) {
+        let checkpoint = self.flow_checkpoint();
+        let milestone_val = u32::from(milestone) << 16;
+        self.set_flow_status(milestone_val | u32::from(checkpoint));
+    }
+
     pub fn flow_milestone(&self) -> u16 {
         (self.flow_status() >> 16) as u16
     }


### PR DESCRIPTION
These milestones are not reset on a warm reset, so the flow_status register does not properly reflect the current state of MCU.

Hardware does not reset this register on a warm reset.