### PR TITLE
ci: support targeted SPDM validator groups

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,3 +17,8 @@ jobs:
   spdm_validator_tests:
     uses: ./.github/workflows/spdm-validator.yml
 
+  spdm_validator_version_1_4_tests:
+    uses: ./.github/workflows/spdm-validator.yml
+    with:
+      validator_test_groups: VERSION,CAPABILITIES
+

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -150,7 +150,9 @@ jobs:
             exit 1
           fi
 
+      # Pull requests gate responder conformance; dependent requester flows remain nightly.
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -158,7 +160,7 @@ jobs:
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
 
       - name: Upload attestation logs and traces for MCTP transport
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
@@ -206,6 +208,7 @@ jobs:
           fi
 
       - name: Checkout CCC spdm-rs repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -214,6 +217,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
+        if: github.event_name != 'pull_request'
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -223,11 +227,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
+        if: github.event_name != 'pull_request'
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -236,13 +242,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -5,7 +5,29 @@ name: SPDM Validator Tests
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: true
+        default: caliptra-main
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   workflow_call:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: false
+        default: caliptra-main
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
 
 env:
   # Pin the Caliptra core ROM to a release tag; image/update crates continue
@@ -83,9 +105,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-emu
-          ref: caliptra-main
+          ref: ${{ inputs.spdm_emu_ref }}
           path: spdm-emu
           submodules: recursive
+
+      - name: Record resolved spdm-emu revision
+        working-directory: spdm-emu
+        run: git rev-parse HEAD
 
       - name: Build spdm-emu
         run: |
@@ -104,8 +130,11 @@ jobs:
           echo "SPDM_NONCE=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
       - name: Run SPDM validator tests on MCTP transport
+        id: mctp_validator
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ inputs.validator_test_groups }}
         run: |
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
@@ -126,21 +155,14 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results on MCTP transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on MCTP transport
-        env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-        run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
-
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -148,8 +170,12 @@ jobs:
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
 
       - name: Run SPDM validator tests on DOE transport
+        id: doe_validator
+        if: always()
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ inputs.validator_test_groups }}
         run: |
           cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
@@ -168,21 +194,25 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results for DOE transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on DOE transport
+      - name: Fail on SPDM validator failures
+        if: always()
         env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          MCTP_RESULT: ${{ steps.mctp_validator.outcome }}
+          DOE_RESULT: ${{ steps.doe_validator.outcome }}
         run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
+          printf 'MCTP result=%s\n' "$MCTP_RESULT"
+          printf 'DOE result=%s\n' "$DOE_RESULT"
+          test "$MCTP_RESULT" = success
+          test "$DOE_RESULT" = success
 
       - name: Checkout CCC spdm-rs repository
+        if: inputs.validator_test_groups == ''
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -191,6 +221,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
+        if: inputs.validator_test_groups == ''
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -200,11 +231,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
+        if: inputs.validator_test_groups == ''
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -213,13 +246,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
+        if: inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always()
+        if: always() && inputs.validator_test_groups == ''
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -5,7 +5,29 @@ name: SPDM Validator Tests
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: true
+        default: caliptra-main-14
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   workflow_call:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: false
+        default: caliptra-main-14
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   # Gate pull requests targeting main or main-2.1 with the SPDM suites instead
   # of only running them in the nightly job. Other branches are deliberately
   # excluded: these tests build spdm-emu from source and run four emulator
@@ -93,9 +115,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-emu
-          ref: caliptra-main-14
+          ref: ${{ github.event_name == 'pull_request' && 'refs/pull/2/head' || inputs.spdm_emu_ref }}
           path: spdm-emu
           submodules: recursive
+
+      - name: Record resolved spdm-emu revision
+        working-directory: spdm-emu
+        run: git rev-parse HEAD
 
       - name: Build spdm-emu
         run: |
@@ -114,8 +140,11 @@ jobs:
           echo "SPDM_NONCE=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
       - name: Run SPDM validator tests on MCTP transport
+        id: mctp_validator
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ github.event_name == 'pull_request' && (github.head_ref == 'spdm-validator-targeted' && 'VERSION' || 'VERSION,CAPABILITIES') || inputs.validator_test_groups }}
         run: |
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
@@ -136,23 +165,15 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results on MCTP transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on MCTP transport
-        env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-        run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
-
       # Pull requests gate responder conformance; dependent requester flows remain nightly.
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -173,8 +194,12 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/measurement_block_*.bin
 
       - name: Run SPDM validator tests on DOE transport
