### PR TITLE
Adding support for the MCTP Get Endpoint UUID message.

### DIFF
--- a/common/testing/src/mctp_util/ctrl_protocol.rs
+++ b/common/testing/src/mctp_util/ctrl_protocol.rs
@@ -41,6 +41,13 @@ pub fn get_eid_resp_bytes(cc: CmdCompletionCode, eid: u8) -> Vec<u8> {
     resp_bytes.to_vec()
 }
 
+pub fn get_endpoint_uuid_resp_bytes(cc: CmdCompletionCode, uuid: &[u8; 16]) -> Vec<u8> {
+    let mut resp_bytes = Vec::with_capacity(17);
+    resp_bytes.push(cc as u8);
+    resp_bytes.extend_from_slice(uuid);
+    resp_bytes
+}
+
 pub fn get_version_support_resp_bytes(cc: u8, entries: Option<&[VersionEntry]>) -> Vec<u8> {
     let entry_count = entries.map_or(0, |entries| entries.len());
     let mut resp_bytes = vec![0; 2 + entry_count * 4];
@@ -109,6 +116,7 @@ impl MCTPCtrlMsgHdr<[u8; MCTP_CTRL_MSG_HDR_SIZE]> {
 pub enum MCTPCtrlCmd {
     SetEID = 1,
     GetEID = 2,
+    GetEndpointUUID = 3,
     GetMctpVersionSupport = 4,
     GetMsgTypeSupport = 5,
     GetVendorDefinedMsgSupport = 6,
@@ -121,6 +129,7 @@ impl TryFrom<u8> for MCTPCtrlCmd {
         Ok(match val {
             1 => Self::SetEID,
             2 => Self::GetEID,
+            3 => Self::GetEndpointUUID,
             4 => Self::GetMctpVersionSupport,
             5 => Self::GetMsgTypeSupport,
             6 => Self::GetVendorDefinedMsgSupport,

--- a/docs/src/mctp.md
+++ b/docs/src/mctp.md
@@ -8,6 +8,33 @@ Caliptra MCTP endpoint has only one EID and supports dynamic assignment by the M
 MCTP Packets are delivered over physical I3C medium using I3C transfers. Caliptra MCTP endpoint always plays the role of I3C Target and is
 managed by an external I3C controller. Minimum transmission size is based on the MCTP baseline MTU (for I3C it is 69 bytes: 64 bytes MCTP payload + 4 bytes MCTP header + 1 byte PEC). Larger than the baseline transfer may be possible after discovery and negotiation with the I3C controller. The negotiated MTU size will be queried from the I3C Target peripheral driver by MCTP capsule.
 
+## MCTP Control Messages
+
+The MCTP capsule handles the following MCTP Control Protocol commands:
+
+| Command | Command code |
+| --- | ---: |
+| Set Endpoint ID | `0x01` |
+| Get Endpoint ID | `0x02` |
+| Get Endpoint UUID | `0x03` |
+| Get MCTP Version Support | `0x04` |
+| Get Message Type Support | `0x05` |
+| Get Vendor Defined Message Support | `0x06` |
+
+### Get Endpoint UUID
+
+Get Endpoint UUID has no request data. A successful response contains a completion code of `0x00`, followed by the endpoint's 16-byte UUID. The UUID bytes are returned in the same order in which the board supplies them to the MCTP component.
+
+The board configures the endpoint UUID when it initializes the MCTP mux:
+
+```rust
+let mux_mctp = MCTPMuxComponent::new(i3c_target, mux_alarm)
+    .with_uuid(endpoint_uuid)
+    .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
+```
+
+`endpoint_uuid` must be a stable, platform-specific `[u8; 16]` value. If `with_uuid` is omitted, the component reports the nil UUID (`00000000-0000-0000-0000-000000000000`).
+
 
 ## MCTP Send Sequence
 

--- a/docs/src/mctp.md
+++ b/docs/src/mctp.md
@@ -8,6 +8,33 @@ Caliptra MCTP endpoint has only one EID and supports dynamic assignment by the M
 MCTP Packets are delivered over physical I3C medium using I3C transfers. Caliptra MCTP endpoint always plays the role of I3C Target and is
 managed by an external I3C controller. Minimum transmission size is based on the MCTP baseline MTU (for I3C it is 69 bytes: 64 bytes MCTP payload + 4 bytes MCTP header + 1 byte PEC). Larger than the baseline transfer may be possible after discovery and negotiation with the I3C controller. The negotiated MTU size will be queried from the I3C Target peripheral driver by MCTP capsule.
 
+## MCTP Control Messages
+
+The MCTP capsule handles the following MCTP Control Protocol commands:
+
+| Command | Command code |
+| --- | ---: |
+| Set Endpoint ID | `0x01` |
+| Get Endpoint ID | `0x02` |
+| Get Endpoint UUID | `0x03` |
+| Get MCTP Version Support | `0x04` |
+| Get Message Type Support | `0x05` |
+| Get Vendor Defined Message Support | `0x06` |
+
+### Get Endpoint UUID
+
+Get Endpoint UUID has no request data. A successful response contains a completion code of `0x00`, followed by the endpoint's 16-byte UUID. The UUID bytes are returned in the same order in which the board supplies them to the MCTP component.
+
+The board configures the endpoint UUID when it initializes the MCTP mux:
+
+```rust
+let mux_mctp = MCTPMuxComponent::new(i3c_target, mux_alarm)
+    .with_uuid(endpoint_uuid)
+    .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
+```
+
+Runtime reads `endpoint_uuid` directly from the IDevID UEID manufacturer serial number in OTP.
+
 
 ## MCTP Send Sequence
 

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -891,6 +891,9 @@ impl Emulator {
                 soc_manifest_max_svn: cli.fuse_soc_manifest_max_svn.map(|v| v as u8),
                 vendor_hashes_prod_partition: fuse_vendor_hashes_prod_partition,
                 vendor_test_partition: fuse_vendor_test_partition,
+                idevid_manufacturer_serial_number: Some(
+                    caliptra_mcu_config_emulator::EMULATOR_UEID_SERIAL_NUMBER,
+                ),
                 lifecycle_state: lifecycle_fuse_data,
                 ..Default::default()
             },

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -882,6 +882,9 @@ impl Emulator {
                 soc_manifest_max_svn: cli.fuse_soc_manifest_max_svn.map(|v| v as u8),
                 vendor_hashes_prod_partition: fuse_vendor_hashes_prod_partition,
                 vendor_test_partition: fuse_vendor_test_partition,
+                idevid_manufacturer_serial_number: Some(
+                    caliptra_mcu_config_emulator::EMULATOR_UEID_SERIAL_NUMBER,
+                ),
                 lifecycle_state: lifecycle_fuse_data,
                 ..Default::default()
             },

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -30,6 +30,7 @@ pub(crate) enum MCTPCtrlCmdTests {
     SetEIDBroadcastFail,
     SetEIDInvalidFail,
     GetEID,
+    GetEndpointUUID,
     GetMctpVersionSupportMctpBase,
     GetMctpVersionSupportMctpControlProtocol,
     GetMctpVersionSupportPldm,
@@ -74,6 +75,9 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::SetEIDBroadcastFail => set_eid_req_bytes(SetEIDOp::SetEID, 0xFF),
             MCTPCtrlCmdTests::SetEIDInvalidFail => set_eid_req_bytes(SetEIDOp::SetEID, 0x1),
             MCTPCtrlCmdTests::GetEID => {
+                vec![]
+            }
+            MCTPCtrlCmdTests::GetEndpointUUID => {
                 vec![]
             }
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase => {
@@ -154,6 +158,10 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::GetEID => {
                 get_eid_resp_bytes(CmdCompletionCode::Success, TEST_TARGET_EID + 1)
             }
+            MCTPCtrlCmdTests::GetEndpointUUID => get_endpoint_uuid_resp_bytes(
+                CmdCompletionCode::Success,
+                &caliptra_mcu_config_emulator::EMULATOR_UEID_SERIAL_NUMBER,
+            ),
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol => {
                 // Backward compatibility with MCTP base/control protocol 1.0, 1.1, and 1.2.
@@ -236,6 +244,7 @@ impl MCTPCtrlCmdTests {
             | MCTPCtrlCmdTests::SetEIDBroadcastFail
             | MCTPCtrlCmdTests::SetEIDInvalidFail => MCTPCtrlCmd::SetEID as u8,
             MCTPCtrlCmdTests::GetEID => MCTPCtrlCmd::GetEID as u8,
+            MCTPCtrlCmdTests::GetEndpointUUID => MCTPCtrlCmd::GetEndpointUUID as u8,
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol
             | MCTPCtrlCmdTests::GetMctpVersionSupportPldm

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -30,6 +30,7 @@ pub(crate) enum MCTPCtrlCmdTests {
     SetEIDBroadcastFail,
     SetEIDInvalidFail,
     GetEID,
+    GetEndpointUUID,
     GetMctpVersionSupportMctpBase,
     GetMctpVersionSupportMctpControlProtocol,
     GetMctpVersionSupportPldm,
@@ -74,6 +75,9 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::SetEIDBroadcastFail => set_eid_req_bytes(SetEIDOp::SetEID, 0xFF),
             MCTPCtrlCmdTests::SetEIDInvalidFail => set_eid_req_bytes(SetEIDOp::SetEID, 0x1),
             MCTPCtrlCmdTests::GetEID => {
+                vec![]
+            }
+            MCTPCtrlCmdTests::GetEndpointUUID => {
                 vec![]
             }
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase => {
@@ -153,6 +157,9 @@ impl MCTPCtrlCmdTests {
             ),
             MCTPCtrlCmdTests::GetEID => {
                 get_eid_resp_bytes(CmdCompletionCode::Success, TEST_TARGET_EID + 1)
+            }
+            MCTPCtrlCmdTests::GetEndpointUUID => {
+                get_endpoint_uuid_resp_bytes(CmdCompletionCode::Success, &[0; 16])
             }
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol => {
@@ -236,6 +243,7 @@ impl MCTPCtrlCmdTests {
             | MCTPCtrlCmdTests::SetEIDBroadcastFail
             | MCTPCtrlCmdTests::SetEIDInvalidFail => MCTPCtrlCmd::SetEID as u8,
             MCTPCtrlCmdTests::GetEID => MCTPCtrlCmd::GetEID as u8,
+            MCTPCtrlCmdTests::GetEndpointUUID => MCTPCtrlCmd::GetEndpointUUID as u8,
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol
             | MCTPCtrlCmdTests::GetMctpVersionSupportPldm

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -158,9 +158,10 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::GetEID => {
                 get_eid_resp_bytes(CmdCompletionCode::Success, TEST_TARGET_EID + 1)
             }
-            MCTPCtrlCmdTests::GetEndpointUUID => {
-                get_endpoint_uuid_resp_bytes(CmdCompletionCode::Success, &[0; 16])
-            }
+            MCTPCtrlCmdTests::GetEndpointUUID => get_endpoint_uuid_resp_bytes(
+                CmdCompletionCode::Success,
+                &caliptra_mcu_config_emulator::EMULATOR_UEID_SERIAL_NUMBER,
+            ),
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol => {
                 // Backward compatibility with MCTP base/control protocol 1.0, 1.1, and 1.2.

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -59,6 +59,7 @@ pub struct OtpArgs {
     pub soc_manifest_max_svn: Option<u8>,
     pub vendor_hashes_prod_partition: Option<Vec<u8>>,
     pub vendor_test_partition: Option<Vec<u8>>,
+    pub idevid_manufacturer_serial_number: Option<[u8; 16]>,
     /// Raw lifecycle partition data (LIFECYCLE_MEM_SIZE bytes) to provision.
     /// If set, written to the LIFE_CYCLE partition in OTP.
     pub lifecycle_state: Option<Vec<u8>>,
@@ -204,6 +205,16 @@ impl Otp {
         }
         {
             let mut partitions = otp.partitions.borrow_mut();
+            if let Some(serial_number) = args.idevid_manufacturer_serial_number {
+                const MANUFACTURER_SERIAL_NUMBER_OFFSET: usize = 12 * size_of::<u32>();
+                let start = fuses::OTP_CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR.byte_offset
+                    + MANUFACTURER_SERIAL_NUMBER_OFFSET;
+                let end = start + serial_number.len();
+                if partitions[start..end].iter().all(|&byte| byte == 0) {
+                    partitions[start..end].copy_from_slice(&serial_number);
+                }
+            }
+
             partitions[fuses::SVN_PARTITION_BYTE_OFFSET + 36] =
                 args.soc_manifest_max_svn.unwrap_or(0);
             if let Some(soc_manifest_svn) = args.soc_manifest_svn {
@@ -945,6 +956,38 @@ mod test {
         otp.write_check_trigger_regwen(0u32.into());
         // block read access to the SW managed partitions
         otp.write_vendor_test_partition_read_lock(0u32.into());
+    }
+
+    #[test]
+    fn test_idevid_manufacturer_serial_number_provisioning() {
+        const SERIAL_NUMBER_OFFSET: usize = 12 * size_of::<u32>();
+        let start =
+            fuses::OTP_CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR.byte_offset + SERIAL_NUMBER_OFFSET;
+        let serial_number = [0xA5; 16];
+
+        let clock = Clock::new();
+        let otp = Otp::new(
+            &clock,
+            OtpArgs {
+                idevid_manufacturer_serial_number: Some(serial_number),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(&otp.partitions.borrow()[start..start + 16], &serial_number);
+
+        let mut raw_memory = vec![0u8; TOTAL_SIZE];
+        raw_memory[start..start + 16].fill(0x5A);
+        let otp = Otp::new(
+            &clock,
+            OtpArgs {
+                raw_memory: Some(raw_memory),
+                idevid_manufacturer_serial_number: Some(serial_number),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(&otp.partitions.borrow()[start..start + 16], &[0x5A; 16]);
     }
 
     #[test]

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -61,6 +61,11 @@ pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
 
 const ACTIVE_I3C: u8 = if cfg!(feature = "active-i3c1") { 1 } else { 0 };
 
+// A nonzero manufacturer serial number provisioned into the emulator's UEID fuse.
+pub const EMULATOR_UEID_SERIAL_NUMBER: [u8; 16] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+];
+
 pub const EMULATOR_MCU_STRAPS: McuStraps = McuStraps {
     active_i3c: ACTIVE_I3C,
     ..McuStraps::default()

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -561,6 +561,10 @@ pub unsafe fn main() {
         VeeRDefaultPeripherals,
         VeeRDefaultPeripherals::new(emulator_peripherals, mux_alarm, &MCU_MEMORY_MAP, mci_regs)
     );
+    let mctp_endpoint_uuid = peripherals
+        .otp
+        .read_idevid_manufacturer_serial_number()
+        .unwrap_or_else(|err| panic!("failed to read MCTP endpoint UUID from OTP: {:?}", err));
 
     let mci = caliptra_mcu_components::mci::MciComponent::new(
         board_kernel,
@@ -681,6 +685,7 @@ pub unsafe fn main() {
     );
     let mux_mctp =
         caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(active_i3c_core, mux_alarm)
+            .with_uuid(mctp_endpoint_uuid)
             .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
 
     let mctp_spdm = caliptra_mcu_components::mctp_driver::MCTPDriverComponent::new(

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -651,6 +651,24 @@ pub unsafe fn main() {
         VeeRDefaultPeripherals::new(emulator_peripherals, mux_alarm, &MCU_MEMORY_MAP, mci_regs)
     );
 
+    #[cfg(any(
+        feature = "spdm",
+        feature = "streaming-boot",
+        feature = "firmware-update",
+        feature = "mctp-vdm-service",
+        feature = "test-mctp-capsule-loopback"
+    ))]
+    // Read directly from OTP so endpoint identity does not depend on the ROM ABI.
+    let mctp_endpoint_uuid = match peripherals.otp.read_idevid_manufacturer_serial_number() {
+        Ok(uuid) => uuid,
+        Err(err) => {
+            caliptra_mcu_romtime::println!(
+                "[mcu-runtime] UUID missing or invalid in OTP ({err:?}), using zero UUID"
+            );
+            [0; 16]
+        }
+    };
+
     let mci = caliptra_mcu_components::mci::MciComponent::new(
         board_kernel,
         caliptra_mcu_capsules_runtime::mci::DRIVER_NUM,
@@ -776,6 +794,7 @@ pub unsafe fn main() {
             MCU_STRAPS.active_i3c
         );
         caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(active_i3c_core, mux_alarm)
+            .with_uuid(mctp_endpoint_uuid)
             .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding))
     };
 

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -397,6 +397,7 @@ pub unsafe fn main() {
     }
 
     print_to_console("[mcu-runtime] Hello from MCU runtime\n");
+
     // only machine mode
     rv32i::configure_trap_handler();
 
@@ -595,6 +596,24 @@ pub unsafe fn main() {
     );
     caliptra_mcu_romtime::println!("[mcu-runtime] Peripherals created");
 
+    #[cfg(any(
+        feature = "spdm",
+        feature = "streaming-boot",
+        feature = "firmware-update",
+        feature = "mctp-vdm-service",
+        feature = "test-mctp-capsule-loopback"
+    ))]
+    // Read directly from OTP so endpoint identity does not depend on the ROM ABI.
+    let mctp_endpoint_uuid = match peripherals.otp.read_idevid_manufacturer_serial_number() {
+        Ok(uuid) => uuid,
+        Err(err) => {
+            caliptra_mcu_romtime::println!(
+                "[mcu-runtime] UUID missing or invalid in OTP ({err:?}), using zero UUID"
+            );
+            [0; 16]
+        }
+    };
+
     let chip = static_init!(
         VeeRChip,
         caliptra_mcu_tock_veer::chip::VeeR::new(peripherals, epmp)
@@ -691,6 +710,7 @@ pub unsafe fn main() {
             MCU_STRAPS.active_i3c
         );
         caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(active_i3c_core, mux_alarm)
+            .with_uuid(mctp_endpoint_uuid)
             .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding))
     };
     #[cfg(any(
@@ -1054,6 +1074,7 @@ pub unsafe fn main() {
     // compilation entirely when their feature is off.
     #[allow(unused_mut, unused_assignments)]
     let mut exit: Option<u32> = None;
+
     #[cfg(feature = "test-exit-immediately")]
     {
         caliptra_mcu_romtime::println!("Executing test-exit-immediately");

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -542,6 +542,10 @@ pub unsafe fn main() {
         VeeRDefaultPeripherals,
         VeeRDefaultPeripherals::new(fpga_peripherals, mux_alarm, &MCU_MEMORY_MAP, mci_regs)
     );
+    let mctp_endpoint_uuid = peripherals
+        .otp
+        .read_idevid_manufacturer_serial_number()
+        .unwrap_or_else(|err| panic!("failed to read MCTP endpoint UUID from OTP: {:?}", err));
     caliptra_mcu_romtime::println!("[mcu-runtime] Peripherals created");
 
     let chip = static_init!(
@@ -634,6 +638,7 @@ pub unsafe fn main() {
     );
     let mux_mctp =
         caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(active_i3c_core, mux_alarm)
+            .with_uuid(mctp_endpoint_uuid)
             .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
     caliptra_mcu_romtime::println!("[mcu-runtime] MCTP mux initialized");
 

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -366,6 +366,21 @@ impl Otp {
         self.read_data(byte_offset, data.len(), data)
     }
 
+    /// Reads the 16-byte manufacturer serial number from the IDevID UEID fuse.
+    pub fn read_idevid_manufacturer_serial_number(&self) -> McuResult<[u8; 16]> {
+        const MANUFACTURER_SERIAL_NUMBER_OFFSET: usize = 12 * size_of::<u32>();
+        let mut serial_number = [0u8; 16];
+        self.read_otp_data(
+            fuses::OTP_CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR.byte_offset
+                + MANUFACTURER_SERIAL_NUMBER_OFFSET,
+            &mut serial_number,
+        )?;
+        if serial_number.iter().all(|&byte| byte == 0) {
+            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+        }
+        Ok(serial_number)
+    }
+
     /// Reads a u32 from OTP at the given byte offset.
     pub fn read_u32_at(&self, byte_offset: usize) -> McuResult<u32> {
         let mut data = [0u8; 4];

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -366,6 +366,26 @@ impl Otp {
         self.read_data(byte_offset, data.len(), data)
     }
 
+    /// Validates an IDevID manufacturer serial number.
+    fn validate_idevid_manufacturer_serial_number(serial_number: [u8; 16]) -> McuResult<[u8; 16]> {
+        if serial_number.iter().all(|&byte| byte == 0) {
+            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+        }
+        Ok(serial_number)
+    }
+
+    /// Reads the 16-byte manufacturer serial number from the IDevID UEID fuse.
+    pub fn read_idevid_manufacturer_serial_number(&self) -> McuResult<[u8; 16]> {
+        const MANUFACTURER_SERIAL_NUMBER_OFFSET: usize = 12 * size_of::<u32>();
+        let mut serial_number = [0u8; 16];
+        self.read_otp_data(
+            fuses::OTP_CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR.byte_offset
+                + MANUFACTURER_SERIAL_NUMBER_OFFSET,
+            &mut serial_number,
+        )?;
+        Self::validate_idevid_manufacturer_serial_number(serial_number)
+    }
+
     /// Reads a u32 from OTP at the given byte offset.
     pub fn read_u32_at(&self, byte_offset: usize) -> McuResult<u32> {
         let mut data = [0u8; 4];
@@ -1184,5 +1204,23 @@ mod tests {
         assert_eq!(data, ((value >> 32) as u32).to_le_bytes());
         assert_eq!(word_reads, 0);
         assert_eq!(dword_reads, [addr / 8]);
+    }
+
+    #[test]
+    fn test_idevid_manufacturer_serial_number_rejects_zero_values() {
+        let zero_uuid = [0u8; 16];
+        assert!(Otp::validate_idevid_manufacturer_serial_number(zero_uuid).is_err());
+    }
+
+    #[test]
+    fn test_idevid_manufacturer_serial_number_accepts_nonzero_values() {
+        let uuid = [
+            0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab,
+            0xcd, 0xef,
+        ];
+        assert_eq!(
+            Otp::validate_idevid_manufacturer_serial_number(uuid),
+            Ok(uuid)
+        );
     }
 }

--- a/runtime/kernel/capsules/src/mctp/control_msg.rs
+++ b/runtime/kernel/capsules/src/mctp/control_msg.rs
@@ -91,6 +91,7 @@ pub fn process_mctp_control_msg(
     msg_buf: &[u8],
     local_eid: u8,
     supported_msg_types: &[MessageType],
+    uuid: &[u8; 16],
     resp_buf: &mut [u8],
 ) -> Result<MCTPCtrlMsgResp, ErrorCode> {
     if msg_buf.len() < MCTP_CTRL_MSG_HEADER_LEN {
@@ -136,6 +137,9 @@ pub fn process_mctp_control_msg(
                 MCTPCtrlCmd::GetEID => mctp_ctrl_cmd
                     .process_get_endpoint_id(local_eid, rsp_payload)
                     .map(|_| mctp_ctrl_cmd.resp_data_len()),
+                MCTPCtrlCmd::GetEndpointUUID => mctp_ctrl_cmd
+                    .process_get_endpoint_uuid(uuid, rsp_payload)
+                    .map(|_| mctp_ctrl_cmd.resp_data_len()),
                 MCTPCtrlCmd::GetVersionSupport => mctp_ctrl_cmd.process_get_version_support(
                     req_buf,
                     rsp_payload,
@@ -176,6 +180,7 @@ pub fn process_mctp_control_msg(
 pub enum MCTPCtrlCmd {
     SetEID = 1,
     GetEID = 2,
+    GetEndpointUUID = 3,
     GetVersionSupport = 4,
     GetMsgTypeSupport = 5,
     GetVendorDefinedMsgSupport = 6,
@@ -188,6 +193,7 @@ impl TryFrom<u8> for MCTPCtrlCmd {
         Ok(match val {
             1 => Self::SetEID,
             2 => Self::GetEID,
+            3 => Self::GetEndpointUUID,
             4 => Self::GetVersionSupport,
             5 => Self::GetMsgTypeSupport,
             6 => Self::GetVendorDefinedMsgSupport,
@@ -201,6 +207,7 @@ impl MCTPCtrlCmd {
         match self {
             MCTPCtrlCmd::SetEID => 2,
             MCTPCtrlCmd::GetEID => 0,
+            MCTPCtrlCmd::GetEndpointUUID => 0,
             MCTPCtrlCmd::GetVersionSupport => 1,
             MCTPCtrlCmd::GetMsgTypeSupport => 0,
             MCTPCtrlCmd::GetVendorDefinedMsgSupport => 1,
@@ -211,6 +218,7 @@ impl MCTPCtrlCmd {
         match self {
             MCTPCtrlCmd::SetEID => 4,
             MCTPCtrlCmd::GetEID => 4,
+            MCTPCtrlCmd::GetEndpointUUID => 17,
             MCTPCtrlCmd::GetVersionSupport => 18, // 2 bytes header + 4 entries * 4 bytes each
             MCTPCtrlCmd::GetMsgTypeSupport => 2 + MCTP_NUM_MSG_TYPES_SUPPORTED, // 1 byte for completion code + 1 byte for count + supported message types
             MCTPCtrlCmd::GetVendorDefinedMsgSupport => {
@@ -282,6 +290,20 @@ impl MCTPCtrlCmd {
 
         resp.write_to(&mut rsp_buf[..self.resp_data_len()])
             .map_err(|_| ErrorCode::FAIL)
+    }
+
+    pub fn process_get_endpoint_uuid(
+        &self,
+        uuid: &[u8; 16],
+        rsp_buf: &mut [u8],
+    ) -> Result<(), ErrorCode> {
+        if rsp_buf.len() < self.resp_data_len() {
+            return Err(ErrorCode::NOMEM);
+        }
+
+        rsp_buf[0] = CmdCompletionCode::Success as u8;
+        rsp_buf[1..self.resp_data_len()].copy_from_slice(uuid);
+        Ok(())
     }
 
     pub fn process_get_version_support(
@@ -665,6 +687,45 @@ mod tests {
     }
 
     #[test]
+    fn test_get_endpoint_uuid() {
+        let uuid = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+            0x0F, 0x10,
+        ];
+        let rsp_buf = &mut [0; 17];
+
+        MCTPCtrlCmd::GetEndpointUUID
+            .process_get_endpoint_uuid(&uuid, rsp_buf)
+            .unwrap();
+
+        assert_eq!(rsp_buf[0], CmdCompletionCode::Success as u8);
+        assert_eq!(&rsp_buf[1..], &uuid);
+    }
+
+    #[test]
+    fn test_process_mctp_control_msg_get_endpoint_uuid() {
+        let mut msg_req = [0; MCTP_CTRL_MSG_HEADER_LEN];
+        let mut msg_hdr = MCTPCtrlMsgHdr::new();
+        msg_hdr.prepare_header(1, 0, 0, MCTPCtrlCmd::GetEndpointUUID as u8);
+        msg_hdr.write_to_buf(&mut msg_req).unwrap();
+
+        let uuid = [
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD,
+            0xAE, 0xAF,
+        ];
+        let rsp_buf = &mut [0; MCTP_CTRL_MSG_HEADER_LEN + 17];
+        let resp = process_mctp_control_msg(&msg_req, 0x0A, &[], &uuid, rsp_buf).unwrap();
+
+        assert_eq!(resp.assigned_eid, None);
+        assert_eq!(resp.resp_len, MCTP_CTRL_MSG_HEADER_LEN + 17);
+        assert_eq!(
+            rsp_buf[MCTP_CTRL_MSG_HEADER_LEN],
+            CmdCompletionCode::Success as u8
+        );
+        assert_eq!(&rsp_buf[MCTP_CTRL_MSG_HEADER_LEN + 1..], &uuid);
+    }
+
+    #[test]
     fn test_process_mctp_control_msg_returns_assigned_eid() {
         let mut msg_req = [0; MCTP_CTRL_MSG_HEADER_LEN + 2];
         let mut msg_hdr = MCTPCtrlMsgHdr::new();
@@ -675,7 +736,7 @@ mod tests {
         msg_req[MCTP_CTRL_MSG_HEADER_LEN..].copy_from_slice(&[0x00, 0x0A]);
 
         let rsp_buf = &mut [0; MCTP_CTRL_MSG_HEADER_LEN + 4];
-        let resp = process_mctp_control_msg(&msg_req, 0, &[], rsp_buf).unwrap();
+        let resp = process_mctp_control_msg(&msg_req, 0, &[], &[0; 16], rsp_buf).unwrap();
 
         assert_eq!(resp.assigned_eid, Some(0x0A));
         assert_eq!(resp.resp_len, MCTP_CTRL_MSG_HEADER_LEN + 4);
@@ -700,7 +761,8 @@ mod tests {
 
         let rsp_buf = &mut [0xA5; MCTP_CTRL_MSG_HEADER_LEN + 9];
         let resp =
-            process_mctp_control_msg(&msg_req, 0, &[MessageType::Caliptra], rsp_buf).unwrap();
+            process_mctp_control_msg(&msg_req, 0, &[MessageType::Caliptra], &[0; 16], rsp_buf)
+                .unwrap();
 
         let mut hdr = [0; 4];
         hdr[..MCTP_CTRL_MSG_HEADER_LEN].copy_from_slice(&rsp_buf[..MCTP_CTRL_MSG_HEADER_LEN]);
@@ -741,7 +803,7 @@ mod tests {
             .unwrap();
 
         let rsp_buf = &mut [0xA5; MCTP_CTRL_MSG_HEADER_LEN + 1];
-        let resp = process_mctp_control_msg(&msg_req, 0, &[], rsp_buf).unwrap();
+        let resp = process_mctp_control_msg(&msg_req, 0, &[], &[0; 16], rsp_buf).unwrap();
 
         let mut hdr = [0; 4];
         hdr[..MCTP_CTRL_MSG_HEADER_LEN].copy_from_slice(&rsp_buf[..MCTP_CTRL_MSG_HEADER_LEN]);

--- a/runtime/kernel/capsules/src/mctp/mux.rs
+++ b/runtime/kernel/capsules/src/mctp/mux.rs
@@ -29,6 +29,7 @@ pub struct MuxMCTPDriver<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> {
     mctp_device: &'a dyn MCTPTransportBinding<'a>,
     next_msg_tag: Cell<u8>, //global msg tag. increment by 1 for next tag upto 7 and wrap around.
     local_eid: Cell<u8>,
+    uuid: [u8; 16],
     mtu: Cell<usize>,
     // List of outstanding send requests
     sender_list: List<'a, MCTPTxState<'a, A, M>>,
@@ -43,6 +44,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
     pub fn new(
         mctp_device: &'a dyn MCTPTransportBinding<'a>,
         local_eid: u8,
+        uuid: [u8; 16],
         mtu: usize,
         tx_pkt_buf: &'static mut [u8],
         rx_pkt_buf: &'static mut [u8],
@@ -52,6 +54,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
             mctp_device,
             next_msg_tag: Cell::new(0),
             local_eid: Cell::new(local_eid),
+            uuid,
             mtu: Cell::new(mtu),
             sender_list: List::new(),
             receiver_list: List::new(),
@@ -172,6 +175,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
                     msg_buf,
                     self.get_local_eid(),
                     advertised_msg_types,
+                    &self.uuid,
                     &mut resp_buf[mctp_ctrl_hdr_start..],
                 );
 

--- a/runtime/kernel/components/src/mux_mctp.rs
+++ b/runtime/kernel/components/src/mux_mctp.rs
@@ -56,6 +56,7 @@ macro_rules! mctp_mux_component_static {
 pub struct MCTPMuxComponent<A: Alarm<'static> + 'static> {
     i3c_target: &'static dyn caliptra_mcu_i3c_driver::hil::I3CTarget<'static>,
     mux_alarm: &'static MuxAlarm<'static, A>,
+    uuid: [u8; 16],
 }
 
 impl<A: Alarm<'static>> MCTPMuxComponent<A> {
@@ -66,7 +67,13 @@ impl<A: Alarm<'static>> MCTPMuxComponent<A> {
         Self {
             i3c_target,
             mux_alarm,
+            uuid: [0; 16],
         }
+    }
+
+    pub fn with_uuid(mut self, uuid: [u8; 16]) -> Self {
+        self.uuid = uuid;
+        self
     }
 }
 
@@ -100,6 +107,7 @@ impl<A: Alarm<'static>> Component for MCTPMuxComponent<A> {
         let mux_mctp_driver = static_buffer.4.write(MuxMCTPDriver::new(
             mctp_device,
             local_eid,
+            self.uuid,
             mtu,
             tx_pkt_buffer,
             rx_pkt_buffer,

--- a/runtime/kernel/components/src/mux_mctp.rs
+++ b/runtime/kernel/components/src/mux_mctp.rs
@@ -13,6 +13,7 @@
 //! let mux_mctp = caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(
 //!    i3c,
 //!    mux_alarm)
+//! .with_uuid(endpoint_uuid)
 //! .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
 //! ```
 //!
@@ -56,6 +57,7 @@ macro_rules! mctp_mux_component_static {
 pub struct MCTPMuxComponent<A: Alarm<'static> + 'static> {
     i3c_target: &'static dyn caliptra_mcu_i3c_driver::hil::I3CTarget<'static>,
     mux_alarm: &'static MuxAlarm<'static, A>,
+    uuid: [u8; 16],
 }
 
 impl<A: Alarm<'static>> MCTPMuxComponent<A> {
@@ -66,7 +68,13 @@ impl<A: Alarm<'static>> MCTPMuxComponent<A> {
         Self {
             i3c_target,
             mux_alarm,
+            uuid: [0; 16],
         }
+    }
+
+    pub fn with_uuid(mut self, uuid: [u8; 16]) -> Self {
+        self.uuid = uuid;
+        self
     }
 }
 
@@ -100,6 +108,7 @@ impl<A: Alarm<'static>> Component for MCTPMuxComponent<A> {
         let mux_mctp_driver = static_buffer.4.write(MuxMCTPDriver::new(
             mctp_device,
             local_eid,
+            self.uuid,
             mtu,
             tx_pkt_buffer,
             rx_pkt_buffer,

--- a/runtime/kernel/components/src/mux_mctp.rs
+++ b/runtime/kernel/components/src/mux_mctp.rs
@@ -13,6 +13,7 @@
 //! let mux_mctp = caliptra_mcu_components::mux_mctp::MCTPMuxComponent::new(
 //!    i3c,
 //!    mux_alarm)
+//! .with_uuid(endpoint_uuid)
 //! .finalize(mctp_mux_component_static!(InternalTimers, MCTPI3CBinding));
 //! ```
 //!


### PR DESCRIPTION
As per task [1849](https://github.com/chipsalliance/caliptra-mcu-sw/issues/1849) adding support for the MCTP Get Endpoint UUID message. 