### PR TITLE
[offline-signing] Add fw-signer tool and validate auth manifest signatures in builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,7 @@ dependencies = [
  "chrono",
  "elf",
  "hex",
+ "openssl",
  "p384",
  "rayon",
  "semver",
@@ -1449,6 +1450,24 @@ dependencies = [
  "serde",
  "serde-hjson",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "caliptra-mcu-fw-signer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "caliptra-image-crypto",
+ "caliptra-image-gen",
+ "caliptra-image-types",
+ "caliptra-mcu-builder",
+ "clap 4.5.51",
+ "hex",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2206,6 +2225,7 @@ dependencies = [
  "caliptra-mcu-error",
  "caliptra-mcu-firmware-bundler",
  "caliptra-mcu-flash-image",
+ "caliptra-mcu-fw-signer",
  "caliptra-mcu-hw-model",
  "caliptra-mcu-image-header",
  "caliptra-mcu-mbox-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,7 @@ dependencies = [
  "chrono",
  "elf",
  "hex",
+ "openssl",
  "p384",
  "rayon",
  "semver",
@@ -1448,6 +1449,24 @@ dependencies = [
  "serde",
  "serde-hjson",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "caliptra-mcu-fw-signer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "caliptra-image-crypto",
+ "caliptra-image-gen",
+ "caliptra-image-types",
+ "caliptra-mcu-builder",
+ "clap 4.5.51",
+ "hex",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2205,6 +2224,7 @@ dependencies = [
  "caliptra-mcu-error",
  "caliptra-mcu-firmware-bundler",
  "caliptra-mcu-flash-image",
+ "caliptra-mcu-fw-signer",
  "caliptra-mcu-hw-model",
  "caliptra-mcu-image-header",
  "caliptra-mcu-mbox-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
     "runtime/userspace/userlog",
     "tests/hello",
     "tests/integration",
+    "tools/fw-signer",
     "tools/pk-hash-checker",
     "xtask",
 ]
@@ -247,6 +248,7 @@ caliptra-mcu-fusegen = { path = "provisioning/fuses/fusegen" }
 caliptra-mcu-i3c-driver = { path = "runtime/kernel/drivers/i3c" }
 caliptra-mcu-libtockasync = { path = "runtime/userspace/libtockasync" }
 caliptra-mcu-builder = { path = "builder" }
+caliptra-mcu-fw-signer = { path = "tools/fw-signer" }
 caliptra-mcu-components = { path = "runtime/kernel/components" }
 caliptra-mcu-config = { path = "common/config" }
 caliptra-mcu-command-auth-challenge-signer = { path = "common/command-auth-challenge-signer" }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -24,6 +24,7 @@ caliptra-mcu-config-emulator.workspace = true
 caliptra-mcu-config-fpga.workspace = true
 caliptra-mcu-firmware-bundler.workspace = true
 caliptra-mcu-pldm-fw-pkg.workspace = true
+openssl.workspace = true
 p384.workspace = true
 rayon = { workspace = true, optional = true }
 serde.workspace = true

--- a/builder/src/offline_signing.rs
+++ b/builder/src/offline_signing.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, Context, Result};
-use caliptra_auth_man_types::{AuthManifestPreamble, AuthorizationManifest};
+use caliptra_auth_man_types::{AuthManifestFlags, AuthManifestPreamble, AuthorizationManifest};
 use caliptra_image_crypto::RustCrypto as Crypto;
 use caliptra_image_gen::{from_hw_format, to_hw_format, ImageGeneratorCrypto};
 use caliptra_image_types::{ImageEccPubKey, ImageEccSignature, ImagePqcSignature};
@@ -237,29 +237,32 @@ pub fn attach_auth_manifest_signatures(
     owner_fw_pub_key_path: Option<&Path>,
     output_path: &Path,
 ) -> Result<()> {
+    // Load unsigned manifest.
     let manifest_bytes = std::fs::read(unsigned_manifest_path).with_context(|| {
         format!(
             "Failed to read unsigned manifest file {}",
             unsigned_manifest_path.display()
         )
     })?;
-
     let mut manifest = AuthorizationManifest::read_from_bytes(&manifest_bytes)
         .map_err(|e| anyhow!("Failed to parse unsigned manifest: {:?}", e))?;
 
+    // Load signatures.
     let sig_file_content = std::fs::read_to_string(signatures_path).with_context(|| {
         format!(
             "Failed to read signatures file {}",
             signatures_path.display()
         )
     })?;
-
     let sigs_json: SignaturesJson = serde_json::from_str(&sig_file_content).with_context(|| {
         format!(
             "Failed to parse signatures JSON file {}",
             signatures_path.display()
         )
     })?;
+
+    let flags = AuthManifestFlags::from(manifest.preamble.flags);
+    let vendor_sig_required = flags.contains(AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED);
 
     // Vendor Pub Keys Signatures (signed by Vendor FW Root key over Vendor Manifest Public Keys)
     if let Some(entry) = &sigs_json.vendor_pub_keys_signatures {
@@ -296,32 +299,36 @@ pub fn attach_auth_manifest_signatures(
     }
 
     // Owner Pub Keys Signatures (signed by Owner FW Root key over Owner Manifest Public Keys)
-    if let Some(entry) = &sigs_json.owner_pub_keys_signatures {
-        if let Some(ecc_hex) = &entry.ecc_sig {
-            manifest.preamble.owner_pub_keys_signatures.ecc_sig =
-                ImageEccSignature::try_from_hex(ecc_hex)?;
-        }
-        if let Some(pqc_hex) = &entry.pqc_sig {
-            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
-            pqc_sig
-                .verify()
-                .context("Owner public keys PQC signature verification failed")?;
-            manifest.preamble.owner_pub_keys_signatures.pqc_sig = pqc_sig;
-        }
+    let owner_pub_sigs = sigs_json
+        .owner_pub_keys_signatures
+        .as_ref()
+        .ok_or_else(|| anyhow!("owner_pub_keys_signatures is required in signatures JSON"))?;
+    let ecc_hex = owner_pub_sigs
+        .ecc_sig
+        .as_ref()
+        .ok_or_else(|| anyhow!("ecc_sig is required in owner_pub_keys_signatures"))?;
+    let pqc_hex = owner_pub_sigs
+        .pqc_sig
+        .as_ref()
+        .ok_or_else(|| anyhow!("pqc_sig is required in owner_pub_keys_signatures"))?;
 
-        if let Some(owner_fw_pub_path) = owner_fw_pub_key_path {
-            let owner_fw_pub = Crypto::ecc_pub_key_from_pem(owner_fw_pub_path)?;
-            let owner_data = manifest.preamble.owner_pub_keys.as_bytes();
-            let digest: [u8; 48] = sha2::Sha384::digest(owner_data).into();
-            verify_ecdsa384_signature(
-                &digest,
-                &owner_fw_pub,
-                &manifest.preamble.owner_pub_keys_signatures.ecc_sig,
-            )
-            .context(
-                "Owner public keys signature verification failed against provided owner FW key",
-            )?;
-        }
+    manifest.preamble.owner_pub_keys_signatures.ecc_sig = ImageEccSignature::try_from_hex(ecc_hex)?;
+    let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+    pqc_sig
+        .verify()
+        .context("Owner public keys PQC signature verification failed")?;
+    manifest.preamble.owner_pub_keys_signatures.pqc_sig = pqc_sig;
+
+    if let Some(owner_fw_pub_path) = owner_fw_pub_key_path {
+        let owner_fw_pub = Crypto::ecc_pub_key_from_pem(owner_fw_pub_path)?;
+        let owner_data = manifest.preamble.owner_pub_keys.as_bytes();
+        let digest: [u8; 48] = sha2::Sha384::digest(owner_data).into();
+        verify_ecdsa384_signature(
+            &digest,
+            &owner_fw_pub,
+            &manifest.preamble.owner_pub_keys_signatures.ecc_sig,
+        )
+        .context("Owner public keys signature verification failed against provided owner FW key")?;
     }
 
     // IMC Digest for Manifest key verification
@@ -331,17 +338,22 @@ pub fn attach_auth_manifest_signatures(
     // Vendor IMC Signatures (signed by Vendor Manifest key; verified against embedded
     // Vendor Manifest Public Key: `preamble.vendor_pub_keys`)
     if let Some(entry) = &sigs_json.vendor_imc_signatures {
-        if let Some(ecc_hex) = &entry.ecc_sig {
-            manifest.preamble.vendor_image_metdata_signatures.ecc_sig =
-                ImageEccSignature::try_from_hex(ecc_hex)?;
-        }
-        if let Some(pqc_hex) = &entry.pqc_sig {
-            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
-            pqc_sig
-                .verify()
-                .context("Vendor IMC PQC signature verification failed")?;
-            manifest.preamble.vendor_image_metdata_signatures.pqc_sig = pqc_sig;
-        }
+        let ecc_hex = entry
+            .ecc_sig
+            .as_ref()
+            .ok_or_else(|| anyhow!("ecc_sig is required in vendor_imc_signatures"))?;
+        let pqc_hex = entry
+            .pqc_sig
+            .as_ref()
+            .ok_or_else(|| anyhow!("pqc_sig is required in vendor_imc_signatures"))?;
+
+        manifest.preamble.vendor_image_metdata_signatures.ecc_sig =
+            ImageEccSignature::try_from_hex(ecc_hex)?;
+        let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+        pqc_sig
+            .verify()
+            .context("Vendor IMC PQC signature verification failed")?;
+        manifest.preamble.vendor_image_metdata_signatures.pqc_sig = pqc_sig;
 
         verify_ecdsa384_signature(
             &imc_digest,
@@ -349,30 +361,39 @@ pub fn attach_auth_manifest_signatures(
             &manifest.preamble.vendor_image_metdata_signatures.ecc_sig,
         )
         .context("Vendor IMC signature verification failed against embedded vendor manifest key")?;
+    } else if vendor_sig_required {
+        anyhow::bail!("vendor_imc_signatures is required in signatures JSON when VENDOR_SIGNATURE_REQUIRED flag is set");
     }
 
     // Owner IMC Signatures (signed by Owner Manifest key; verified against embedded
     // Owner Manifest Public Key: `preamble.owner_pub_keys`)
-    if let Some(entry) = &sigs_json.owner_imc_signatures {
-        if let Some(ecc_hex) = &entry.ecc_sig {
-            manifest.preamble.owner_image_metdata_signatures.ecc_sig =
-                ImageEccSignature::try_from_hex(ecc_hex)?;
-        }
-        if let Some(pqc_hex) = &entry.pqc_sig {
-            let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
-            pqc_sig
-                .verify()
-                .context("Owner IMC PQC signature verification failed")?;
-            manifest.preamble.owner_image_metdata_signatures.pqc_sig = pqc_sig;
-        }
+    let owner_imc_sigs = sigs_json
+        .owner_imc_signatures
+        .as_ref()
+        .ok_or_else(|| anyhow!("owner_imc_signatures is required in signatures JSON"))?;
+    let ecc_hex = owner_imc_sigs
+        .ecc_sig
+        .as_ref()
+        .ok_or_else(|| anyhow!("ecc_sig is required in owner_imc_signatures"))?;
+    let pqc_hex = owner_imc_sigs
+        .pqc_sig
+        .as_ref()
+        .ok_or_else(|| anyhow!("pqc_sig is required in owner_imc_signatures"))?;
 
-        verify_ecdsa384_signature(
-            &imc_digest,
-            &manifest.preamble.owner_pub_keys.ecc_pub_key,
-            &manifest.preamble.owner_image_metdata_signatures.ecc_sig,
-        )
-        .context("Owner IMC signature verification failed against embedded owner manifest key")?;
-    }
+    manifest.preamble.owner_image_metdata_signatures.ecc_sig =
+        ImageEccSignature::try_from_hex(ecc_hex)?;
+    let pqc_sig = ImagePqcSignature::try_from_hex(pqc_hex)?;
+    pqc_sig
+        .verify()
+        .context("Owner IMC PQC signature verification failed")?;
+    manifest.preamble.owner_image_metdata_signatures.pqc_sig = pqc_sig;
+
+    verify_ecdsa384_signature(
+        &imc_digest,
+        &manifest.preamble.owner_pub_keys.ecc_pub_key,
+        &manifest.preamble.owner_image_metdata_signatures.ecc_sig,
+    )
+    .context("Owner IMC signature verification failed against embedded owner manifest key")?;
 
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;

--- a/builder/src/offline_signing.rs
+++ b/builder/src/offline_signing.rs
@@ -4,7 +4,16 @@ use anyhow::{anyhow, Context, Result};
 use caliptra_auth_man_types::{AuthManifestFlags, AuthManifestPreamble, AuthorizationManifest};
 use caliptra_image_crypto::RustCrypto as Crypto;
 use caliptra_image_gen::{from_hw_format, to_hw_format, ImageGeneratorCrypto};
-use caliptra_image_types::{ImageEccPubKey, ImageEccSignature, ImagePqcSignature};
+use caliptra_image_types::{
+    ImageEccPubKey, ImageEccSignature, ImageLmsPublicKey, ImageLmsSignature, ImageMldsaPubKey,
+    ImageMldsaSignature, ImagePqcSignature,
+};
+use openssl::{
+    pkey::Public,
+    pkey_ctx::PkeyCtx,
+    pkey_ml_dsa::{PKeyMlDsaBuilder, Variant},
+    signature::Signature as OsslSignature,
+};
 use p384::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
@@ -227,6 +236,34 @@ pub fn verify_ecdsa384_signature(
     verifying_key
         .verify_prehash(digest, &signature)
         .map_err(|e| anyhow!("ECDSA P-384 signature verification failed: {}", e))
+}
+
+/// Perform cryptographic verification of an LMS signature over a 48-byte digest against an `ImageLmsPublicKey`.
+pub fn verify_lms_signature(
+    _digest: &[u8; 48],
+    _pub_key: &ImageLmsPublicKey,
+    _sig: &ImageLmsSignature,
+) -> Result<()> {
+    eprintln!("WARNING: LMS signature cryptographic verification is not yet implemented.");
+    // TODO(timothytrippel): Cryptographically verify LMS signatures.
+    Ok(())
+}
+
+/// Perform cryptographic verification of an ML-DSA-87 signature over a message against an `ImageMldsaPubKey`.
+pub fn verify_mldsa_signature(
+    msg: &[u8],
+    pub_key: &ImageMldsaPubKey,
+    sig: &ImageMldsaSignature,
+) -> Result<()> {
+    let builder = PKeyMlDsaBuilder::<Public>::new(Variant::MlDsa87, pub_key.0.as_bytes(), None)?;
+    let pkey = builder.build()?;
+    let mut algo = OsslSignature::for_ml_dsa(Variant::MlDsa87)?;
+    let mut ctx = PkeyCtx::new(&pkey)?;
+    ctx.verify_message_init(&mut algo)?;
+    match ctx.verify(msg, &sig.0.as_bytes()[..4627]) {
+        Ok(true) => Ok(()),
+        _ => anyhow::bail!("ML-DSA-87 signature verification failed against ImageMldsaPubKey"),
+    }
 }
 
 /// Attach signatures from a `SignaturesJson` file to an unsigned authorization manifest binary, verify all signatures, and save the resulting `signed_auth_manifest.bin`.

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -54,6 +54,7 @@ caliptra-mcu-mbox-common.workspace = true
 caliptra-mcu-debug-unlock-signer.workspace = true
 caliptra-mcu-rom-common.workspace = true
 caliptra-mcu-testing-common.workspace = true
+caliptra-mcu-fw-signer.workspace = true
 p384 = { workspace = true, features = ["ecdsa"] }
 caliptra-mcu-pldm-common.workspace = true
 caliptra-mcu-pldm-fw-pkg.workspace = true

--- a/tools/fw-signer/Cargo.toml
+++ b/tools/fw-signer/Cargo.toml
@@ -1,0 +1,27 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-mcu-fw-signer"
+version = "0.1.0"
+edition = "2021"
+description = "Helper library and standalone CLI tool (fw-signer) to generate offline signatures.json from signing_request.json using a key manifest for Caliptra auth manifests"
+
+[[bin]]
+name = "fw-signer"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+caliptra-image-crypto.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-types.workspace = true
+caliptra-mcu-builder.workspace = true
+clap.workspace = true
+hex.workspace = true
+openssl.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+zerocopy.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/tools/fw-signer/README.md
+++ b/tools/fw-signer/README.md
@@ -1,0 +1,138 @@
+# Caliptra MCU Firmware Signer (`fw-signer`)
+
+`fw-signer` is a command-line tool and Rust library for generating offline
+authorization manifest signatures (`signatures.json`) from signing request
+files (`signing_request.json`) in the Caliptra MCU software ecosystem.
+
+It leverages `caliptra-image-gen` and `caliptra-image-crypto` to perform
+cryptographic signing using either local PEM key files or Hardware Security
+Modules (HSMs) via custom OpenSSL 3 Providers.
+
+## Supported Cryptographic Algorithms
+
+- **ECC P-384 (ECDSA)**: SHA-384 digests signed over NIST P-384 curves.
+- **LMS (RFC 8554)**: Leighton-Micali Signatures for post-quantum security.
+- **ML-DSA-87 (FIPS 204)**: Module-Lattice-Based Digital Signature Algorithm.
+
+## Command-Line Usage
+
+```bash
+fw-signer \
+  --signing-request /path/to/signing_request.json \
+  --key-manifest /path/to/key_manifest.json \
+  --output /path/to/signatures.json \
+  [--openssl-provider <PROVIDER_NAME>]
+```
+
+### CLI Options
+
+- `-r, --signing-request <PATH>`: Path to input `signing_request.json` file.
+- `-k, --key-manifest <PATH>`: Path to JSON key manifest specifying key paths
+  or OpenSSL provider key names.
+- `-o, --output <PATH>`: Path to output `signatures.json` file.
+- `--openssl-provider <NAME>`: Optional OpenSSL 3 provider name to load for
+  cryptographic operations (e.g., `pkcs11`, `fips`, `default`).
+
+## Key Manifest Schema (`key_manifest.json`)
+
+The key manifest is a JSON file that configures signing keys for all four
+authorization manifest signature targets: `vendor_fw`, `owner_fw`,
+`vendor_man`, and `owner_man`.
+
+Each component entry requires valid ECC P-384 and PQC key configurations.
+
+### Example Key Manifest
+
+```json
+{
+  "vendor_fw": {
+    "ecc_priv_key": "path/to/vendor_ecc_priv.pem",
+    "ecc_pub_key": "path/to/vendor_ecc_pub.pem",
+    "pqc_priv_key": "path/to/vendor_lms_priv.pem",
+    "pqc_pub_key": null,
+    "pqc_type": "LMS"
+  },
+  "owner_fw": {
+    "ecc_priv_key": "path/to/owner_ecc_priv.pem",
+    "ecc_pub_key": "path/to/owner_ecc_pub.pem",
+    "pqc_priv_key": "path/to/owner_mldsa_priv.pem",
+    "pqc_pub_key": "path/to/owner_mldsa_pub.pem",
+    "pqc_type": "MLDSA"
+  },
+  "vendor_man": {
+    "ecc_priv_key": "path/to/vendor_man_ecc_priv.pem",
+    "ecc_pub_key": "path/to/vendor_man_ecc_pub.pem",
+    "pqc_priv_key": "path/to/vendor_man_lms_priv.pem",
+    "pqc_pub_key": null,
+    "pqc_type": "LMS"
+  },
+  "owner_man": {
+    "ecc_priv_key": "path/to/owner_man_ecc_priv.pem",
+    "ecc_pub_key": "path/to/owner_man_ecc_pub.pem",
+    "pqc_priv_key": "path/to/owner_man_lms_priv.pem",
+    "pqc_pub_key": null,
+    "pqc_type": "LMS"
+  }
+}
+```
+
+### Key Manifest Fields
+
+- `ecc_priv_key` (string): Local PEM file path or OpenSSL provider key URI.
+- `ecc_pub_key` (string): Local PEM file path or OpenSSL provider key URI.
+- `pqc_priv_key` (string): Local PEM file path or OpenSSL provider key URI.
+- `pqc_pub_key` (string | null): Required when `pqc_type` is set to `MLDSA`.
+- `pqc_type` (string): Must be either `"LMS"` or `"MLDSA"` (case-insensitive).
+
+## OpenSSL Provider & HSM Integration
+
+When `--openssl-provider <NAME>` is specified, `fw-signer` dynamically loads
+the requested OpenSSL 3 provider (such as `pkcs11` for HSM access or `fips`
+for FIPS-140 compliance).
+
+When using an HSM provider, the key fields in `key_manifest.json` can be set
+to PKCS#11 URIs or provider-specific key labels instead of filesystem paths:
+
+```json
+{
+  "vendor_fw": {
+    "ecc_priv_key": "pkcs11:token=MyHSM;object=vendor_ecc_key;type=private",
+    "ecc_pub_key": "pkcs11:token=MyHSM;object=vendor_ecc_key;type=public",
+    "pqc_priv_key": "pkcs11:token=MyHSM;object=vendor_lms_key;type=private",
+    "pqc_pub_key": null,
+    "pqc_type": "LMS"
+  }
+}
+```
+
+## End-to-End Workflow
+
+1. **Generate Unsigned Manifest & Signing Request**:
+   Use `cargo xtask auth-manifest create` to generate an unsigned auth
+   manifest binary (`unsigned_manifest.bin`) and export the offline signing
+   request (`signing_request.json`):
+   ```bash
+   cargo xtask auth-manifest create \
+     --mcu_image mcu-runtime.bin,0xA8000000,0x60000000,2,2 \
+     --output unsigned_manifest.bin \
+     --signing-request signing_request.json \
+     --vendor-fw-pub-key path/to/vendor_ecc_pub.pem \
+     --owner-fw-pub-key path/to/owner_ecc_pub.pem
+   ```
+
+2. **Generate Offline Signatures**:
+   Invoke `fw-signer` with your key manifest (`key_manifest.json`) to sign the
+   digests in `signing_request.json` and generate `signatures.json`:
+   ```bash
+   fw-signer -r signing_request.json -k key_manifest.json -o signatures.json
+   ```
+
+3. **Attach Signatures**:
+   Attach the resulting `signatures.json` to the unsigned authorization
+   manifest using `cargo xtask auth-manifest attach-signatures`:
+   ```bash
+   cargo xtask auth-manifest attach-signatures \
+     --unsigned-manifest unsigned_manifest.bin \
+     --signatures signatures.json \
+     --output signed_manifest.bin
+   ```

--- a/tools/fw-signer/src/lib.rs
+++ b/tools/fw-signer/src/lib.rs
@@ -1,0 +1,358 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::{anyhow, Context, Result};
+use caliptra_image_crypto::OsslCrypto;
+use caliptra_image_gen::ImageGeneratorCrypto;
+use caliptra_mcu_builder::offline_signing::{SignatureEntry, SignaturesJson, SigningRequestJson};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use zerocopy::IntoBytes;
+
+/// Key manifest entry specifying key file paths or OpenSSL provider key names for a component.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyManifestEntry {
+    /// Path or OpenSSL provider key name for ECC P-384 private key.
+    pub ecc_priv_key: String,
+    /// Path or OpenSSL provider key name for ECC P-384 public key.
+    pub ecc_pub_key: String,
+    /// Path or OpenSSL provider key name for PQC private key (LMS or ML-DSA).
+    pub pqc_priv_key: String,
+    /// Optional path or OpenSSL provider key name for PQC public key (required for ML-DSA).
+    pub pqc_pub_key: Option<String>,
+    /// PQC algorithm type: "LMS" or "MLDSA" (case-insensitive).
+    pub pqc_type: String,
+}
+
+/// Key manifest JSON file structure containing signing keys for all authorization manifest components.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyManifest {
+    pub vendor_fw: KeyManifestEntry,
+    pub owner_fw: KeyManifestEntry,
+    pub vendor_man: KeyManifestEntry,
+    pub owner_man: KeyManifestEntry,
+}
+
+/// Sign a 48-byte hex digest using an ECC P-384 private and public key via `ImageGeneratorCrypto` (`OsslCrypto`).
+pub fn sign_ecc(digest_hex: &str, priv_key_path: &Path, pub_key_path: &Path) -> Result<String> {
+    let digest_bytes = hex::decode(digest_hex.trim()).context("Invalid digest hex string")?;
+    let digest: caliptra_image_types::ImageDigest384 =
+        caliptra_image_gen::to_hw_format(&digest_bytes);
+    let priv_key = OsslCrypto::ecc_priv_key_from_pem(priv_key_path)?;
+    let pub_key = OsslCrypto::ecc_pub_key_from_pem(pub_key_path)?;
+    let crypto = OsslCrypto::default();
+    let sig = ImageGeneratorCrypto::ecdsa384_sign(&crypto, &digest, &priv_key, &pub_key)?;
+    let mut raw = [0u8; 96];
+    raw[..48].copy_from_slice(&caliptra_image_gen::from_hw_format(&sig.r));
+    raw[48..].copy_from_slice(&caliptra_image_gen::from_hw_format(&sig.s));
+    Ok(hex::encode(raw))
+}
+
+/// Sign a 48-byte hex digest using an LMS private key PEM file via `ImageGeneratorCrypto` (`OsslCrypto`).
+pub fn sign_lms(digest_hex: &str, priv_key_path: &Path) -> Result<String> {
+    let digest_bytes = hex::decode(digest_hex.trim()).context("Invalid digest hex string")?;
+    let digest: caliptra_image_types::ImageDigest384 =
+        caliptra_image_gen::to_hw_format(&digest_bytes);
+    let lms_priv_key = OsslCrypto::lms_priv_key_from_file(priv_key_path)?;
+    let crypto = OsslCrypto::default();
+    let lms_sig = ImageGeneratorCrypto::lms_sign(&crypto, &digest, &lms_priv_key)?;
+    Ok(hex::encode(lms_sig.as_bytes()))
+}
+
+/// Sign a hex payload message using an ML-DSA-87 private and public key PEM file via `ImageGeneratorCrypto` (`OsslCrypto`).
+pub fn sign_mldsa(msg_hex: &str, priv_key_path: &Path, pub_key_path: &Path) -> Result<String> {
+    let msg_bytes = hex::decode(msg_hex.trim()).context("Invalid message hex string")?;
+    let priv_key = OsslCrypto::mldsa_priv_key_from_file(priv_key_path)?;
+    let pub_key = OsslCrypto::mldsa_pub_key_from_file(pub_key_path)?;
+    let crypto = OsslCrypto::default();
+    let mldsa_sig = ImageGeneratorCrypto::mldsa_sign(&crypto, &msg_bytes, &priv_key, &pub_key)?;
+    Ok(hex::encode(mldsa_sig.as_bytes()))
+}
+
+fn sign_entry(
+    digest_sha384: &str,
+    payload_hex: &str,
+    entry: &KeyManifestEntry,
+) -> Result<SignatureEntry> {
+    let ecc_sig = sign_ecc(
+        digest_sha384,
+        Path::new(&entry.ecc_priv_key),
+        Path::new(&entry.ecc_pub_key),
+    )?;
+
+    let pqc_sig = match entry.pqc_type.to_uppercase().as_str() {
+        "LMS" => sign_lms(digest_sha384, Path::new(&entry.pqc_priv_key))?,
+        "MLDSA" | "ML-DSA" | "MLDSA87" | "ML-DSA-87" => {
+            let pub_path = entry
+                .pqc_pub_key
+                .as_ref()
+                .ok_or_else(|| anyhow!("pqc_pub_key required for MLDSA signing"))?;
+            sign_mldsa(
+                payload_hex,
+                Path::new(&entry.pqc_priv_key),
+                Path::new(pub_path),
+            )?
+        }
+        other => anyhow::bail!(
+            "Unsupported or invalid PQC algorithm type '{}' (expected 'LMS' or 'MLDSA')",
+            other
+        ),
+    };
+
+    Ok(SignatureEntry {
+        ecc_sig: Some(ecc_sig),
+        pqc_sig: Some(pqc_sig),
+    })
+}
+
+/// Parse `signing_request.json`, sign each target digest with the keys in `KeyManifest`, and write `signatures.json`.
+pub fn generate_offline_signatures(
+    signing_request_path: &Path,
+    key_manifest: &KeyManifest,
+    output_signatures_path: &Path,
+) -> Result<SignaturesJson> {
+    let req_content = std::fs::read_to_string(signing_request_path).with_context(|| {
+        format!(
+            "Failed to read signing request {}",
+            signing_request_path.display()
+        )
+    })?;
+    let req: SigningRequestJson = serde_json::from_str(&req_content)?;
+
+    let vendor_pub_keys_signatures = Some(sign_entry(
+        &req.requests.vendor_pub_keys_signatures.digest_sha384,
+        &req.requests.vendor_pub_keys_signatures.payload_hex,
+        &key_manifest.vendor_fw,
+    )?);
+
+    let owner_pub_keys_signatures = Some(sign_entry(
+        &req.requests.owner_pub_keys_signatures.digest_sha384,
+        &req.requests.owner_pub_keys_signatures.payload_hex,
+        &key_manifest.owner_fw,
+    )?);
+
+    let vendor_imc_signatures = Some(sign_entry(
+        &req.requests.vendor_imc_signatures.digest_sha384,
+        &req.requests.vendor_imc_signatures.payload_hex,
+        &key_manifest.vendor_man,
+    )?);
+
+    let owner_imc_signatures = Some(sign_entry(
+        &req.requests.owner_imc_signatures.digest_sha384,
+        &req.requests.owner_imc_signatures.payload_hex,
+        &key_manifest.owner_man,
+    )?);
+
+    let sigs_json = SignaturesJson {
+        vendor_pub_keys_signatures,
+        owner_pub_keys_signatures,
+        vendor_imc_signatures,
+        owner_imc_signatures,
+    };
+
+    let formatted_json = serde_json::to_string_pretty(&sigs_json)?;
+    if let Some(parent) = output_signatures_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output_signatures_path, formatted_json)?;
+    Ok(sigs_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use caliptra_image_types::{
+        ImageEccSignature, ImageLmsPublicKey, ImageLmsSignature, ImageMldsaSignature,
+    };
+    use caliptra_mcu_builder::offline_signing::{
+        verify_ecdsa384_signature, verify_lms_signature, verify_mldsa_signature,
+        ImageEccSignatureExt,
+    };
+    use tempfile::NamedTempFile;
+    use zerocopy::FromBytes;
+
+    #[test]
+    fn test_sign_and_verify_ecc() {
+        let sw_root = caliptra_mcu_builder::caliptra_sw_workspace_root();
+        let vendor_ecc_priv = sw_root.join("image/fake-keys/keys/vendor_ecc_0_key.pem");
+        let vendor_ecc_pub = sw_root.join("image/fake-keys/keys/vendor_ecc_0_pub.pem");
+
+        let dummy_digest = "01".repeat(48);
+        let ecc_sig = sign_ecc(&dummy_digest, &vendor_ecc_priv, &vendor_ecc_pub).unwrap();
+        assert_eq!(ecc_sig.len(), 192); // 96 bytes * 2 hex chars per byte
+        let parsed_ecc = ImageEccSignature::try_from_hex(&ecc_sig).unwrap();
+
+        let digest_bytes = hex::decode(&dummy_digest).unwrap();
+        let digest_array: [u8; 48] = digest_bytes.try_into().unwrap();
+        let pub_key = OsslCrypto::ecc_pub_key_from_pem(&vendor_ecc_pub).unwrap();
+        verify_ecdsa384_signature(&digest_array, &pub_key, &parsed_ecc)
+            .expect("Generated ECDSA P-384 signature failed verification against public key");
+    }
+
+    #[test]
+    fn test_sign_and_verify_lms() {
+        let sw_root = caliptra_mcu_builder::caliptra_sw_workspace_root();
+        let lms_pem = sw_root.join("image/fake-keys/keys/vendor_lms_0_key.pem");
+
+        let dummy_digest = "01".repeat(48);
+        let lms_sig_hex = sign_lms(&dummy_digest, &lms_pem).unwrap();
+        assert_eq!(lms_sig_hex.len(), 1620 * 2);
+
+        let digest_bytes = hex::decode(&dummy_digest).unwrap();
+        let digest_array: [u8; 48] = digest_bytes.try_into().unwrap();
+        let sig_bytes = hex::decode(&lms_sig_hex).unwrap();
+        let lms_pub_key = ImageLmsPublicKey::default();
+        let lms_sig = ImageLmsSignature::ref_from_bytes(&sig_bytes).unwrap();
+        verify_lms_signature(&digest_array, &lms_pub_key, lms_sig)
+            .expect("LMS signature verification failed");
+    }
+
+    #[test]
+    fn test_sign_and_verify_mldsa() {
+        let sw_root = caliptra_mcu_builder::caliptra_sw_workspace_root();
+        let mldsa_priv = sw_root.join("image/fake-keys/keys/vendor_mldsa_0_key.pem");
+        let mldsa_pub = sw_root.join("image/fake-keys/keys/vendor_mldsa_0_pub.pem");
+
+        let dummy_msg = "02".repeat(64);
+        let mldsa_sig_hex = sign_mldsa(&dummy_msg, &mldsa_priv, &mldsa_pub).unwrap();
+        assert_eq!(mldsa_sig_hex.len(), 4628 * 2);
+
+        let msg_bytes = hex::decode(&dummy_msg).unwrap();
+        let sig_bytes = hex::decode(&mldsa_sig_hex).unwrap();
+        let pub_key = OsslCrypto::mldsa_pub_key_from_file(&mldsa_pub).unwrap();
+        let mldsa_sig = ImageMldsaSignature::ref_from_bytes(&sig_bytes).unwrap();
+        verify_mldsa_signature(&msg_bytes, &pub_key, mldsa_sig)
+            .expect("Generated ML-DSA signature failed verification against public key");
+    }
+
+    #[test]
+    fn test_generate_offline_signatures_with_manifest() {
+        let sw_root = caliptra_mcu_builder::caliptra_sw_workspace_root();
+        let vendor_ecc_priv = sw_root.join("image/fake-keys/keys/vendor_ecc_0_key.pem");
+        let vendor_ecc_pub = sw_root.join("image/fake-keys/keys/vendor_ecc_0_pub.pem");
+        let owner_ecc_priv = sw_root.join("image/fake-keys/keys/owner_ecc_key.pem");
+        let owner_ecc_pub = sw_root.join("image/fake-keys/keys/owner_ecc_pub.pem");
+        let vendor_man_priv = sw_root.join("image/fake-keys/keys/vendor_ecc_1_key.pem");
+        let vendor_man_pub = sw_root.join("image/fake-keys/keys/vendor_ecc_1_pub.pem");
+
+        let mldsa_priv = sw_root.join("image/fake-keys/keys/owner_mldsa_key.pem");
+        let mldsa_pub = sw_root.join("image/fake-keys/keys/owner_mldsa_pub.pem");
+
+        let req_json = r#"{
+            "version": 1,
+            "requests": {
+                "vendor_pub_keys_signatures": {
+                    "ecc_key": "vendor_fw_ecc_key",
+                    "pqc_key": "vendor_fw_pqc_key",
+                    "digest_sha384": "010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101",
+                    "payload_hex": "00"
+                },
+                "owner_pub_keys_signatures": {
+                    "ecc_key": "owner_fw_ecc_key",
+                    "pqc_key": "owner_fw_pqc_key",
+                    "digest_sha384": "020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202",
+                    "payload_hex": "00"
+                },
+                "vendor_imc_signatures": {
+                    "ecc_key": "vendor_man_ecc_key",
+                    "pqc_key": "vendor_man_pqc_key",
+                    "digest_sha384": "030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303",
+                    "payload_hex": "00"
+                },
+                "owner_imc_signatures": {
+                    "ecc_key": "owner_man_ecc_key",
+                    "pqc_key": "owner_man_pqc_key",
+                    "digest_sha384": "040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404",
+                    "payload_hex": "00"
+                }
+            }
+        }"#;
+
+        let req_file = NamedTempFile::new().unwrap();
+        std::fs::write(req_file.path(), req_json).unwrap();
+
+        let manifest = KeyManifest {
+            vendor_fw: KeyManifestEntry {
+                ecc_priv_key: vendor_ecc_priv.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: mldsa_priv.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            owner_fw: KeyManifestEntry {
+                ecc_priv_key: owner_ecc_priv.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: mldsa_priv.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            vendor_man: KeyManifestEntry {
+                ecc_priv_key: vendor_man_priv.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_man_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: mldsa_priv.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            owner_man: KeyManifestEntry {
+                ecc_priv_key: owner_ecc_priv.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: mldsa_priv.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+        };
+
+        let sig_file = NamedTempFile::new().unwrap();
+        let sigs =
+            generate_offline_signatures(req_file.path(), &manifest, sig_file.path()).unwrap();
+
+        let mldsa_pub_key = OsslCrypto::mldsa_pub_key_from_file(&mldsa_pub).unwrap();
+
+        assert!(sigs.vendor_pub_keys_signatures.is_some());
+        let v_entry = sigs.vendor_pub_keys_signatures.as_ref().unwrap();
+        let vendor_ecc =
+            ImageEccSignature::try_from_hex(v_entry.ecc_sig.as_ref().unwrap()).unwrap();
+        let vendor_pub = OsslCrypto::ecc_pub_key_from_pem(&vendor_ecc_pub).unwrap();
+        let v_digest = hex::decode("010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101").unwrap();
+        verify_ecdsa384_signature(&v_digest.try_into().unwrap(), &vendor_pub, &vendor_ecc)
+            .expect("vendor_pub_keys_signatures ECC signature verification failed");
+        let v_mldsa_bytes = hex::decode(v_entry.pqc_sig.as_ref().unwrap()).unwrap();
+        let v_mldsa_sig = ImageMldsaSignature::ref_from_bytes(&v_mldsa_bytes).unwrap();
+        verify_mldsa_signature(&[0u8], &mldsa_pub_key, v_mldsa_sig)
+            .expect("vendor_pub_keys_signatures MLDSA signature verification failed");
+
+        assert!(sigs.owner_pub_keys_signatures.is_some());
+        let o_entry = sigs.owner_pub_keys_signatures.as_ref().unwrap();
+        let owner_ecc = ImageEccSignature::try_from_hex(o_entry.ecc_sig.as_ref().unwrap()).unwrap();
+        let owner_pub = OsslCrypto::ecc_pub_key_from_pem(&owner_ecc_pub).unwrap();
+        let o_digest = hex::decode("020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202").unwrap();
+        verify_ecdsa384_signature(&o_digest.try_into().unwrap(), &owner_pub, &owner_ecc)
+            .expect("owner_pub_keys_signatures ECC signature verification failed");
+        let o_mldsa_bytes = hex::decode(o_entry.pqc_sig.as_ref().unwrap()).unwrap();
+        let o_mldsa_sig = ImageMldsaSignature::ref_from_bytes(&o_mldsa_bytes).unwrap();
+        verify_mldsa_signature(&[0u8], &mldsa_pub_key, o_mldsa_sig)
+            .expect("owner_pub_keys_signatures MLDSA signature verification failed");
+
+        assert!(sigs.vendor_imc_signatures.is_some());
+        let vm_entry = sigs.vendor_imc_signatures.as_ref().unwrap();
+        let vm_ecc = ImageEccSignature::try_from_hex(vm_entry.ecc_sig.as_ref().unwrap()).unwrap();
+        let vm_pub = OsslCrypto::ecc_pub_key_from_pem(&vendor_man_pub).unwrap();
+        let vm_digest = hex::decode("030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303").unwrap();
+        verify_ecdsa384_signature(&vm_digest.try_into().unwrap(), &vm_pub, &vm_ecc)
+            .expect("vendor_imc_signatures ECC signature verification failed");
+        let vm_mldsa_bytes = hex::decode(vm_entry.pqc_sig.as_ref().unwrap()).unwrap();
+        let vm_mldsa_sig = ImageMldsaSignature::ref_from_bytes(&vm_mldsa_bytes).unwrap();
+        verify_mldsa_signature(&[0u8], &mldsa_pub_key, vm_mldsa_sig)
+            .expect("vendor_imc_signatures MLDSA signature verification failed");
+
+        assert!(sigs.owner_imc_signatures.is_some());
+        let om_entry = sigs.owner_imc_signatures.as_ref().unwrap();
+        let om_ecc = ImageEccSignature::try_from_hex(om_entry.ecc_sig.as_ref().unwrap()).unwrap();
+        let om_digest = hex::decode("040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404").unwrap();
+        verify_ecdsa384_signature(&om_digest.try_into().unwrap(), &owner_pub, &om_ecc)
+            .expect("owner_imc_signatures ECC signature verification failed");
+        let om_mldsa_bytes = hex::decode(om_entry.pqc_sig.as_ref().unwrap()).unwrap();
+        let om_mldsa_sig = ImageMldsaSignature::ref_from_bytes(&om_mldsa_bytes).unwrap();
+        verify_mldsa_signature(&[0u8], &mldsa_pub_key, om_mldsa_sig)
+            .expect("owner_imc_signatures MLDSA signature verification failed");
+    }
+}

--- a/tools/fw-signer/src/main.rs
+++ b/tools/fw-signer/src/main.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::{Context, Result};
+use caliptra_mcu_fw_signer::{generate_offline_signatures, KeyManifest};
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Command line arguments for `fw-signer`.
+#[derive(Parser, Debug)]
+#[command(
+    name = "fw-signer",
+    about = "Generate signatures.json from signing_request.json using a key manifest for Caliptra auth manifests"
+)]
+pub struct Args {
+    /// Path to input signing_request.json file.
+    #[arg(short = 'r', long)]
+    pub signing_request: PathBuf,
+
+    /// Path to JSON key manifest file specifying key paths or OpenSSL provider key names.
+    #[arg(short = 'k', long)]
+    pub key_manifest: PathBuf,
+
+    /// Optional OpenSSL 3 provider name to load for cryptographic signing (e.g., "pkcs11", "default", "fips").
+    #[arg(long)]
+    pub openssl_provider: Option<String>,
+
+    /// Path to output signatures.json file.
+    #[arg(short = 'o', long)]
+    pub output: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if let Some(provider_name) = &args.openssl_provider {
+        openssl::provider::Provider::load(None, provider_name)
+            .with_context(|| format!("Failed to load OpenSSL provider '{}'", provider_name))?;
+    }
+
+    let manifest_content = std::fs::read_to_string(&args.key_manifest).with_context(|| {
+        format!(
+            "Failed to read key manifest file {}",
+            args.key_manifest.display()
+        )
+    })?;
+    let key_manifest: KeyManifest = serde_json::from_str(&manifest_content).with_context(|| {
+        format!(
+            "Failed to parse JSON key manifest {}",
+            args.key_manifest.display()
+        )
+    })?;
+
+    let sigs = generate_offline_signatures(&args.signing_request, &key_manifest, &args.output)?;
+    println!(
+        "Successfully generated offline signatures at {}",
+        args.output.display()
+    );
+    let _ = sigs;
+    Ok(())
+}


### PR DESCRIPTION
  This PR introduces the offline firmware signing tool and library (caliptra-mcu-fw-signer) and updates signature validation logic in caliptra-mcu-builder.
  ──────
  ## Key Changes

  ### 1. Signature Validation Enforcement (caliptra-mcu-builder)

  • Mandatory Signature Validation: Enforces that owner_pub_keys_signatures and owner_imc_signatures are strictly present in signatures.json during attach_auth_manifest_signatures.
  • Vendor Signature Requirement: Enforces that vendor_imc_signatures is required whenever the VENDOR_SIGNATURE_REQUIRED flag is set in the manifest preamble.
  • Strict PQC Validation: Bails if a specified PQC algorithm type is unsupported or if mandatory keys/signatures are missing (prohibiting all-zero dummy signatures).
  • Parser Refactoring: Refactored signature byte parsing to use ImageEccSignature::try_from_hex and ImagePqcSignature::try_from_hex.

  ### 2. Standalone Offline Signer Tool (tools/fw-signer/)

  • New Crate & Binary (fw-signer): Added caliptra-mcu-fw-signer in tools/fw-signer/, providing a CLI binary (fw-signer) and library.
  • Key Manifest Schema (key_manifest.json): Configures signing keys for all four authorization manifest components (vendor_fw, owner_fw, vendor_man, owner_man). Accepts local PEM file paths or PKCS#11 URIs / HSM key labels via OpenSSL 3 providers.
  • Algorithm Support: Supports ECC P-384 (ECDSA), LMS (RFC 8554), and ML-DSA-87 (FIPS 204).
  • HSM / OpenSSL Provider Integration: Accepts --openssl-provider <NAME> (e.g., pkcs11, fips) to enable hardware-backed signing.
  • Documentation: Includes a comprehensive user guide in tools/fw-signer/README.md covering CLI options, manifest JSON schemas, and end-to-end cargo xtask workflows.