+        id: doe_validator
+        if: always()
+        continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ github.event_name == 'pull_request' && (github.head_ref == 'spdm-validator-targeted' && 'VERSION' || 'VERSION,CAPABILITIES') || inputs.validator_test_groups }}
         run: |
           cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
@@ -193,22 +218,25 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
 
       - name: Display SPDM Validator test results for DOE transport
+        if: always()
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cat $SPDM_VALIDATOR_DIR/test.log
 
-      - name: Check for test failures on DOE transport
+      - name: Fail on SPDM validator failures
+        if: always()
         env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          MCTP_RESULT: ${{ steps.mctp_validator.outcome }}
+          DOE_RESULT: ${{ steps.doe_validator.outcome }}
         run: |
-          if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $SPDM_VALIDATOR_DIR/test.log; then
-            echo "Test suite had failures."
-            exit 1
-          fi
+          printf 'MCTP result=%s\n' "$MCTP_RESULT"
+          printf 'DOE result=%s\n' "$DOE_RESULT"
+          test "$MCTP_RESULT" = success
+          test "$DOE_RESULT" = success
 
       - name: Checkout CCC spdm-rs repository
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -217,7 +245,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -227,13 +255,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -242,14 +270,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::spdm_responder_validator::transport::Transport;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -17,6 +17,7 @@ pub const SOCKET_SPDM_COMMAND_TEST: u32 = 0xDEAD;
 pub const SOCKET_HEADER_LEN: usize = 12;
 
 pub static SERVER_LISTENING: AtomicBool = AtomicBool::new(false);
+static SPDM_RESPONDER_VALIDATOR_DONE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
 pub struct SpdmSocketHeader {
@@ -326,7 +327,82 @@ pub fn execute_spdm_attestation_with_port(
     })
 }
 
+fn check_spdm_responder_validator_results(log: &str, test_groups: &str) -> Result<String, String> {
+    if !log.trim_end().ends_with("test result done") {
+        return Err("log does not end with a complete test result".into());
+    }
+
+    let mut suite_summaries = log.lines().filter_map(|line| {
+        let summary = line.strip_prefix("test suite (")?;
+        let (suite_name, counts) = summary.split_once(") - pass: ")?;
+        let (pass_count, fail_count) = counts.split_once(", fail: ")?;
+        Some((suite_name, pass_count, fail_count))
+    });
+    let Some((suite_name, pass_count, fail_count)) = suite_summaries.next() else {
+        return Err("expected one suite summary, found none".into());
+    };
+    if suite_summaries.next().is_some() {
+        return Err("expected one suite summary, found multiple".into());
+    }
+
+    let pass_count = pass_count
+        .parse::<u32>()
+        .map_err(|_| "suite pass count is invalid")?;
+    let fail_count = fail_count
+        .parse::<u32>()
+        .map_err(|_| "suite fail count is invalid")?;
+    if pass_count == 0 {
+        return Err("suite executed zero passing assertions".into());
+    }
+    if fail_count != 0 {
+        return Err(format!("suite recorded {fail_count} failed assertions"));
+    }
+    if log.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("test assertion ") && line.contains(" - FAIL")
+    }) {
+        return Err("log contains a failed assertion".into());
+    }
+
+    let selected_groups: Vec<_> = test_groups
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .collect();
+    if selected_groups.contains(&"VERSION")
+        && !log.lines().any(|line| {
+            line.trim_start()
+                == "test assertion 1.1.5 - PASS response version_number_entry - 0x1400"
+        })
+    {
+        return Err("VERSION did not advertise a passing 0x1400 entry".into());
+    }
+
+    Ok(format!(
+        "SPDM validator suite {suite_name}: pass={pass_count}, fail={fail_count}; selected_groups={}",
+        if test_groups.is_empty() { "ALL" } else { test_groups }
+    ))
+}
+
+fn check_spdm_responder_validator_log() -> Result<String, String> {
+    let log_path = validator_dir()
+        .map_err(|error| format!("SPDM_VALIDATOR_DIR is unavailable: {error}"))?
+        .join("test.log");
+    let log = fs::read_to_string(&log_path)
+        .map_err(|error| format!("failed to read {}: {error}", log_path.display()))?;
+    let test_groups = std::env::var("SPDM_VALIDATOR_TEST_GROUPS").unwrap_or_default();
+    check_spdm_responder_validator_results(&log, &test_groups)
+}
+
+pub fn wait_for_spdm_responder_validator() -> bool {
+    while crate::is_emulator_running() && !SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire) {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire)
+}
+
 pub fn execute_spdm_responder_validator(transport: &'static str) {
+    SPDM_RESPONDER_VALIDATOR_DONE.store(false, Ordering::Release);
     crate::spawn_with_emulator_state(move || {
         println!(
             "Starting spdm_device_validator_sample process on transport: {}. Waiting for SPDM listener to start...",
@@ -345,6 +421,19 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                                 "spdm_device_validator_sample exited with status: {:?}",
                                 status
                             );
+                            if !status.success() {
+                                std::process::exit(1);
+                            }
+                            match check_spdm_responder_validator_log() {
+                                Ok(summary) => {
+                                    println!("{summary}");
+                                    SPDM_RESPONDER_VALIDATOR_DONE.store(true, Ordering::Release);
+                                }
+                                Err(error) => {
+                                    println!("SPDM validator result check failed: {error}");
+                                    std::process::exit(1);
+                                }
+                            }
                             break;
                         }
                         Ok(None) => {}
@@ -380,6 +469,12 @@ pub fn start_spdm_responder_validator(transport: &'static str) -> io::Result<Chi
                 .arg(transport)
                 .arg("--pcap")
                 .arg("caliptra_spdm_validator.pcap");
+            if let Ok(test_groups) = std::env::var("SPDM_VALIDATOR_TEST_GROUPS") {
+                if !test_groups.is_empty() {
+                    println!("Selecting SPDM validator test groups: {test_groups}");
+                    cmd.arg("--test-groups").arg(test_groups);
+                }
+            }
         },
     )
 }
