### PR TITLE
fix(size): right-size ML-DSA verify buffer and lower app stack budget

### DIFF
--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -38,5 +38,10 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0xae80
+# Measured worst-case app stack (deepest additive chain, -Z emit-stack-sizes)
+# is 13,520 B. Budget = ~1.5x that, covering the .stack_sizes undercount
+# (indirect/dyn-dispatch edges the static walker can't follow, asm frames).
+# App faults trap to the kernel M-mode stack, so no ISR headroom is needed here.
+# Keep emulator and fpga equal.
+stack = 0x5000
 grant_space = 0x4000

--- a/firmware-bundler/reference/fpga/user-app.toml
+++ b/firmware-bundler/reference/fpga/user-app.toml
@@ -30,5 +30,10 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0xae80
+# Measured worst-case app stack (deepest additive chain, -Z emit-stack-sizes)
+# is 13,520 B. Budget = ~1.5x that, covering the .stack_sizes undercount
+# (indirect/dyn-dispatch edges the static walker can't follow, asm frames).
+# App faults trap to the kernel M-mode stack, so no ISR headroom is needed here.
+# Keep emulator and fpga equal.
+stack = 0x5000
 grant_space = 0x4000

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -24,6 +24,43 @@ use zerocopy::IntoBytes;
 const ALGO_ECC_P384: u32 = 0x0001;
 const ALGO_MLDSA87: u32 = 0x0002;
 
