### PR TITLE
[xtask] Support signing request generation and signature reattachment

### DIFF
--- a/builder/src/offline_signing.rs
+++ b/builder/src/offline_signing.rs
@@ -1,13 +1,15 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, Context, Result};
-use caliptra_auth_man_types::AuthManifestPreamble;
-use caliptra_image_gen::to_hw_format;
-use caliptra_image_types::{ImageEccSignature, ImagePqcSignature};
-use p384::ecdsa::Signature;
+use caliptra_auth_man_types::{AuthManifestPreamble, AuthorizationManifest};
+use caliptra_image_crypto::RustCrypto as Crypto;
+use caliptra_image_gen::{from_hw_format, to_hw_format, ImageGeneratorCrypto};
+use caliptra_image_types::{ImageEccPubKey, ImageEccSignature, ImagePqcSignature};
+use p384::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
-use zerocopy::IntoBytes;
+use std::path::Path;
+use zerocopy::{FromBytes, IntoBytes};
 
 /// Request payload containing signature targets to be signed offline.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -191,9 +193,192 @@ impl ImagePqcSignatureExt for ImagePqcSignature {
                 non_zero_len
             ));
         }
-        // TODO(timothytrippel): cryptographically verify the PQ signatures.
+        // TODO(timothytrippel): Cryptographically verify PQC signatures (LMS / ML-DSA-87).
         Ok(())
     }