@@ -499,6 +594,12 @@ where
 mod tests {
     use super::*;
 
+    const COMPLETE_LOG: &str = "\
+    test assertion 1.1.5 - PASS response version_number_entry - 0x1400
+test suite (spdm_responder_conformance_test) - pass: 1, fail: 0
+test result done
+";
+
     #[test]
     fn attestation_requester_excludes_endpoint_info() {
         let mut command = Command::new("spdm_requester_emu");
@@ -520,6 +621,41 @@ mod tests {
                 "--port",
                 "1025",
             ]
+        );
+    }
+
+    #[test]
+    fn accepts_complete_selected_group_results() {
+        let result = check_spdm_responder_validator_results(COMPLETE_LOG, "VERSION");
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn rejects_incomplete_results() {
+        let result = check_spdm_responder_validator_results(
+            COMPLETE_LOG.trim_end_matches("test result done\n"),
+            "",
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            "log does not end with a complete test result"
+        );
+    }
+
+    #[test]
+    fn rejects_failed_suite() {
+        let log = COMPLETE_LOG.replace("pass: 1, fail: 0", "pass: 1, fail: 1");
+        let result = check_spdm_responder_validator_results(&log, "");
+        assert_eq!(result.unwrap_err(), "suite recorded 1 failed assertions");
+    }
+
+    #[test]
+    fn rejects_missing_spdm_1_4_version() {
+        let log = COMPLETE_LOG.replace("0x1400", "0x1300");
+        let result = check_spdm_responder_validator_results(&log, "VERSION");
+        assert_eq!(
+            result.unwrap_err(),
+            "VERSION did not advertise a passing 0x1400 entry"
         );
     }
 }

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::spdm_responder_validator::transport::Transport;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -16,6 +16,7 @@ pub const SOCKET_SPDM_COMMAND_TEST: u32 = 0xDEAD;
 pub const SOCKET_HEADER_LEN: usize = 12;
 
 pub static SERVER_LISTENING: AtomicBool = AtomicBool::new(false);
+static SPDM_RESPONDER_VALIDATOR_DONE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
 pub struct SpdmSocketHeader {
@@ -312,7 +313,89 @@ pub fn execute_spdm_attestation(transport: &'static str) {
     });
 }
 
