### PR TITLE
Run rom and romtime crates from MCU SRAM.

### DIFF
--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -31,9 +31,12 @@ pub fn rom_build(args: &CaliptraBuildArgs) -> Result<PathBuf> {
     };
     let rom_size = rom_size_for_platform(platform.unwrap_or("emulator"));
     let rom_binary = common.release_dir().map(|t| t.join(format!("{rom}.bin")))?;
+    let rom_from_ram = features
+        .map(|f| f.split(',').any(|x| x == "rom-from-ram"))
+        .unwrap_or(false);
     let build_cmd = Commands::Build {
         common,
-        ld: LdArgs::default(),
+        ld: rom_ld_args(platform.unwrap_or("emulator"), &target_name, rom_from_ram),
         build: BuildArgs {
             rom_features: features.filter(|s| !s.is_empty()).map(|s| s.to_string()),
             no_default_features: true,
@@ -86,6 +89,18 @@ pub fn rom_size_for_platform(platform: &str) -> usize {
     }
 }
 
+/// Selects the rom-from-ram SRAM layout when explicitly enabled for
+/// `mcu-rom-emulator`.
+pub(crate) fn rom_ld_args(platform: &str, crate_name: &str, rom_from_ram: bool) -> LdArgs {
+    match (platform, crate_name) {
+        ("emulator", "mcu-rom-emulator") if rom_from_ram => LdArgs {
+            rom_ld_base: Some(PROJECT_ROOT.join("firmware-bundler/data/rom-ram-text-layout.ld")),
+            ..Default::default()
+        },
+        _ => LdArgs::default(),
+    }
+}
+
 pub fn test_rom_build(args: &CaliptraBuildArgs) -> Result<String> {
     let platform = args.platform.unwrap_or("emulator");
     let fwid = args
@@ -124,10 +139,11 @@ pub fn test_rom_build(args: &CaliptraBuildArgs) -> Result<String> {
     if platform != "emulator" {
         features.push("fpga_realtime");
     }
+    let rom_from_ram = features.contains(&"rom-from-ram");
 
     let build_cmd = Commands::Build {
         common,
-        ld: LdArgs::default(),
+        ld: rom_ld_args(platform, fwid.crate_name, rom_from_ram),
         build: BuildArgs {
             rom_features: Some(features.join(",")),
             no_default_features: true,

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -38,9 +38,12 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
     let runtime_bin = release_dir.join(&output_name);
 
     let runtime_features = features.filter(|s| !s.is_empty()).map(|f| f.to_string());
+    // This path never threads ROM-specific features through, so rom-from-ram
+    // can never be "explicitly passed" here -- always pass `false`.
+    let ld = crate::rom::rom_ld_args(platform_str, &format!("mcu-rom-{platform_str}"), false);
     let bundle_cmd = BundleCommands::Bundle {
         common,
-        ld: LdArgs::default(),
+        ld,
         build: BuildArgs {
             runtime_features,
             no_default_features: args.no_default_features,

--- a/firmware-bundler/data/rom-ram-text-layout.ld
+++ b/firmware-bundler/data/rom-ram-text-layout.ld
@@ -1,0 +1,130 @@
+
+/* Licensed under the Apache-2.0 license. */
+
+ENTRY(_start)
+
+/*
+ * The last 48 bytes of the ROM image are reserved for a SHA-384 digest that is
+ * appended by the build step (see `append_rom_digest`). Carve them out of the
+ * ROM region so the linker refuses to place code or rodata there.
+ */
+ROM_DIGEST_SIZE = 48;
+
+/*
+ * rom-from-ram: relocates caliptra-mcu-rom-common/romtime into SRAM
+ * (RAM_TEXT, the last RAM_TEXT_SIZE bytes of SRAM) instead of executing them
+ * from ROM; the platform adapter (platforms/emulator/rom/src) stays in ROM.
+ *
+ * .ram_text matches by input-section *name*, not archive/file: full LTO
+ * (codegen-units = 1) erases per-crate object boundaries, but per-function
+ * sections keep the v0-mangled crate name as a substring, so that still
+ * routes each crate's surviving (non-inlined) functions to SRAM.
+ *
+ * Geometry here mirrors EMULATOR_MEMORY_MAP / MCU_ROM_RAM_TEXT_SIZE in
+ * platforms/emulator/config/src/lib.rs -- keep both in sync by hand.
+ */
+SRAM_OFFSET = 0x40000000;
+SRAM_SIZE = 0x100000;
+RAM_TEXT_SIZE = 0x40000;
+RAM_TEXT_ORIGIN = SRAM_OFFSET + SRAM_SIZE - RAM_TEXT_SIZE;
+
+MEMORY
+{
+  ROM      (rx) : ORIGIN = ROM_START, LENGTH = ROM_LENGTH - ROM_DIGEST_SIZE
+  RAM     (rwx) : ORIGIN = RAM_START, LENGTH = RAM_LENGTH /* dedicated SRAM for the ROM stack */
+  RAM_TEXT(rwx) : ORIGIN = RAM_TEXT_ORIGIN, LENGTH = RAM_TEXT_SIZE
+}
+
+SECTIONS
+{
+    /* _start is the CPU reset vector; must be first in ROM. */
+    .text.init :
+    {
+        *(.text.init)
+        . = ALIGN(4);
+    } > ROM
+
+    /* Copied into SRAM by copy_ram_text() (riscv.rs). Symbols defined outside
+       the section body so they still resolve if it ends up empty. */
+    .ram_text : ALIGN(4)
+    {
+        /* explicitly `#[link_section = ".ram_text"]`-tagged items */
+        *(.ram_text)
+        *(.text.*caliptra_mcu_rom_common*)
+        *(.text.*caliptra_mcu_romtime*)
+        *(.rodata.*caliptra_mcu_rom_common*)
+        *(.rodata.*caliptra_mcu_romtime*)
+        . = ALIGN(4);
+    } > RAM_TEXT AT> ROM
+
+    ROM_RAM_TEXT_START = ADDR(.ram_text);
+    ROM_RAM_TEXT_END = ADDR(.ram_text) + SIZEOF(.ram_text);
+    ROM_RAM_TEXT_LOAD = LOADADDR(.ram_text);
+
+    ASSERT(SIZEOF(.ram_text) <= RAM_TEXT_SIZE,
+           "ROM .ram_text exceeds its reserved SRAM budget -- increase MCU_ROM_RAM_TEXT_SIZE (platforms/emulator/config) and RAM_TEXT_SIZE (this file), then adjust mcu_fw_sram_exec_region_size() to match")
+
+    /* Everything else: remaining platform-adapter code and rodata. */
+    .text :
+    {
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > ROM
+
+    ROM_DATA = .;
+
+    .stack (NOLOAD):
+    {
+        . = ALIGN(4);
+        . = . + STACK_SIZE;
+        . = ALIGN(4);
+    } > RAM
+
+    .estack (NOLOAD):
+    {
+        . = ALIGN(4);
+        . = . + ESTACK_SIZE;
+        . = ALIGN(4);
+        PROVIDE(ESTACK_START = . );
+    } > RAM
+
+    /DISCARD/ :
+    {
+        *(.eh_frame*)
+    }
+
+    .data : AT(ROM_DATA)
+    {
+        . = ALIGN(4);
+        *(.data*);
+        *(.sdata*);
+        . = ALIGN(4);
+        PROVIDE( GLOBAL_POINTER = . + 0x800 );
+        . = ALIGN(4);
+    } > RAM
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        *(.bss*)
+        *(.sbss*)
+        *(COMMON)
+        . = ALIGN(4);
+    } > RAM
+
+    _end = . ;
+
+    /DISCARD/ :
+    {
+        *(.eh_frame*)
+    }
+}
+
+BSS_START = ADDR(.bss);
+BSS_END = BSS_START + SIZEOF(.bss);
+DATA_START = ADDR(.data);
+DATA_END = DATA_START + SIZEOF(.data);
+ROM_DATA_START = LOADADDR(.data);
+STACK_TOP = ORIGIN(RAM) + SIZEOF(.stack);
+STACK_ORIGIN = ORIGIN(RAM);

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -59,6 +59,11 @@ pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     lc_properties: MemoryRegionType::MMIO,
 };
 
+/// Size of the SRAM block (the last N bytes of SRAM) reserved for copied ROM
+/// logic under `rom-from-ram`. Must match `RAM_TEXT_SIZE` in
+/// rom-ram-text-layout.ld.
+pub const MCU_ROM_RAM_TEXT_SIZE: u32 = 256 * 1024;
+
 const ACTIVE_I3C: u8 = if cfg!(feature = "active-i3c1") { 1 } else { 0 };
 
 pub const EMULATOR_MCU_STRAPS: McuStraps = McuStraps {

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -55,3 +55,5 @@ active-i3c1 = ["caliptra-mcu-config-emulator/active-i3c1"]
 test-i3c-services = ["caliptra-mcu-rom-common/test-i3c-services"]
 test-dot-recovery-reset-flow = ["caliptra-mcu-rom-common/test-dot-recovery-reset-flow"]
 test-rom-hooks = []
+# Runs the bulk of ROM logic from SRAM instead of ROM; see rom-ram-text-layout.ld.
+rom-from-ram = ["caliptra-mcu-rom-common/rom-from-ram"]

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -31,6 +31,7 @@ use caliptra_mcu_config_emulator::flash::{
     PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
     PARTITION_TABLE,
 };
+use caliptra_mcu_config_emulator::MCU_ROM_RAM_TEXT_SIZE;
 use caliptra_mcu_rom_common::flash::flash_partition::FlashPartition;
 use caliptra_mcu_rom_common::hil::FlashStorage;
 use caliptra_mcu_rom_common::memory::SimpleFlash;
@@ -177,7 +178,72 @@ pub static MCU_MEMORY_MAP: McuMemoryMap = caliptra_mcu_config_emulator::EMULATOR
 #[used]
 pub static MCU_STRAPS: McuStraps = caliptra_mcu_config_emulator::EMULATOR_MCU_STRAPS;
 
+/// Number of 4 KiB blocks of MCU SRAM firmware execution is allowed to use.
+/// With `rom-from-ram`, excludes the SRAM block reserved for copied ROM
+/// logic so firmware never loads on top of code the ROM is still running.
+#[cfg(feature = "rom-from-ram")]
+fn mcu_fw_sram_exec_region_size() -> u32 {
+    (MCU_MEMORY_MAP.sram_size - MCU_ROM_RAM_TEXT_SIZE) / 4096
+}
+
+#[cfg(not(feature = "rom-from-ram"))]
+fn mcu_fw_sram_exec_region_size() -> u32 {
+    (MCU_MEMORY_MAP.sram_size - MCU_MEMORY_MAP.storage_size) / 4096
+        - caliptra_mcu_rom_common::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS
+        - 1
+}
+
+// Linker-provided addresses of the `.ram_text` block; pure address markers,
+// so only ever take their address (`addr_of!`), never read as data.
+#[cfg(feature = "rom-from-ram")]
+extern "C" {
+    static ROM_RAM_TEXT_LOAD: u8;
+    static ROM_RAM_TEXT_START: u8;
+    static ROM_RAM_TEXT_END: u8;
+}
+
+/// Copies `.ram_text` from its ROM load address to SRAM. Must run before
+/// anything reachable from `.ram_text` (i.e. `rom_common`) is called.
+#[cfg(feature = "rom-from-ram")]
+fn copy_ram_text() {
+    unsafe {
+        let load = core::ptr::addr_of!(ROM_RAM_TEXT_LOAD);
+        let start = core::ptr::addr_of!(ROM_RAM_TEXT_START) as *mut u8;
+        let end = core::ptr::addr_of!(ROM_RAM_TEXT_END);
+        let len = end as usize - start as usize;
+        core::ptr::copy_nonoverlapping(load, start, len);
+    }
+}
+
+/// Hand-off point from ROM into `.ram_text`. `#[inline(never)]` keeps it a
+/// standalone symbol so `auipc` reads its own (SRAM) address, not a caller's.
+#[cfg(feature = "rom-from-ram")]
+#[link_section = ".ram_text"]
+#[inline(never)]
+fn rom_common(params: RomParameters) {
+    let pc: u32;
+    unsafe {
+        core::arch::asm!("auipc {pc}, 0", pc = out(reg) pc);
+    }
+    caliptra_mcu_romtime::println!(
+        "[mcu-rom] rom_common executing from SRAM at {}",
+        HexWord(pc)
+    );
+    caliptra_mcu_rom_common::rom_start(params);
+}
+
+/// Without `rom-from-ram`, a plain alias for `rom_start`.
+#[cfg(not(feature = "rom-from-ram"))]
+fn rom_common(params: RomParameters) {
+    caliptra_mcu_rom_common::rom_start(params);
+}
+
+/// ROM-resident entry point.
+#[link_section = ".text"]
 pub extern "C" fn rom_entry() -> ! {
+    #[cfg(feature = "rom-from-ram")]
+    copy_ram_text();
+
     unsafe {
         #[allow(static_mut_refs)]
         caliptra_mcu_romtime::set_printer(&mut EMULATOR_WRITER);
@@ -250,7 +316,7 @@ pub extern "C" fn rom_entry() -> ! {
             _ => fatal_error(EmulatorError::InvalidPartitionId.into()),
         };
 
-        caliptra_mcu_rom_common::rom_start(RomParameters {
+        rom_common(RomParameters {
             flash_partition_driver: Some(&mut flash_image_partition_driver),
             dot_flash: Some(dot_flash),
             owner_pk_hash_policy: read_owner_pk_hash_policy(),
@@ -261,6 +327,7 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         });
     } else if cfg!(any(
@@ -283,14 +350,15 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         };
-        caliptra_mcu_rom_common::rom_start(rom_parameters);
+        rom_common(rom_parameters);
     } else if cfg!(any(
         feature = "test-fw-manifest-dot",
         feature = "test-fw-manifest-dot-hitless"
     )) {
-        caliptra_mcu_rom_common::rom_start(RomParameters {
+        rom_common(RomParameters {
             dot_flash: Some(dot_flash),
             owner_pk_hash_policy: read_owner_pk_hash_policy(),
             fw_manifest_dot_enabled: true,
@@ -302,6 +370,7 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         });
     } else if cfg!(feature = "test-svn-manifest") {
@@ -325,7 +394,7 @@ pub extern "C" fn rom_entry() -> ! {
                 fuse_entry: SOC_IMAGE_MIN_SVN_1,
             },
         ];
-        caliptra_mcu_rom_common::rom_start(RomParameters {
+        rom_common(RomParameters {
             dot_flash: Some(dot_flash),
             owner_pk_hash_policy: read_owner_pk_hash_policy(),
             svn_manifest_enabled: true,
@@ -338,6 +407,7 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         });
     } else if cfg!(feature = "flash-boot") {
@@ -356,7 +426,7 @@ pub extern "C" fn rom_entry() -> ! {
 
         caliptra_mcu_romtime::println!("[mcu-rom] Booting from flash");
 
-        caliptra_mcu_rom_common::rom_start(RomParameters {
+        rom_common(RomParameters {
             flash_partition_driver: Some(&mut flash_partition),
             dot_flash: Some(dot_flash),
             owner_pk_hash_policy: read_owner_pk_hash_policy(),
@@ -368,6 +438,7 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         });
     } else {
@@ -417,7 +488,7 @@ pub extern "C" fn rom_entry() -> ! {
 
         let hooks = LoggingRomHooks;
 
-        caliptra_mcu_rom_common::rom_start(RomParameters {
+        rom_common(RomParameters {
             dot_flash: Some(dot_flash),
             owner_pk_hash_policy: read_owner_pk_hash_policy(),
             cptra_mbox_axi_users: mbox_axi_users,
@@ -532,11 +603,7 @@ pub extern "C" fn rom_entry() -> ! {
             } else {
                 &[]
             },
-            mcu_fw_sram_exec_region_size: Some(
-                (MCU_MEMORY_MAP.sram_size - MCU_MEMORY_MAP.storage_size) / 4096
-                    - caliptra_mcu_rom_common::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS
-                    - 1,
-            ),
+            mcu_fw_sram_exec_region_size: Some(mcu_fw_sram_exec_region_size()),
             ..Default::default()
         });
     }

--- a/platforms/emulator/rom/src/start.s
+++ b/platforms/emulator/rom/src/start.s
@@ -63,7 +63,6 @@ copy_data:
     addi t1, t1, 4
     j copy_data
 end_copy_data:
-
     # call main entry point
     call main
 

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -44,3 +44,5 @@ svn-manifest = []
 # `FirmwareBootReset`. Used by the DOT manifest hitless-update integration
 # test to exercise `FwHitlessUpdate::run` without a real PLDM update flow.
 test-force-hitless-update = []
+# Debug prints of the execution address in cold_boot.rs/fw_boot.rs.
+rom-from-ram = []

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -1089,6 +1089,18 @@ impl BootFlow for ColdBoot {
                 .modify(ResetReason::FwBootUpdReset::CLEAR + ResetReason::FwHitlessUpdReset::SET);
         }
 
+        #[cfg(all(target_arch = "riscv32", feature = "rom-from-ram"))]
+        {
+            let pc: u32;
+            unsafe {
+                core::arch::asm!("auipc {pc}, 0", pc = out(reg) pc);
+            }
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] ColdBoot::run() executing from {} before warm reset",
+                HexWord(pc)
+            );
+        }
+
         mci.trigger_warm_reset();
         caliptra_mcu_romtime::println!("[mcu-rom] ERROR: Still running after reset request!");
         fatal_error(McuError::ROM_COLD_BOOT_RESET_ERROR);

--- a/rom/src/fw_boot.rs
+++ b/rom/src/fw_boot.rs
@@ -41,6 +41,17 @@ impl BootFlow for FwBoot {
 
         // Jump to firmware
         caliptra_mcu_romtime::println!("[mcu-rom] Jumping to firmware");
+        #[cfg(all(target_arch = "riscv32", feature = "rom-from-ram"))]
+        {
+            let pc: u32;
+            unsafe {
+                core::arch::asm!("auipc {pc}, 0", pc = out(reg) pc);
+            }
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] FwBoot::run() currently executing from {}",
+                caliptra_mcu_romtime::HexWord(pc)
+            );
+        }
         env.mci
             .set_flow_milestone(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());
         crate::call_hook(params.hooks, |h| h.post_fw_boot());

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -1041,12 +1041,47 @@ mod test {
         }
     }
 
+    // Builds the ROM directly rather than via get_rom_with_feature: no
+    // prebuilt bundle has this variant, and its fallback on a miss is the
+    // plain default ROM, which would pass without testing rom-from-ram.
+    fn create_soc_boot_options_rom_from_ram(is_flash_based_boot: bool) -> TestOptions {
+        env::set_var(
+            "CPTRA_EMULATOR_SS_MCI_OFFSET",
+            format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
+        );
+
+        let feature = if is_flash_based_boot {
+            "test-flash-based-boot"
+        } else {
+            "test-pldm-streaming-boot"
+        };
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
+
+        let mut opts =
+            create_soc_boot_test_options_build(feature, is_flash_based_boot, i3c_port, false);
+        opts.rom = caliptra_mcu_builder::rom_build(&caliptra_mcu_builder::CaliptraBuildArgs {
+            platform: Some("emulator"),
+            features: Some(&format!("{feature},rom-from-ram")),
+            ..Default::default()
+        })
+        .expect("rom-from-ram ROM build failed");
+        opts
+    }
+
     // ==================== Flash-based boot tests ====================
 
     #[test]
     fn test_flash_soc_boot_successful() {
         let lock = TEST_LOCK.lock().unwrap();
         let opts = create_soc_boot_options(true);
+        test_successful_boot(&opts);
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_flash_soc_boot_rom_from_ram() {
+        let lock = TEST_LOCK.lock().unwrap();
+        let opts = create_soc_boot_options_rom_from_ram(true);
         test_successful_boot(&opts);
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }


### PR DESCRIPTION
Part of RFC #3399 (https://github.com/chipsalliance/caliptra-sw/issues/3399)

This patch is the first part of being able to patch part of the MCU ROM by running some of the crates from the later half of MCU SRAM (the first part of MCU SRAM is for the MCU runtime image).  We have a special linker script for running from the second half of MCU SRAM and we have code at the beginning of the emulator MCU ROM that copies the necessary parts of MCU ROM to RAM and run it from there.  For demonstration purposes, the platform specific parts of the MCU ROM run from ROM space.

Right now this is gated by a featre "rom_from_ram" so as not to affect the normal ROM build.  Eventually a hash check and/or measurement will validate what we have copied to RAM.

There is also a SoC boot test to validate the MCU boot when we are running some of it from MCU SRAM.

An example boot is:

[mcu-rom] Booting from Partition A
[mcu-rom] rom_common executing from SRAM at 400C0014 [mcu-rom] Hello from ROM
[mcu-rom] Device lifecycle: Production
...
[mcu-rom] ColdBoot::run() executing from 400C6A20 before warm reset MCI: MCU reset requested
MCI: MCU proceeding with reboot
[mcu-rom] Booting from Partition A
[mcu-rom] rom_common executing from SRAM at 400C0014 ...
[mcu-rom] Starting fw boot reset flow
[mcu-rom] Jumping to firmware
[mcu-rom] FwBoot::run() currently executing from 400C7328