+}
+/// Perform cryptographic verification of an ECDSA P-384 signature over a 48-byte digest against an `ImageEccPubKey`.
+pub fn verify_ecdsa384_signature(
+    digest: &[u8; 48],
+    pub_key: &ImageEccPubKey,
+    sig: &ImageEccSignature,
+) -> Result<()> {
+    let x_bytes: [u8; 48] = from_hw_format(&pub_key.x);
+    let y_bytes: [u8; 48] = from_hw_format(&pub_key.y);
+
+    let mut encoded_point = [0u8; 97];
+    encoded_point[0] = 0x04;
+    encoded_point[1..49].copy_from_slice(&x_bytes);
+    encoded_point[49..97].copy_from_slice(&y_bytes);
+
+    let verifying_key = VerifyingKey::from_sec1_bytes(&encoded_point)
+        .map_err(|e| anyhow!("Failed to parse public key for verification: {}", e))?;
+
+    let r_bytes: [u8; 48] = from_hw_format(&sig.r);
+    let s_bytes: [u8; 48] = from_hw_format(&sig.s);
+
+    let mut sig_bytes = [0u8; 96];
+    sig_bytes[..48].copy_from_slice(&r_bytes);
+    sig_bytes[48..].copy_from_slice(&s_bytes);
+
+    let signature = Signature::from_slice(&sig_bytes)
+        .map_err(|e| anyhow!("Failed to parse signature bytes for verification: {}", e))?;
+
+    verifying_key
+        .verify_prehash(digest, &signature)
+        .map_err(|e| anyhow!("ECDSA P-384 signature verification failed: {}", e))
+}
+
+/// Attach signatures from a `SignaturesJson` file to an unsigned authorization manifest binary, verify all signatures, and save the resulting `signed_auth_manifest.bin`.
+pub fn attach_auth_manifest_signatures(
+    unsigned_manifest_path: &Path,
+    signatures_path: &Path,
+    vendor_fw_pub_key_path: Option<&Path>,
+    owner_fw_pub_key_path: Option<&Path>,
+    output_path: &Path,
+) -> Result<()> {
+    let manifest_bytes = std::fs::read(unsigned_manifest_path).with_context(|| {
+        format!(
+            "Failed to read unsigned manifest file {}",
+            unsigned_manifest_path.display()
+        )
+    })?;
+
+    let mut manifest = AuthorizationManifest::read_from_bytes(&manifest_bytes)
+        .map_err(|e| anyhow!("Failed to parse unsigned manifest: {:?}", e))?;
+
+    let sig_file_content = std::fs::read_to_string(signatures_path).with_context(|| {
+        format!(
+            "Failed to read signatures file {}",
+            signatures_path.display()
+        )
+    })?;
+
+    let sigs_json: SignaturesJson = serde_json::from_str(&sig_file_content).with_context(|| {
+        format!(
+            "Failed to parse signatures JSON file {}",
+            signatures_path.display()
+        )
+    })?;
+
+    // Vendor Pub Keys Signatures (signed by Vendor FW Root key over Vendor Manifest Public Keys)
+    if let Some(entry) = &sigs_json.vendor_pub_keys_signatures {
+        if let Some(ecc_hex) = &entry.ecc_sig {
+            manifest.preamble.vendor_pub_keys_signatures.ecc_sig =
+                ImageEccSignature::try_from_hex(ecc_hex)?;
+        }
+        if let Some(pqc_hex) = &entry.pqc_sig {
+            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+            pqc_sig
+                .verify()
+                .context("Vendor public keys PQC signature verification failed")?;
+            manifest.preamble.vendor_pub_keys_signatures.pqc_sig = pqc_sig;
+        }
+
+        if let Some(vendor_fw_pub_path) = vendor_fw_pub_key_path {
+            let vendor_fw_pub = Crypto::ecc_pub_key_from_pem(vendor_fw_pub_path)?;
+            let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+            let vendor_data = manifest
+                .preamble
+                .as_bytes()
+                .get(vendor_range.start as usize..vendor_range.end as usize)
+                .ok_or_else(|| anyhow!("Invalid vendor signed data range"))?;
+            let digest: [u8; 48] = sha2::Sha384::digest(vendor_data).into();
+            verify_ecdsa384_signature(
+                &digest,
+                &vendor_fw_pub,
+                &manifest.preamble.vendor_pub_keys_signatures.ecc_sig,
+            )
+            .context(
+                "Vendor public keys signature verification failed against provided vendor FW key",
+            )?;
+        }
+    }
+
+    // Owner Pub Keys Signatures (signed by Owner FW Root key over Owner Manifest Public Keys)
+    if let Some(entry) = &sigs_json.owner_pub_keys_signatures {
+        if let Some(ecc_hex) = &entry.ecc_sig {
+            manifest.preamble.owner_pub_keys_signatures.ecc_sig =
+                ImageEccSignature::try_from_hex(ecc_hex)?;
+        }
+        if let Some(pqc_hex) = &entry.pqc_sig {
+            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+            pqc_sig
+                .verify()
+                .context("Owner public keys PQC signature verification failed")?;
+            manifest.preamble.owner_pub_keys_signatures.pqc_sig = pqc_sig;
+        }
+
+        if let Some(owner_fw_pub_path) = owner_fw_pub_key_path {
+            let owner_fw_pub = Crypto::ecc_pub_key_from_pem(owner_fw_pub_path)?;
+            let owner_data = manifest.preamble.owner_pub_keys.as_bytes();
+            let digest: [u8; 48] = sha2::Sha384::digest(owner_data).into();
+            verify_ecdsa384_signature(
+                &digest,
+                &owner_fw_pub,
+                &manifest.preamble.owner_pub_keys_signatures.ecc_sig,
+            )
+            .context(
+                "Owner public keys signature verification failed against provided owner FW key",
+            )?;
+        }
+    }
+
+    // IMC Digest for Manifest key verification
+    let imc_data = manifest.image_metadata_col.as_bytes();
+    let imc_digest: [u8; 48] = sha2::Sha384::digest(imc_data).into();
+
+    // Vendor IMC Signatures (signed by Vendor Manifest key; verified against embedded
+    // Vendor Manifest Public Key: `preamble.vendor_pub_keys`)
+    if let Some(entry) = &sigs_json.vendor_imc_signatures {
+        if let Some(ecc_hex) = &entry.ecc_sig {
+            manifest.preamble.vendor_image_metdata_signatures.ecc_sig =
+                ImageEccSignature::try_from_hex(ecc_hex)?;
+        }
+        if let Some(pqc_hex) = &entry.pqc_sig {
+            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+            pqc_sig
+                .verify()
+                .context("Vendor IMC PQC signature verification failed")?;
+            manifest.preamble.vendor_image_metdata_signatures.pqc_sig = pqc_sig;
+        }
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.vendor_pub_keys.ecc_pub_key,
+            &manifest.preamble.vendor_image_metdata_signatures.ecc_sig,
+        )
+        .context("Vendor IMC signature verification failed against embedded vendor manifest key")?;
+    }
+
+    // Owner IMC Signatures (signed by Owner Manifest key; verified against embedded
+    // Owner Manifest Public Key: `preamble.owner_pub_keys`)
+    if let Some(entry) = &sigs_json.owner_imc_signatures {
+        if let Some(ecc_hex) = &entry.ecc_sig {
+            manifest.preamble.owner_image_metdata_signatures.ecc_sig =
+                ImageEccSignature::try_from_hex(ecc_hex)?;
+        }
+        if let Some(pqc_hex) = &entry.pqc_sig {
+            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+            pqc_sig
+                .verify()
+                .context("Owner IMC PQC signature verification failed")?;
+            manifest.preamble.owner_image_metdata_signatures.pqc_sig = pqc_sig;
+        }
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.owner_pub_keys.ecc_pub_key,
+            &manifest.preamble.owner_image_metdata_signatures.ecc_sig,
+        )
+        .context("Owner IMC signature verification failed against embedded owner manifest key")?;
+    }
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output_path, manifest.as_bytes())?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/auth_manifest.rs
+++ b/xtask/src/auth_manifest.rs
@@ -5,6 +5,7 @@ use caliptra_auth_man_types::AuthorizationManifest;
 use caliptra_mcu_builder::{CaliptraBuilder, ImageCfg};
 use clap::{Args, Subcommand};
 use hex::ToHex;