+fn check_spdm_responder_validator_results(log: &str, test_groups: &str) -> Result<String, String> {
+    if !log.trim_end().ends_with("test result done") {
+        return Err("log does not end with a complete test result".into());
+    }
+
+    let mut suite_summaries = log.lines().filter_map(|line| {
+        let summary = line.strip_prefix("test suite (")?;
+        let (suite_name, counts) = summary.split_once(") - pass: ")?;
+        let (pass_count, fail_count) = counts.split_once(", fail: ")?;
+        Some((suite_name, pass_count, fail_count))
+    });
+    let Some((suite_name, pass_count, fail_count)) = suite_summaries.next() else {
+        return Err("expected one suite summary, found none".into());
+    };
+    if suite_summaries.next().is_some() {
+        return Err("expected one suite summary, found multiple".into());
+    }
+
+    let pass_count = pass_count
+        .parse::<u32>()
+        .map_err(|_| "suite pass count is invalid")?;
+    let fail_count = fail_count
+        .parse::<u32>()
+        .map_err(|_| "suite fail count is invalid")?;
+    if pass_count == 0 {
+        return Err("suite executed zero passing assertions".into());
+    }
+    if fail_count != 0 {
+        return Err(format!("suite recorded {fail_count} failed assertions"));
+    }
+    if log.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("test assertion ") && line.contains(" - FAIL")
+    }) {
+        return Err("log contains a failed assertion".into());
+    }
+
+    let selected_groups: Vec<_> = test_groups
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .collect();
+    // CAPABILITIES is selected alongside VERSION so its existing cases run, but
+    // dedicated SPDM 1.4 capability assertions will be required separately as
+    // that validator coverage is added.
+    if selected_groups.contains(&"VERSION")
+        && !log.lines().any(|line| {
+            line.trim_start()
+                == "test assertion 1.1.5 - PASS response version_number_entry - 0x1400"
+        })
+    {
+        return Err("VERSION did not advertise a passing 0x1400 entry".into());
+    }
+
+    Ok(format!(
+        "SPDM validator suite {suite_name}: pass={pass_count}, fail={fail_count}; selected_groups={}",
+        if test_groups.is_empty() {
+            "ALL"
+        } else {
+            test_groups
+        }
+    ))
+}
+
+fn check_spdm_responder_validator_log() -> Result<String, String> {
+    let log_path = validator_dir()
+        .map_err(|error| format!("SPDM_VALIDATOR_DIR is unavailable: {error}"))?
+        .join("test.log");
+    let log = fs::read_to_string(&log_path)
+        .map_err(|error| format!("failed to read {}: {error}", log_path.display()))?;
+    let test_groups = std::env::var("SPDM_VALIDATOR_TEST_GROUPS").unwrap_or_default();
+    check_spdm_responder_validator_results(&log, &test_groups)
+}
+
+pub fn wait_for_spdm_responder_validator() -> bool {
+    while crate::is_emulator_running() && !SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire) {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire)
+}
+
 pub fn execute_spdm_responder_validator(transport: &'static str) {
+    SPDM_RESPONDER_VALIDATOR_DONE.store(false, Ordering::Release);
     crate::spawn_with_emulator_state(move || {
         println!(
             "Starting spdm_device_validator_sample process on transport: {}. Waiting for SPDM listener to start...",
@@ -331,6 +414,19 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                                 "spdm_device_validator_sample exited with status: {:?}",
                                 status
                             );
+                            if !status.success() {
+                                std::process::exit(1);
+                            }
+                            match check_spdm_responder_validator_log() {
+                                Ok(summary) => {
+                                    println!("{summary}");
+                                    SPDM_RESPONDER_VALIDATOR_DONE.store(true, Ordering::Release);
+                                }
+                                Err(error) => {
+                                    println!("SPDM validator result check failed: {error}");
+                                    std::process::exit(1);
+                                }
+                            }
                             break;
                         }
                         Ok(None) => {}
@@ -348,6 +444,7 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                     "Error: {:?} Failed to spawn spdm_device_validator_sample!!",
                     e
                 );
+                std::process::exit(1);
             }
         }
     });
@@ -366,6 +463,12 @@ pub fn start_spdm_responder_validator(transport: &'static str) -> io::Result<Chi
                 .arg(transport)
                 .arg("--pcap")
                 .arg("caliptra_spdm_validator.pcap");
+            if let Ok(test_groups) = std::env::var("SPDM_VALIDATOR_TEST_GROUPS") {
+                if !test_groups.is_empty() {
+                    println!("Selecting SPDM validator test groups: {test_groups}");
+                    cmd.arg("--test-groups").arg(test_groups);
+                }
+            }
         },
     )
 }