+// ML-DSA verify message is a fixed 64-byte SHA-512 digest; only the prefix up
+// to `message[..64]` is transmitted, so the shared request buffer is sized to
+// that instead of the full MldsaVerifyReq (keeps the 4 KB message tail out of .bss).
+const MLDSA_VERIFY_DIGEST_LEN: usize = 64;
+const MLDSA_VERIFY_REQ_WIRE_LEN: usize =
+    core::mem::offset_of!(MldsaVerifyReq, message) + MLDSA_VERIFY_DIGEST_LEN;
+// Must equal MldsaVerifyReq::as_bytes_partial_mut() length at message_size=64.
+const _: () = assert!(
+    MLDSA_VERIFY_REQ_WIRE_LEN
+        == core::mem::size_of::<MldsaVerifyReq>()
+            - (caliptra_api::mailbox::MAX_CMB_DATA_SIZE - MLDSA_VERIFY_DIGEST_LEN)
+);
+// The right-size only helps if the buffer is smaller than the full struct.
+const _: () = assert!(MLDSA_VERIFY_REQ_WIRE_LEN < core::mem::size_of::<MldsaVerifyReq>());
+
+// Serialize an MLDSA87_SIGNATURE_VERIFY request into `out` at the real
+// MldsaVerifyReq field offsets. chksum ([0..pub_key]) is zeroed: the caller's
+// populate_checksum() sums the whole slice then overwrites [0..4]; RT verifies
+// over [4..], so a nonzero header would break the checksum.
+fn build_mldsa_verify_req(
+    out: &mut [u8; MLDSA_VERIFY_REQ_WIRE_LEN],
+    pub_key: &[u8; 2592],
+    signature: &[u8; 4628],
+    message: &[u8; MLDSA_VERIFY_DIGEST_LEN],
+) {
+    const O_PUB_KEY: usize = core::mem::offset_of!(MldsaVerifyReq, pub_key);
+    const O_SIGNATURE: usize = core::mem::offset_of!(MldsaVerifyReq, signature);
+    const O_MESSAGE_SIZE: usize = core::mem::offset_of!(MldsaVerifyReq, message_size);
+    const O_MESSAGE: usize = core::mem::offset_of!(MldsaVerifyReq, message);
+    out[..O_PUB_KEY].fill(0);
+    out[O_PUB_KEY..O_PUB_KEY + pub_key.len()].copy_from_slice(pub_key);
+    out[O_SIGNATURE..O_SIGNATURE + signature.len()].copy_from_slice(signature);
+    out[O_MESSAGE_SIZE..O_MESSAGE_SIZE + 4]
+        .copy_from_slice(&(MLDSA_VERIFY_DIGEST_LEN as u32).to_le_bytes());
+    out[O_MESSAGE..O_MESSAGE + message.len()].copy_from_slice(message);
+}
+
 pub async fn request_debug_unlock<A: ApiAlloc>(
     alloc: &A,
     unlock_level: u8,
@@ -160,26 +197,19 @@ pub async fn verify_authorized_signatures(
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
-    // Use a shared static buffer behind an async Mutex to avoid inflating
-    // the async task future by ~11 KB.  The guard is held across `.await`.
-    // SAFETY: MldsaVerifyReq derives FromBytes, so all-zeros is a valid repr.
-    static MLDSA_REQ: Mutex<CriticalSectionRawMutex, core::mem::MaybeUninit<MldsaVerifyReq>> =
-        Mutex::new(core::mem::MaybeUninit::zeroed());
+    // Shared static request buffer behind an async Mutex (held across `.await`)
+    // so the ~11 KB request is not duplicated into every task's future. Sized
+    // to the transmitted prefix (message is a fixed 64-byte digest, not the
+    // full MAX_CMB_DATA_SIZE), which keeps ~4 KB out of `.bss` vs storing the
+    // whole MldsaVerifyReq. Fields are written at the real struct offsets so
+    // the wire image is byte-identical to as_bytes_partial_mut() at
+    // message_size=64.
+    static MLDSA_REQ: Mutex<CriticalSectionRawMutex, [u8; MLDSA_VERIFY_REQ_WIRE_LEN]> =
+        Mutex::new([0u8; MLDSA_VERIFY_REQ_WIRE_LEN]);
 
     let mut guard = MLDSA_REQ.lock().await;
-    // SAFETY: MldsaVerifyReq derives FromBytes — all-zeros (from the static
-    // initializer) and any byte pattern we write are valid representations.
-    let req: &mut MldsaVerifyReq = unsafe { guard.assume_init_mut() };
-    req.hdr = MailboxReqHeader::default();
-    req.pub_key = *mldsa_pub;
-    req.signature = sig.mldsa_sig;
-    req.message_size = mldsa_msg.len() as u32;
-    req.message = [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE];
-    req.message[..mldsa_msg.len()].copy_from_slice(&mldsa_msg);
-
-    let mldsa_req_bytes = req
-        .as_bytes_partial_mut()
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    build_mldsa_verify_req(&mut guard, mldsa_pub, &sig.mldsa_sig, &mldsa_msg);
+    let mldsa_req_bytes = guard.as_mut_slice();
 
     let mut mldsa_resp = MailboxRespHeader::default();
     let mldsa_resp_bytes = mldsa_resp.as_mut_bytes();
@@ -224,5 +254,58 @@ pub(crate) fn map_mailbox_error(e: MailboxError) -> CaliptraCompletionCode {
         MailboxError::ErrorCode(_) | MailboxError::MailboxError(_) => {
             CaliptraCompletionCode::OperationFailed
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The right-sized shared buffer must be byte-identical to what the full
+    // MldsaVerifyReq would transmit via as_bytes_partial_mut() at message_size=64.
+    #[test]
+    fn mldsa_verify_req_wire_matches_full_struct() {
+        let mut pub_key = [0u8; 2592];
+        let mut signature = [0u8; 4628];
+        let mut message = [0u8; MLDSA_VERIFY_DIGEST_LEN];
+        for (i, b) in pub_key.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        for (i, b) in signature.iter_mut().enumerate() {
+            *b = (i as u8) ^ 0x5a;
+        }
+        for (i, b) in message.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_add(3);
+        }
+
+        let mut got = [0u8; MLDSA_VERIFY_REQ_WIRE_LEN];
+        build_mldsa_verify_req(&mut got, &pub_key, &signature, &message);
+
+        let mut full = MldsaVerifyReq {
+            hdr: MailboxReqHeader::default(),
+            pub_key,
+            signature,
+            message_size: MLDSA_VERIFY_DIGEST_LEN as u32,
+            message: [0u8; caliptra_api::mailbox::MAX_CMB_DATA_SIZE],
+        };
+        full.message[..MLDSA_VERIFY_DIGEST_LEN].copy_from_slice(&message);
+        let want = full.as_bytes_partial_mut().unwrap();
+
+        assert_eq!(want.len(), MLDSA_VERIFY_REQ_WIRE_LEN);
+        assert_eq!(got.as_slice(), &*want);
+    }
+
+    // chksum field stays zero so populate_checksum() computes correctly.
+    #[test]
+    fn mldsa_verify_req_checksum_field_zeroed() {
+        let mut got = [0xffu8; MLDSA_VERIFY_REQ_WIRE_LEN];
+        build_mldsa_verify_req(
+            &mut got,
+            &[1u8; 2592],
+            &[2u8; 4628],
+            &[3u8; MLDSA_VERIFY_DIGEST_LEN],
+        );
+        let chksum_len = core::mem::offset_of!(MldsaVerifyReq, pub_key);
+        assert!(got[..chksum_len].iter().all(|&b| b == 0));
     }
 }


### PR DESCRIPTION
Closes #1884

## Summary

Two SRAM reductions on top of #1859: **−28,224 B reserved SRAM** (78.3% → 73.0%), +194 B flash.
No change to what is sent to Caliptra or how verification works.

**1. Right-size the shared ML-DSA request buffer (`.bss`, −4 KB).**
`MldsaVerifyReq.message` is a fixed 4,096 B field, but this call site only puts a 64-byte SHA-512
digest in it. #1859 moved the struct to a shared `static` but reserved the full struct — including the
4,032 B tail that is never transmitted.

```text
before:  static = MldsaVerifyReq { … message: [0u8; 4096] }  → 11,340 B
after:   static = [0u8; 7292]  (same wire bytes)             →  7,308 B
```

Fields are written at the struct's `offset_of!` positions, so the request is **byte-identical** at
`message_size = 64` (the mailbox already transmits only `message_size` bytes of that field).

**2. Lower the app stack budget (`.stack`, −24 KB).**
Measured worst-case depth is **13,776 B** (deepest additive chain, `-Z emit-stack-sizes`, across all
tasks; they never coexist on the single cooperative executor). The budget was 3.24× that.

```text
before:  [[app]] stack = 0xae80 (44,672 B)  → 3.24x peak
after:   [[app]] stack = 0x5000 (20,480 B)  → 1.49x peak
```

The 1.49× margin covers the `.stack_sizes` undercount (indirect/`dyn` edges, asm frames). App faults
trap to the kernel M-mode stack, so no interrupt headroom is needed here. Emulator and fpga kept equal.

## Measured (FPGA, `test-mctp-spdm-attestation`, release, base `81b33fc94`)

| | main | this PR | Δ |
|---|---:|---:|---:|
| `MLDSA_REQ` static (`.bss`) | 11,340 B | 7,308 B | **−4,032 B** |
| App `.bss` | 66,952 B | 62,920 B | **−4,032 B** |
| App `.stack` (budget) | 44,672 B | 20,480 B | **−24,192 B** |
| App `.text` / `.rodata` | 141,288 / 26,164 B | 141,370 / 26,276 B | +82 / +112 B |
| **Total MCU SRAM used** | 410,736 B (78.3 %) | **382,512 B (73.0 %)** | **−28,224 B** |

`.stack` and `.bss` are NOBITS (reserved SRAM, absent from the flashed image), so this reduces SRAM.

## Safety

- Unit test `mldsa_verify_req_wire_matches_full_struct` asserts byte-equality with the full-struct
  `as_bytes_partial_mut()` output; `…checksum_field_zeroed` covers the checksum invariant; a
  `const _: () = assert!(WIRE_LEN < size_of::<MldsaVerifyReq>())` fails the build if the tail returns.
- Both platforms link at `0x5000`; `runtime::test_mcu_mailbox` 4/4 on the emulator, no stack fault.
- No change to signing, verification, transcript, or auth outcomes.