+use std::path::{Path, PathBuf};
 use zerocopy::FromBytes;
 
 /// Paths to public key files used for authorization manifest creation and signing.
@@ -63,6 +64,32 @@ pub enum AuthManifestCommands {
         #[arg(long = "svn", value_name = "SVN")]
         svn: Option<u32>,
     },
+    /// Attach signatures to an unsigned auth manifest file and verify all signatures
+    AttachSignatures {
+        /// Path to the unsigned auth manifest binary
+        #[arg(
+            long = "unsigned-manifest",
+            value_name = "UNSIGNED_MANIFEST",
+            required = true
+        )]
+        unsigned_manifest: String,
+
+        /// Path to the JSON file containing signatures
+        #[arg(long = "signatures", value_name = "SIGNATURES", required = true)]
+        signatures: String,
+
+        /// Optional path to Vendor FW Public Key PEM file for signature verification
+        #[arg(long = "vendor-fw-pub-key", value_name = "VENDOR_FW_PUB_KEY")]
+        vendor_fw_pub_key: Option<String>,
+
+        /// Optional path to Owner FW Public Key PEM file for signature verification
+        #[arg(long = "owner-fw-pub-key", value_name = "OWNER_FW_PUB_KEY")]
+        owner_fw_pub_key: Option<String>,
+
+        /// Output file path for the signed manifest binary
+        #[arg(long, value_name = "OUTPUT", required = true)]
+        output: String,
+    },
     /// Parse and display contents of an existing SoC manifest file
     Parse {
         /// Path to the SoC manifest file to parse
@@ -80,8 +107,6 @@ pub fn create(
     key_paths: &AuthManifestKeyPaths,
     svn: Option<u32>,
 ) -> Result<()> {
-    use std::path::PathBuf;
-
     let mut builder = CaliptraBuilder::new(&caliptra_mcu_builder::CaliptraBuildArgs {
         mcu_firmware: Some(mcu_image.clone().path),
         soc_images: Some(soc_images.to_vec()),
@@ -116,6 +141,32 @@ pub fn create(
         std::fs::copy(&path, output)?;
         println!("Auth Manifest created at: {}", output);
     }
+    Ok(())
+}
+
+/// Attaches offline signatures to an unsigned authorization manifest binary and writes the signed binary.
+pub fn attach_signatures(
+    unsigned_manifest: &str,
+    signatures: &str,
+    vendor_fw_pub_key: Option<&str>,
+    owner_fw_pub_key: Option<&str>,
+    output: &str,
+) -> Result<()> {
+    let unsigned_path = Path::new(unsigned_manifest);
+    let sigs_path = Path::new(signatures);
+    let vendor_pub_path = vendor_fw_pub_key.map(Path::new);
+    let owner_pub_path = owner_fw_pub_key.map(Path::new);
+    let out_path = Path::new(output);
+
+    caliptra_mcu_builder::attach_auth_manifest_signatures(
+        unsigned_path,
+        sigs_path,
+        vendor_pub_path,
+        owner_pub_path,
+        out_path,
+    )?;
+
+    println!("Signed Auth Manifest written to: {}", output);
     Ok(())
 }
 
@@ -217,6 +268,42 @@ mod tests {
                 assert_eq!(svn, Some(5));
             }
             _ => panic!("Expected AuthManifestCommands::Create"),
+        }
+    }
+
+    #[test]
+    fn test_auth_manifest_attach_signatures_cli_parse() {
+        let args = vec![
+            "test",
+            "attach-signatures",
+            "--unsigned-manifest",
+            "unsigned.bin",
+            "--signatures",
+            "sigs.json",
+            "--vendor-fw-pub-key",
+            "vendor_fw.pem",
+            "--owner-fw-pub-key",
+            "owner_fw.pem",
+            "--output",
+            "signed.bin",
+        ];
+
+        let cli = Cli::parse_from(args);
+        match cli.cmd {
+            AuthManifestCommands::AttachSignatures {
+                unsigned_manifest,
+                signatures,
+                vendor_fw_pub_key,
+                owner_fw_pub_key,
+                output,
+            } => {
+                assert_eq!(unsigned_manifest, "unsigned.bin");
+                assert_eq!(signatures, "sigs.json");
+                assert_eq!(vendor_fw_pub_key, Some("vendor_fw.pem".to_string()));
+                assert_eq!(owner_fw_pub_key, Some("owner_fw.pem".to_string()));
+                assert_eq!(output, "signed.bin");
+            }
+            _ => panic!("Expected AuthManifestCommands::AttachSignatures"),
         }
     }
 }