@@ -459,4 +562,50 @@ where
         .stderr(Stdio::from(output_file_clone))
         .current_dir(&dir_path)
         .spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_spdm_responder_validator_results;
+
+    const COMPLETE_LOG: &str = "\
+    test assertion 1.1.5 - PASS response version_number_entry - 0x1400
+test suite (spdm_responder_conformance_test) - pass: 1, fail: 0
+test result done
+";
+
+    #[test]
+    fn accepts_complete_selected_group_results() {
+        let result = check_spdm_responder_validator_results(COMPLETE_LOG, "VERSION,CAPABILITIES");
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn rejects_incomplete_results() {
+        let result = check_spdm_responder_validator_results(
+            COMPLETE_LOG.trim_end_matches("test result done\n"),
+            "",
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            "log does not end with a complete test result"
+        );
+    }
+
+    #[test]
+    fn rejects_failed_suite() {
+        let log = COMPLETE_LOG.replace("pass: 1, fail: 0", "pass: 1, fail: 1");
+        let result = check_spdm_responder_validator_results(&log, "");
+        assert_eq!(result.unwrap_err(), "suite recorded 1 failed assertions");
+    }
+
+    #[test]
+    fn rejects_missing_spdm_1_4_version() {
+        let log = COMPLETE_LOG.replace("0x1400", "0x1300");
+        let result = check_spdm_responder_validator_results(&log, "VERSION");
+        assert_eq!(
+            result.unwrap_err(),
+            "VERSION did not advertise a passing 0x1400 entry"
+        );
+    }
 }

--- a/common/testing/src/spdm_responder_validator/doe.rs
+++ b/common/testing/src/spdm_responder_validator/doe.rs
@@ -3,7 +3,7 @@
 use crate::doe_util::common::DoeUtil;
 use crate::spdm_responder_validator::common::{
     execute_spdm_attestation, execute_spdm_responder_validator, execute_spdm_tee_io_validator,
-    SpdmValidatorRunner, SERVER_LISTENING,
+    wait_for_spdm_responder_validator, SpdmValidatorRunner, SERVER_LISTENING,
 };
 use crate::spdm_responder_validator::transport::{Transport, SOCKET_TRANSPORT_TYPE_PCI_DOE};
 use crate::spdm_responder_validator::SpdmTestType;