--- a/xtask/src/auth_manifest.rs
+++ b/xtask/src/auth_manifest.rs
@@ -3,13 +3,35 @@
 use anyhow::Result;
 use caliptra_auth_man_types::AuthorizationManifest;
 use caliptra_mcu_builder::{CaliptraBuilder, ImageCfg};
-use clap::Subcommand;
+use clap::{Args, Subcommand};
 use hex::ToHex;
 use zerocopy::FromBytes;
 
+/// Paths to public key files used for authorization manifest creation and signing.
+#[derive(Args, Clone, Debug, Default)]
+pub struct AuthManifestKeyPaths {
+    /// Path to Vendor FW Public Key PEM file
+    #[arg(long = "vendor-fw-pub-key", value_name = "VENDOR_FW_PUB_KEY")]
+    pub vendor_fw_pub_key: Option<String>,
+
+    /// Path to Owner FW Public Key PEM file
+    #[arg(long = "owner-fw-pub-key", value_name = "OWNER_FW_PUB_KEY")]
+    pub owner_fw_pub_key: Option<String>,
+
+    /// Path to Vendor Manifest Public Key PEM file
+    #[arg(long = "vendor-man-pub-key", value_name = "VENDOR_MAN_PUB_KEY")]
+    pub vendor_man_pub_key: Option<String>,
+
+    /// Path to Owner Manifest Public Key PEM file
+    #[arg(long = "owner-man-pub-key", value_name = "OWNER_MAN_PUB_KEY")]
+    pub owner_man_pub_key: Option<String>,
+}
+
+/// Subcommands for creating and inspecting authorization manifests.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum AuthManifestCommands {
-    /// Create a Authentication Manifest
+    /// Create an Authentication Manifest
     Create {
         /// List of soc images with format: <path>,<load_addr>,<staging_addr>,<image_id>,<exec_bit>,<component_id>,<feature>
         /// Example: --soc_image image1.bin,0x80000000,0x60000000,2,2
@@ -29,6 +51,17 @@ pub enum AuthManifestCommands {
         /// Output file path
         #[arg(long, value_name = "OUTPUT", required = true)]
         output: String,
+
+        /// Path to export signing request JSON for offline signing
+        #[arg(long = "signing-request", value_name = "SIGNING_REQUEST")]
+        signing_request: Option<String>,
+
+        #[command(flatten)]
+        key_paths: AuthManifestKeyPaths,
+
+        /// Auth Manifest SVN value
+        #[arg(long = "svn", value_name = "SVN")]
+        svn: Option<u32>,
     },
     /// Parse and display contents of an existing SoC manifest file
     Parse {
@@ -38,19 +71,55 @@ pub enum AuthManifestCommands {
     },
 }
 
-pub fn create(soc_images: &[ImageCfg], mcu_image: &ImageCfg, output: &str) -> Result<()> {
+/// Creates a signed or unsigned authorization manifest from SoC and MCU image configurations.
+pub fn create(
+    soc_images: &[ImageCfg],
+    mcu_image: &ImageCfg,
+    output: &str,
+    signing_request_path: Option<&str>,
+    key_paths: &AuthManifestKeyPaths,
+    svn: Option<u32>,
+) -> Result<()> {
+    use std::path::PathBuf;
+
     let mut builder = CaliptraBuilder::new(&caliptra_mcu_builder::CaliptraBuildArgs {
         mcu_firmware: Some(mcu_image.clone().path),
         soc_images: Some(soc_images.to_vec()),
         mcu_image_cfg: Some(mcu_image.clone()),
+        soc_manifest_svn: svn,
         ..Default::default()
     });
-    let path = builder.get_soc_manifest(None)?;
-    std::fs::copy(&path, output)?;
-    println!("Auth Manifest created at: {}", output);
+
+    if let Some(req_path) = signing_request_path {
+        let vendor_fw_path = key_paths.vendor_fw_pub_key.as_ref().map(PathBuf::from);
+        let owner_fw_path = key_paths.owner_fw_pub_key.as_ref().map(PathBuf::from);
+        let vendor_man_path = key_paths.vendor_man_pub_key.as_ref().map(PathBuf::from);
+        let owner_man_path = key_paths.owner_man_pub_key.as_ref().map(PathBuf::from);
+
+        let builder_key_paths = caliptra_mcu_builder::AuthManifestPubKeysPaths {
+            vendor_fw_ecc_pub_key: vendor_fw_path.as_deref(),
+            owner_fw_ecc_pub_key: owner_fw_path.as_deref(),
+            vendor_man_ecc_pub_key: vendor_man_path.as_deref(),
+            owner_man_ecc_pub_key: owner_man_path.as_deref(),
+            ..Default::default()
+        };
+
+        let (path, request) =
+            builder.get_unsigned_auth_manifest(Some(output), Some(&builder_key_paths))?;
+
+        let json_data = serde_json::to_string_pretty(&request)?;
+        std::fs::write(req_path, json_data)?;
+        println!("Unsigned Auth Manifest created at: {}", path.display());
+        println!("Signing Request JSON exported to: {}", req_path);
+    } else {
+        let path = builder.get_soc_manifest(None)?;
+        std::fs::copy(&path, output)?;
+        println!("Auth Manifest created at: {}", output);
+    }
     Ok(())
 }
 
+/// Parses and prints the preamble and image metadata of an existing SoC manifest file.
 pub fn parse(file: &str) -> Result<()> {
     let data = std::fs::read(file)?;
 
@@ -98,4 +167,56 @@ pub fn parse(file: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(clap::Parser)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: AuthManifestCommands,
+    }
+
+    #[test]
+    fn test_auth_manifest_create_cli_parse() {
+        let args = vec![
+            "test",
+            "create",
+            "--mcu_image",
+            "runtime.bin,0xA8000000,0x60000000,1,2,0,feature",
+            "--soc_image",
+            "soc.bin,0x80000000,0x60000000,2,2,0,feature",
+            "--output",
+            "out.bin",
+            "--signing-request",
+            "req.json",
+            "--vendor-man-pub-key",
+            "vendor.pem",
+            "--owner-man-pub-key",
+            "owner.pem",
+            "--svn",
+            "5",
+        ];
+
+        let cli = Cli::parse_from(args);
+        match cli.cmd {
+            AuthManifestCommands::Create {
+                output,
+                signing_request,
+                key_paths,
+                svn,
+                ..
+            } => {
+                assert_eq!(output, "out.bin");
+                assert_eq!(signing_request, Some("req.json".to_string()));
+                assert_eq!(key_paths.vendor_man_pub_key, Some("vendor.pem".to_string()));
+                assert_eq!(key_paths.owner_man_pub_key, Some("owner.pem".to_string()));
+                assert_eq!(svn, Some(5));
+            }
+            _ => panic!("Expected AuthManifestCommands::Create"),
+        }
+    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -781,6 +781,19 @@ fn main() {
                 key_paths,
                 *svn,
             ),
+            AuthManifestCommands::AttachSignatures {
+                unsigned_manifest,
+                signatures,
+                vendor_fw_pub_key,
+                owner_fw_pub_key,
+                output,
+            } => auth_manifest::attach_signatures(
+                unsigned_manifest,
+                signatures,
+                vendor_fw_pub_key.as_deref(),
+                owner_fw_pub_key.as_deref(),
+                output,
+            ),
             AuthManifestCommands::Parse { file } => auth_manifest::parse(file),
         },
         Commands::Corim { subcommand } => match subcommand {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -770,7 +770,17 @@ fn main() {
                 images,
                 mcu_image,
                 output,
-            } => auth_manifest::create(images, mcu_image, output),
+                signing_request,
+                key_paths,
+                svn,
+            } => auth_manifest::create(
+                images,
+                mcu_image,
+                output,
+                signing_request.as_deref(),
+                key_paths,
+                *svn,
+            ),
             AuthManifestCommands::Parse { file } => auth_manifest::parse(file),
         },
         Commands::Corim { subcommand } => match subcommand {


### PR DESCRIPTION
This PR adds cargo xtask tooling to support the offline authorization manifest signing workflow described in #1833 . It allows developers to generate unsigned authorization manifest templates alongside structured signing requests, and reattach/verify externally computed signatures.

  ## Commits in this PR

  ### 1. [xtask] Support --signing-request and manifest key flags in auth-manifest create (offline-signing)

  • Adds AuthManifestKeyPaths to group public key file arguments (--vendor-fw-pub-key, --owner-fw-pub-key, --vendor-man-pub-key, --owner-man-pub-key).
  • Adds --signing-request <PATH> and --svn <SVN> flags to cargo xtask auth-manifest create.
  • Connects xtask to CaliptraBuilder::get_unsigned_auth_manifest() to emit:
      1. An unsigned authorization manifest binary template (unsigned_auth_manifest.bin).
      2. A formatted signing_request.json file containing the digests and payloads to be signed offline.
  • Adds CLI argument parsing unit tests.

  ### 2. [xtask] Add attach-signatures subcommand for auth manifest re-signing (offline-signing)

  • Adds cargo xtask auth-manifest attach-signatures subcommand.
  • Implements caliptra_mcu_builder::attach_auth_manifest_signatures():
      • Parses signatures.json and populates the AuthManifestPreamble signature fields.
      • Performs pre-flight cryptographic verification of ECDSA P-384 signatures against embedded Manifest Public Keys and provided Root FW Public Keys (verify_ecdsa384_signature).
      • Performs structural and size validation of PQC signatures (with TODO for future full cryptographic verification).
      • Writes the final signed authorization manifest binary (signed_auth_manifest.bin).
  • Adds CLI parsing unit tests for attach-signatures.