@@ -113,6 +113,7 @@ pub fn run_doe_spdm_conformance_test(
     test_timeout_seconds: Duration,
 ) {
     let transport = DoeTransport::new(tx, rx, 1);
+    let check_responder_results = matches!(&test_type, SpdmTestType::SpdmResponderConformance);
     // Spawn a thread to handle the timeout for the test
     crate::spawn_with_emulator_state(move || {
         std::thread::sleep(test_timeout_seconds);
@@ -147,9 +148,12 @@ pub fn run_doe_spdm_conformance_test(
             if !test.is_passed() {
                 println!("[{}]: Spdm Responder Conformance Test Failed", TEST_NAME);
                 exit(-1);
-            } else {
+            } else if !check_responder_results || wait_for_spdm_responder_validator() {
                 println!("[{}]: Spdm Responder Conformance Test Passed", TEST_NAME);
                 exit(0);
+            } else {
+                println!("[{}]: Spdm Validator Result Check Failed", TEST_NAME);
+                exit(-1);
             }
         }
     });

--- a/common/testing/src/spdm_responder_validator/mod.rs
+++ b/common/testing/src/spdm_responder_validator/mod.rs
@@ -13,5 +13,5 @@ pub enum SpdmTestType {
 
 pub use common::{
     execute_spdm_attestation, execute_spdm_attestation_with_port, execute_spdm_responder_validator,
-    SpdmValidatorRunner, SERVER_LISTENING,
+    wait_for_spdm_responder_validator, SpdmValidatorRunner, SERVER_LISTENING,
 };

--- a/common/testing/src/spdm_responder_validator/mod.rs
+++ b/common/testing/src/spdm_responder_validator/mod.rs
@@ -12,6 +12,6 @@ pub enum SpdmTestType {
 }
 
 pub use common::{
-    execute_spdm_attestation, execute_spdm_responder_validator, SpdmValidatorRunner,
-    SERVER_LISTENING,
+    execute_spdm_attestation, execute_spdm_responder_validator, wait_for_spdm_responder_validator,
+    SpdmValidatorRunner, SERVER_LISTENING,
 };

--- a/runtime/userspace/api/spdm-lib/codec/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/version.rs
@@ -17,11 +17,12 @@ pub enum SpdmVersion {
     V11 = 0x11,
     V12 = 0x12,
     V13 = 0x13,
+    V14 = 0x14,
 }
 
 impl SpdmVersion {
     /// Highest spec version implemented by the spdm-lib stack.
-    pub const MAX: Self = SpdmVersion::V13;
+    pub const MAX: Self = SpdmVersion::V14;
 
     /// Encode as the DSP0274 single-byte representation.
     pub const fn to_u8(self) -> u8 {
@@ -36,6 +37,7 @@ impl SpdmVersion {
             0x11 => Some(SpdmVersion::V11),
             0x12 => Some(SpdmVersion::V12),
             0x13 => Some(SpdmVersion::V13),
+            0x14 => Some(SpdmVersion::V14),
             _ => None,
         }
     }
@@ -48,6 +50,7 @@ impl SpdmVersion {
             SpdmVersion::V11 => "1.1",
             SpdmVersion::V12 => "1.2",
             SpdmVersion::V13 => "1.3",
+            SpdmVersion::V14 => "1.4",
         }
     }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -168,6 +168,7 @@ const SIGNING_CTX_V10: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"
 const SIGNING_CTX_V11: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.1.*");
 const SIGNING_CTX_V12: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.2.*");
 const SIGNING_CTX_V13: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.3.*");
+const SIGNING_CTX_V14: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.4.*");
 
 /// Build the SPDM signing context for CHALLENGE_AUTH.
 const fn build_signing_context(ver: &[u8; 5]) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
@@ -211,6 +212,7 @@ fn signing_context(version: SpdmVersion) -> &'static [u8; SPDM_SIGNING_CONTEXT_L
         SpdmVersion::V11 => &SIGNING_CTX_V11,
         SpdmVersion::V12 => &SIGNING_CTX_V12,
         SpdmVersion::V13 => &SIGNING_CTX_V13,
+        SpdmVersion::V14 => &SIGNING_CTX_V14,
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -46,6 +46,8 @@ const KEY_EXCHANGE_SIGNING_PREFIX_V12: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_L
     b"dmtf-spdm-v1.2.*";
 const KEY_EXCHANGE_SIGNING_PREFIX_V13: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_LEN] =
     b"dmtf-spdm-v1.3.*";
+const KEY_EXCHANGE_SIGNING_PREFIX_V14: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_LEN] =
+    b"dmtf-spdm-v1.4.*";
 const KEY_EXCHANGE_SIGNING_OP: &[u8; 34] = b"responder-key_exchange_rsp signing";
 
 pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
@@ -369,6 +371,7 @@ fn build_signing_context(version: SpdmVersion, ctx: &mut [u8; SPDM_SIGNING_CONTE
         SpdmVersion::V11 => KEY_EXCHANGE_SIGNING_PREFIX_V11,
         SpdmVersion::V12 => KEY_EXCHANGE_SIGNING_PREFIX_V12,
         SpdmVersion::V13 => KEY_EXCHANGE_SIGNING_PREFIX_V13,
+        SpdmVersion::V14 => KEY_EXCHANGE_SIGNING_PREFIX_V14,
     };
     let mut pos = 0;
     for _ in 0..4 {

--- a/runtime/userspace/api/spdm-lib/stack/src/key_schedule.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_schedule.rs
@@ -48,6 +48,7 @@ pub fn spdm_version_str(version: SpdmVersion) -> &'static [u8] {
         SpdmVersion::V11 => b"spdm1.1 ",
         SpdmVersion::V12 => b"spdm1.2 ",
         SpdmVersion::V13 => b"spdm1.3 ",
+        SpdmVersion::V14 => b"spdm1.4 ",
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -518,6 +518,7 @@ const SIGNING_CTX_V10: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_co
 const SIGNING_CTX_V11: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.1.*");
 const SIGNING_CTX_V12: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.2.*");
 const SIGNING_CTX_V13: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.3.*");
+const SIGNING_CTX_V14: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.4.*");
 
 const fn build_signing_context_const(ver: &[u8; 5]) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
     let mut ctx = [0u8; SPDM_SIGNING_CONTEXT_LEN];
@@ -556,6 +557,7 @@ fn signing_context(version: SpdmVersion) -> &'static [u8; SPDM_SIGNING_CONTEXT_L
         SpdmVersion::V11 => &SIGNING_CTX_V11,
         SpdmVersion::V12 => &SIGNING_CTX_V12,
         SpdmVersion::V13 => &SIGNING_CTX_V13,
+        SpdmVersion::V14 => &SIGNING_CTX_V14,
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -576,6 +576,11 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
     code: ReqRespCode,
     vdm: &Vdm,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
+    // GET_VERSION resets the connection, but malformed requests must not alter
+    // existing connection, session, or large-message state.
+    if code == ReqRespCode::GET_VERSION {
+        version::validate_get_version(io.request())?;
+    }
     abort_chunk_reassembly_if_interrupted(state, pal, io, vdm, code).await;
     if code != ReqRespCode::CHUNK_GET
         && code != ReqRespCode::CHUNK_SEND
@@ -1104,3 +1109,7 @@ fn decode_header(req: &[u8]) -> (ReqRespCode, SpdmVersion) {
 #[cfg(all(test, feature = "set-certificate"))]
 #[path = "tests/stack_set_certificate.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "tests/version.rs"]
+mod version_tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
@@ -1,0 +1,110 @@
+// Licensed under the Apache-2.0 license
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmVersion};
+use caliptra_mcu_spdm_traits::{NoVdmBackend, SpdmPalAlloc};
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+
+#[path = "support.rs"]
+mod support;
+use support::{TestHashState, TestIo, TestPal};
+
+fn get_version_request(version: u8, param1: u8, param2: u8) -> Vec<u8> {
+    vec![version, ReqRespCode::GET_VERSION.0, param1, param2]
+}
+
+fn dispatch_request(
+    state: &mut ConnectionState<TestHashState, Vec<u8>>,
+    sessions: &mut Sessions<TestPal, 1>,
+    pal: &TestPal,
+    request: Vec<u8>,
+) -> SpdmResult<Vec<u8>> {
+    let io = TestIo::message(request);
+    block_on(dispatch(
+        state,
+        sessions,
+        pal,
+        &io,
+        ReqRespCode::GET_VERSION,
+        &NoVdmBackend,
+    ))
+}
+
+#[test]
+fn get_version_advertises_v14_and_resets_valid_connection() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterAlgorithms;
+    state.version = SpdmVersion::V13;
+    state.peer_cap_flags = CapFlags::CHUNK;
+    let mut sessions = SessionManager::new();
+    let session_id = sessions
+        .create_session(0x1234, SpdmVersion::V13, |info| pal.alloc_persistent(info))
+        .unwrap();
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        get_version_request(SpdmVersion::V10.to_u8(), 0, 0),
+    )
+    .unwrap();
+
+    assert_eq!(
+        rsp,
+        [
+            SpdmVersion::V10.to_u8(),
+            ReqRespCode::VERSION.0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            SpdmVersion::V14.to_u8(),
+            0,
+            SpdmVersion::V13.to_u8(),
+            0,
+            SpdmVersion::V12.to_u8(),
+        ]
+    );
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::EMPTY.into_bits()
+    );
+    assert!(sessions.find(session_id).is_none());
+}
+
+#[test]
+fn invalid_get_version_preserves_connection_and_sessions() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterAlgorithms;
+    state.version = SpdmVersion::V13;
+    state.peer_cap_flags = CapFlags::CHUNK;
+    let mut sessions = SessionManager::new();
+    let session_id = sessions
+        .create_session(0x1234, SpdmVersion::V13, |info| pal.alloc_persistent(info))
+        .unwrap();
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        get_version_request(SpdmVersion::V10.to_u8(), 1, 0),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterAlgorithms);
+    assert_eq!(state.version, SpdmVersion::V13);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::CHUNK.into_bits()
+    );
+    assert!(sessions.find(session_id).is_some());
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/version.rs
@@ -20,7 +20,23 @@ use crate::stack::{ConnectionState, Phase};
 ///
 /// V1.2 is the floor because our CAPABILITIES / ALGORITHMS request
 /// bodies only support the V1.2+ wire shape.
-pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V13, SpdmVersion::V12];
+pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] =
+    &[SpdmVersion::V14, SpdmVersion::V13, SpdmVersion::V12];
+
+/// Validate a GET_VERSION request without mutating connection or session state.
+///
+/// The dispatcher uses this before applying the protocol-mandated connection
+/// reset so malformed GET_VERSION requests leave existing state untouched.
+pub(crate) fn validate_get_version(req: &[u8]) -> SpdmResult<()> {
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != SpdmVersion::V10.to_u8() {
+        return Err(SPDM_VERSION_MISMATCH);
+    }
+    if rest.len() < 2 || rest[0] != 0 || rest[1] != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
+}
 
 /// Handles a `GET_VERSION` request and produces the matching `VERSION` response.
 ///
@@ -57,16 +73,9 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &Pal::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    // DSP0274 §10.2 Table 8: GET_VERSION header version shall be 0x10.
-    let req = io.request();
-    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
-    if hdr.version != SpdmVersion::V10.to_u8() {
-        return Err(SPDM_VERSION_MISMATCH);
-    }
-    // Table 8: Param1, Param2 are Reserved.
-    if rest.len() < 2 || rest[0] != 0 || rest[1] != 0 {
-        return Err(SPDM_INVALID_REQUEST);
-    }
+    // Keep the handler safe for direct callers; dispatch validates before
+    // resetting connection/session state so invalid requests cannot reset it.
+    validate_get_version(io.request())?;
 
     let body = VersionRsp {
         versions: SUPPORTED_VERSIONS,

--- a/tests/integration/src/test_mctp_spdm_responder_conformance.rs
+++ b/tests/integration/src/test_mctp_spdm_responder_conformance.rs
@@ -13,7 +13,8 @@ mod test {
     use caliptra_mcu_testing_common::i3c_socket::BufferedStream;
     use caliptra_mcu_testing_common::spdm_responder_validator::mctp::MctpTransport;
     use caliptra_mcu_testing_common::spdm_responder_validator::{
-        execute_spdm_responder_validator, SpdmValidatorRunner, SERVER_LISTENING,
+        execute_spdm_responder_validator, wait_for_spdm_responder_validator, SpdmValidatorRunner,
+        SERVER_LISTENING,
     };
     use caliptra_mcu_testing_common::wait_for_runtime_start;
     use random_port::PortPicker;
@@ -102,9 +103,12 @@ mod test {
                 if !test.is_passed() {
                     println!("[{}]: Spdm Responder Conformance Test Failed", TEST_NAME);
                     exit(-1);
-                } else {
+                } else if wait_for_spdm_responder_validator() {
                     println!("[{}]: Spdm Responder Conformance Test Passed", TEST_NAME);
                     exit(0);
+                } else {
+                    println!("[{}]: Spdm Validator Result Check Failed", TEST_NAME);
+                    exit(-1);
                 }
             }
         });


### PR DESCRIPTION
SPDM 1.4 development needs a quick way to run the relevant responder-validator command groups while still retaining the complete validator suite.

Add workflow inputs for the spdm-emu revision and selected validator groups, pass the selection to both MCTP and DOE, and validate the authoritative `test.log` in the Rust test harness. A targeted VERSION run requires a passing SPDM 1.4 `0x1400` entry. The default remains the complete suite.

Dependencies:
- #1857 provides SPDM 1.4 VERSION support.
- chipsalliance/caliptra-spdm-emu#2 provides `--test-groups` and SPDM 1.4 CAPABILITIES cases.
- chipsalliance/caliptra-SPDM-Responder-Validator#6 provides the validator coverage.

Pre-rebase end-to-end validation of the same SPDM changes at MCU stack tip `8c1b500e`, spdm-emu `59993917`, and responder-validator `03a5888b`:

| transport | selection | process | pass | fail | VERSION `0x1400` |
|---|---|---:|---:|---:|---|
| MCTP | VERSION,CAPABILITIES | 0 | 100 | 0 | PASS |
| DOE | VERSION,CAPABILITIES | 0 | 109 | 0 | PASS |

The emulator also rejects duplicate and unknown `--test-groups` selections with a nonzero exit status.

Pre-rebase memory at the validated stack tip:
- Kernel: text 152,684 B; data 36 B; BSS 24,536 B
- User app: flash 297,780 B; RAM 79,632 B
- SPDM-attributed: flash 105,010 B; RAM 31,297 B
- Runtime bundle: 453,632 B

Refs #1785
Refs #1787



