### PR TITLE
common-commands: share authorized fuse operations across transports

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -9,13 +9,14 @@ use caliptra_mcu_common_commands::{
 use caliptra_mcu_libapi_caliptra::crypto::hash::{HashAlgoType, HashContext};
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
-use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libsyscall_caliptra::otp::{Otp, RevokeVendorPubKeyType};
+use caliptra_mcu_libsyscall_caliptra::{caliptra, otp, DefaultSyscalls};
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use mcu_caliptra_api_lite::{
-    fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
+    fe_prog, fw_info, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
     request_debug_unlock_challenge, ApiAlloc, McuErrorCode, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD,
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
@@ -237,6 +238,121 @@ pub async fn verify_authorized_signatures(
     .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
 
     Ok(())
+}
+
+pub fn provision_vendor_pk_hash(slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+    Otp::<DefaultSyscalls>::new()
+        .provision_vendor_pk_hash(slot, hash)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)
+}
+
+pub async fn increase_caliptra_min_svn<A: ApiAlloc>(alloc: &A, svn: u32) -> CaliptraCmdResult<()> {
+    if svn == 0 || svn > 128 {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
+    let caliptra_fw_info = fw_info(alloc)
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    if svn > caliptra_fw_info.fw_svn {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
+    let otp = Otp::<DefaultSyscalls>::new();
+    let mut current_fuses = [0u32; 4];
+    for (i, fuse) in current_fuses.iter_mut().enumerate() {
+        *fuse = otp
+            .read(otp::reg::CALIPTRA_FW_SVN, i as u32)
+            .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    }
+
+    let fuse = u128::from_le_bytes(current_fuses.as_bytes().try_into().unwrap());
+    let fused_min_svn = 128 - fuse.leading_zeros();
+    if svn < fused_min_svn {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+    if svn == fused_min_svn {
+        return Ok(());
+    }
+
+    let new_fuse_svn = if svn == 128 {
+        u128::MAX
+    } else {
+        !(u128::MAX << svn)
+    };
+    for (i, (current, new_bytes)) in current_fuses
+        .iter()
+        .zip(new_fuse_svn.as_bytes().chunks_exact(4))
+        .enumerate()
+    {
+        let new_svn_word = u32::from_le_bytes(new_bytes.try_into().unwrap());
+        if *current != new_svn_word {
+            otp.write(otp::reg::CALIPTRA_FW_SVN, i as u32, new_svn_word)
+                .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
+    alloc: &A,
+    vendor_pk_hash_slot: u32,
+    key_type: u32,
+    key_index: u32,
+) -> CaliptraCmdResult<()> {
+    let key_type = RevokeVendorPubKeyType::try_from(key_type)
+        .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    let otp = Otp::<DefaultSyscalls>::new();
+    if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
+    let caliptra_info = fw_info(alloc)
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
+        .read_vendor_pk_hash()
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    let pk_hash_from_slot = otp
+        .read_vendor_pk_hash(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+    if booted_pk_hash == pk_hash_from_slot {
+        const FW_VERIFICATION_PQC_TYPE_MLDSA: u32 = 1;
+        const FW_VERIFICATION_PQC_TYPE_LMS: u32 = 3;
+        let same_key = match (key_type, caliptra_info.image_manifest_pqc_type) {
+            (RevokeVendorPubKeyType::Ecdsa384, _) => {
+                key_index == caliptra_info.vendor_ecc384_pub_key_index
+            }
+            (RevokeVendorPubKeyType::Lms, FW_VERIFICATION_PQC_TYPE_LMS)
+            | (RevokeVendorPubKeyType::Mldsa87, FW_VERIFICATION_PQC_TYPE_MLDSA) => {
+                key_index == caliptra_info.vendor_pqc_pub_key_index
+            }
+            _ => false,
+        };
+        if same_key {
+            return Err(CaliptraCompletionCode::InvalidParameter);
+        }
+    }
+
+    otp.revoke_vendor_pub_key(vendor_pk_hash_slot, key_type, key_index)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)
+}
+
+pub fn revoke_vendor_pk_hash(vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+    let otp = Otp::<DefaultSyscalls>::new();
+    let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
+        .read_vendor_pk_hash()
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    let pk_hash_from_slot = otp
+        .read_vendor_pk_hash(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    if booted_pk_hash == pk_hash_from_slot {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
+    otp.revoke_vendor_pk_hash(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)
 }
 
 pub async fn program_field_entropy<A: ApiAlloc>(

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -88,6 +88,32 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         }
     }
 
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        device_ops::provision_vendor_pk_hash(slot, hash)
+    }
+
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        device_ops::increase_caliptra_min_svn(alloc, svn).await
+    }
+
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        device_ops::revoke_vendor_pub_key(alloc, vendor_pk_hash_slot, key_type, key_index).await
+    }
+
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        device_ops::revoke_vendor_pk_hash(vendor_pk_hash_slot)
+    }
+
     async fn program_field_entropy<Alloc: ApiAlloc>(
         &self,
         alloc: &Alloc,

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -202,6 +202,32 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         }
     }
 
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        device_ops::provision_vendor_pk_hash(slot, hash)
+    }
+
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        device_ops::increase_caliptra_min_svn(alloc, svn).await
+    }
+
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        device_ops::revoke_vendor_pub_key(alloc, vendor_pk_hash_slot, key_type, key_index).await
+    }
+
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        device_ops::revoke_vendor_pk_hash(vendor_pk_hash_slot)
+    }
+
     async fn program_field_entropy<Alloc: ApiAlloc>(
         &self,
         alloc: &Alloc,

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -103,6 +103,40 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         CaliptraCmdBackend.clear_log(log_type).await
     }
 
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .provision_vendor_pk_hash(slot, hash)
+            .await
+    }
+
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .increase_caliptra_min_svn(alloc, svn)
+            .await
+    }
+
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .revoke_vendor_pub_key(alloc, vendor_pk_hash_slot, key_type, key_index)
+            .await
+    }
+
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .revoke_vendor_pk_hash(vendor_pk_hash_slot)
+            .await
+    }
+
     async fn program_field_entropy<Alloc: ApiAlloc>(
         &self,
         alloc: &Alloc,

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -1,0 +1,149 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_mcu_common_commands::{
+    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
+    DeviceCapabilities, FirmwareVersion, GetLogResult, MAX_FW_VERSION_LEN,
+};
+use caliptra_mcu_mbox_common::config;
+use mcu_caliptra_api_lite::ApiAlloc;
+
+use crate::caliptra_cmd_handler::CaliptraCmdBackend;
+
+// TODO: Remove this mock and use CaliptraCmdBackend directly.
+#[derive(Default)]
+pub struct NonCryptoCmdHandlerMock;
+
+/// Mock implementation of the `CaliptraCmdHandler` trait.
+///
+/// This handler provides mock responses for firmware version queries
+/// and device capabilities. Intended to use for
+/// integration testing on the emulator platform.
+impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
+    async fn get_firmware_version(
+        &self,
+        index: u32,
+        version: &mut FirmwareVersion,
+    ) -> CaliptraCmdResult<()> {
+        let s = match index {
+            0 => config::TEST_FIRMWARE_VERSIONS[0],
+            1 => config::TEST_FIRMWARE_VERSIONS[1],
+            2 => config::TEST_FIRMWARE_VERSIONS[2],
+            _ => return Err(CaliptraCompletionCode::InvalidParameter),
+        };
+
+        let bytes = s.as_bytes();
+        if bytes.len() > MAX_FW_VERSION_LEN {
+            return Err(CaliptraCompletionCode::InvalidPayloadSize);
+        }
+        let len = bytes.len().min(version.ver_str.len());
+        version.ver_str[..len].copy_from_slice(&bytes[..len]);
+        version.len = len;
+        Ok(())
+    }
+
+    async fn get_device_capabilities(
+        &self,
+        capabilities: &mut DeviceCapabilities,
+    ) -> CaliptraCmdResult<()> {
+        let test_capabilities = &config::TEST_DEVICE_CAPABILITIES;
+        capabilities.caliptra_rt = test_capabilities.caliptra_rt;
+        capabilities.caliptra_fmc = test_capabilities.caliptra_fmc;
+        capabilities.caliptra_rom = test_capabilities.caliptra_rom;
+        capabilities.mcu_rt = test_capabilities.mcu_rt;
+        capabilities.mcu_rom = test_capabilities.mcu_rom;
+        capabilities.reserved = test_capabilities.reserved;
+        Ok(())
+    }
+
+    async fn export_attested_csr<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        device_key_id: u32,
+        algorithm: u32,
+        nonce: &[u8; 32],
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        // Delegate to real CaliptraCmdBackend for actual Caliptra mailbox interaction
+        let handler = CaliptraCmdBackend;
+        handler
+            .export_attested_csr(alloc, device_key_id, algorithm, nonce, csr_buf)
+            .await
+    }
+
+    async fn request_debug_unlock<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        unlock_level: u8,
+        challenge: &mut DebugUnlockChallenge,
+    ) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler
+            .request_debug_unlock(alloc, unlock_level, challenge)
+            .await
+    }
+
+    async fn authorize_debug_unlock_token<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        token_request: &[u8],
+    ) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler
+            .authorize_debug_unlock_token(alloc, token_request)
+            .await
+    }
+
+    async fn get_log(&self, log_type: u32, data: &mut [u8]) -> CaliptraCmdResult<GetLogResult> {
+        // Delegate to the production backend so the real Tock logging-flash
+        // path is exercised end-to-end by mailbox command tests.
+        CaliptraCmdBackend.get_log(log_type, data).await
+    }
+
+    async fn clear_log(&self, log_type: u32) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend.clear_log(log_type).await
+    }
+
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .provision_vendor_pk_hash(slot, hash)
+            .await
+    }
+
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .increase_caliptra_min_svn(alloc, svn)
+            .await
+    }
+
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .revoke_vendor_pub_key(alloc, vendor_pk_hash_slot, key_type, key_index)
+            .await
+    }
+
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .revoke_vendor_pk_hash(vendor_pk_hash_slot)
+            .await
+    }
+
+    async fn program_field_entropy<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        partition: u32,
+    ) -> CaliptraCmdResult<()> {
+        CaliptraCmdBackend
+            .program_field_entropy(alloc, partition)
+            .await
+    }
+}

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -264,6 +264,40 @@ pub trait CaliptraCmdHandler {
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
 
+    /// Provision a vendor public-key hash in an OTP slot.
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        let _ = (slot, hash);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Increase the minimum allowed Caliptra firmware SVN.
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        let _ = (alloc, svn);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Revoke one vendor public key in a provisioned public-key-hash slot.
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        let _ = (alloc, vendor_pk_hash_slot, key_type, key_index);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Revoke a provisioned vendor public-key-hash slot.
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        let _ = vendor_pk_hash_slot;
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
     /// Program field entropy for a given partition.
     ///
     /// Over both the MCU mailbox and VDM paths, the dispatch layer verifies

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -266,6 +266,40 @@ pub trait CaliptraCmdHandler {
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
 
+    /// Provision a vendor public-key hash in an OTP slot.
+    async fn provision_vendor_pk_hash(&self, slot: u32, hash: &[u8; 48]) -> CaliptraCmdResult<()> {
+        let _ = (slot, hash);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Increase the minimum allowed Caliptra firmware SVN.
+    async fn increase_caliptra_min_svn<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        svn: u32,
+    ) -> CaliptraCmdResult<()> {
+        let _ = (alloc, svn);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Revoke one vendor public key in a provisioned public-key-hash slot.
+    async fn revoke_vendor_pub_key<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+    ) -> CaliptraCmdResult<()> {
+        let _ = (alloc, vendor_pk_hash_slot, key_type, key_index);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Revoke a provisioned vendor public-key-hash slot.
+    async fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+        let _ = vendor_pk_hash_slot;
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
     /// Program field entropy for a given partition.
     ///
     /// Over both the MCU mailbox and VDM paths, the dispatch layer verifies

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -3,13 +3,11 @@
 use crate::errors;
 use crate::transport::McuMboxTransport;
 use caliptra_mcu_common_commands::{
-    CaliptraCmdHandler, CommandAuthorizer, DebugUnlockChallenge, DeviceCapabilities,
-    FirmwareVersion, GetLogResult,
+    CaliptraCmdHandler, CaliptraCompletionCode, CommandAuthorizer, DebugUnlockChallenge,
+    DeviceCapabilities, FirmwareVersion, GetLogResult,
 };
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
-use caliptra_mcu_libsyscall_caliptra::otp::{Otp, RevokeVendorPubKeyType};
-use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
-use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
+use caliptra_mcu_libsyscall_caliptra::{otp, DefaultSyscalls};
 use caliptra_mcu_mbox_common::messages::{
     ClearLogReq, ClearLogResp, CommandId, DeviceCapsReq, DeviceCapsResp, ExportAttestedCsrReq,
     FirmwareVersionReq, FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq,
@@ -29,12 +27,19 @@ use caliptra_mcu_mbox_common::messages::{
 };
 use caliptra_mcu_otp_fuse::{fuse_read_dai_params, PartitionId};
 use core::sync::atomic::{AtomicBool, Ordering};
-use mcu_caliptra_api_lite::{raw, ApiAlloc, FwInfo};
-use mcu_error::McuResult;
+use mcu_caliptra_api_lite::{raw, ApiAlloc};
+use mcu_error::{McuErrorCode, McuResult};
 use zerocopy::{FromBytes, IntoBytes};
 
 pub trait McuMboxScratch: ApiAlloc {
     fn shrink(buf: &mut Self::Buf<'_>, new_len: usize) -> McuResult<()>;
+}
+
+fn map_common_cmd_error(error: CaliptraCompletionCode) -> McuErrorCode {
+    match error {
+        CaliptraCompletionCode::InvalidParameter => errors::INVALID_PARAMS,
+        _ => errors::MCU_MBOX_COMMON,
+    }
 }
 
 /// Command interface for handling MCU mailbox commands.
@@ -659,9 +664,12 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
     ) -> McuResult<(&'r mut [u8], MbxCmdStatus)> {
         let req =
             ProvisionVendorPkHashReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
-        let otp: Otp<DefaultSyscalls> = Otp::new();
-        let res = match otp.provision_vendor_pk_hash(req.slot, &req.hash) {
-            Ok(_) => MbxCmdStatus::Complete,
+        let res = match self
+            .non_crypto_cmds_handler
+            .provision_vendor_pk_hash(req.slot, &req.hash)
+            .await
+        {
+            Ok(()) => MbxCmdStatus::Complete,
             Err(_) => MbxCmdStatus::Failure,
         };
         let resp = ProvisionVendorPkHashResp::default();
@@ -683,67 +691,10 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
         let req = FuseIncreaseCaliptraMinSvnReq::ref_from_bytes(req)
             .map_err(|_| errors::INVALID_PARAMS)?;
 
-        // Check the request has a valid SVN value
-        if req.svn == 0 {
-            return Err(errors::INVALID_PARAMS);
-        }
-        if req.svn > 128 {
-            return Err(errors::INVALID_PARAMS);
-        }
-
-        let caliptra_fw_info = self.get_caliptra_fw_info().await?;
-
-        // Ensure the requested SVN will allow current Caliptra firmware to run
-        if req.svn > caliptra_fw_info.fw_svn {
-            return Err(errors::INVALID_PARAMS);
-        }
-
-        // Get the minimum SVN set in fuses
-        let otp: otp::Otp<DefaultSyscalls> = otp::Otp::new();
-        let mut current_fuses = [0u32; 4];
-        for (i, fuse) in current_fuses.iter_mut().enumerate() {
-            *fuse = otp
-                .read(otp::reg::CALIPTRA_FW_SVN, i as u32)
-                .map_err(|_| errors::MCU_MBOX_COMMON)?;
-        }
-
-        // Convert the fuses to the SVN value
-        let fused_min_svn = {
-            // Value is take as the most significant bit set in fuses
-            let fuse: u128 = u128::from_le_bytes(current_fuses.as_bytes().try_into().unwrap());
-            128 - fuse.leading_zeros()
-        };
-
-        // Ensure we are not trying to decrease the SVN
-        if req.svn < fused_min_svn {
-            return Err(errors::INVALID_PARAMS);
-        }
-
-        // We are done, if the fuses already match the requested SVN.
-        if fused_min_svn == req.svn {
-            let resp = FuseIncreaseCaliptraMinSvnResp::default();
-            let resp_bytes = resp.as_bytes();
-            resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
-            return Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete));
-        }
-
-        let new_fuse_svn = if req.svn == 128 {
-            u128::MAX
-        } else {
-            !(u128::MAX << req.svn)
-        };
-
-        for (i, (current, new_bytes)) in current_fuses
-            .iter()
-            .zip(new_fuse_svn.as_bytes().chunks_exact(4))
-            .enumerate()
-        {
-            let new_svn_word = u32::from_le_bytes(new_bytes.try_into().unwrap());
-            if *current != new_svn_word {
-                otp.write(otp::reg::CALIPTRA_FW_SVN, i as u32, new_svn_word)
-                    .map_err(|_| errors::INVALID_PARAMS)?;
-            }
-        }
+        self.non_crypto_cmds_handler
+            .increase_caliptra_min_svn(self.scratch, req.svn)
+            .await
+            .map_err(map_common_cmd_error)?;
 
         let resp = FuseIncreaseCaliptraMinSvnResp::default();
         let resp_bytes = resp.as_bytes();
@@ -780,56 +731,15 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
             FuseRevokeVendorPubKeyReq::ref_from_bytes(req).map_err(|_| errors::INVALID_PARAMS)?;
         let (resp, _) = FuseRevokeVendorPubKeyResp::mut_from_prefix(resp_buf)
             .map_err(|_| errors::INVALID_PARAMS)?;
-        let key_type =
-            RevokeVendorPubKeyType::try_from(req.key_type).map_err(|_| errors::INVALID_PARAMS)?;
-
-        // Check the given slot has a valid PK hash provisioned
-        let otp = otp::Otp::<DefaultSyscalls>::new();
-        if !otp.valid_vendor_pk_hash_slot(req.vendor_pk_hash_slot) {
-            Err(errors::INVALID_PARAMS)?;
-        }
-
-        let caliptra_info = self.get_caliptra_fw_info().await?;
-
-        // Check if the key to be revoked was a key used to boot. If so, return an error as a form
-        // of proof of possession for other keys.
-        let same_key_used_to_boot = || -> McuResult<bool> {
-            let caliptra_soc = caliptra::Caliptra::<DefaultSyscalls>::new();
-            let booted_pk_hash = caliptra_soc
-                .read_vendor_pk_hash()
-                .map_err(|_| errors::MCU_MBOX_COMMON)?;
-            let pk_hash_from_slot = otp
-                .read_vendor_pk_hash(req.vendor_pk_hash_slot)
-                .map_err(|_| errors::MCU_MBOX_COMMON)?;
-
-            // Check if the requested slot was the one used to boot
-            if booted_pk_hash != pk_hash_from_slot {
-                return Ok(false);
-            }
-
-            const FW_VERIFICATION_PQC_TYPE_MLDSA: u32 = 1;
-            const FW_VERIFICATION_PQC_TYPE_LMS: u32 = 3;
-            let same_key = match (key_type, caliptra_info.image_manifest_pqc_type) {
-                (RevokeVendorPubKeyType::Ecdsa384, _) => {
-                    req.key_index == caliptra_info.vendor_ecc384_pub_key_index
-                }
-                // Same PQC type
-                (RevokeVendorPubKeyType::Lms, FW_VERIFICATION_PQC_TYPE_LMS)
-                | (RevokeVendorPubKeyType::Mldsa87, FW_VERIFICATION_PQC_TYPE_MLDSA) => {
-                    req.key_index == caliptra_info.vendor_pqc_pub_key_index
-                }
-                // Different PQC types
-                _ => false,
-            };
-            Ok(same_key)
-        };
-
-        if same_key_used_to_boot()? {
-            Err(errors::INVALID_PARAMS)?;
-        }
-
-        otp.revoke_vendor_pub_key(req.vendor_pk_hash_slot, key_type, req.key_index)
-            .map_err(|_| errors::MCU_MBOX_COMMON)?;
+        self.non_crypto_cmds_handler
+            .revoke_vendor_pub_key(
+                self.scratch,
+                req.vendor_pk_hash_slot,
+                req.key_type,
+                req.key_index,
+            )
+            .await
+            .map_err(map_common_cmd_error)?;
 
         *resp = FuseRevokeVendorPubKeyResp::default();
         let len = size_of_val(resp);
@@ -847,39 +757,14 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
         let (resp, _) = FuseRevokeVendorPkHashResp::mut_from_prefix(resp_buf)
             .map_err(|_| errors::INVALID_PARAMS)?;
 
-        let otp = otp::Otp::<DefaultSyscalls>::new();
-
-        // Check if the PK hash to be revoked was used to boot. If so, return an error as a form
-        // of proof of possession for other keys.
-        let same_key_used_to_boot = || -> McuResult<bool> {
-            let caliptra_soc = caliptra::Caliptra::<DefaultSyscalls>::new();
-            let booted_pk_hash = caliptra_soc
-                .read_vendor_pk_hash()
-                .map_err(|_| errors::MCU_MBOX_COMMON)?;
-            let pk_hash_from_slot = otp
-                .read_vendor_pk_hash(req.vendor_pk_hash_slot)
-                .map_err(|_| errors::MCU_MBOX_COMMON)?;
-
-            // Check if the requested slot was the one used to boot
-            Ok(booted_pk_hash == pk_hash_from_slot)
-        };
-
-        if same_key_used_to_boot()? {
-            Err(errors::INVALID_PARAMS)?;
-        }
-
-        otp.revoke_vendor_pk_hash(req.vendor_pk_hash_slot)
-            .map_err(|_| errors::MCU_MBOX_COMMON)?;
+        self.non_crypto_cmds_handler
+            .revoke_vendor_pk_hash(req.vendor_pk_hash_slot)
+            .await
+            .map_err(map_common_cmd_error)?;
 
         *resp = FuseRevokeVendorPkHashResp::default();
         let resp_len = resp.as_bytes().len();
         Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete))
-    }
-
-    async fn get_caliptra_fw_info(&self) -> McuResult<FwInfo> {
-        mcu_caliptra_api_lite::fw_info(self.scratch)
-            .await
-            .map_err(|_| errors::MCU_MBOX_COMMON)
     }
 
     #[cfg(feature = "periodic-fips-self-test")]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -98,7 +98,43 @@ fn box_cache(val: impl Cache + 'static) -> Box<dyn Cache> {
     Box::new(val)
 }
 
-fn build_runtime(target_dir: &Path) -> Result<PathBuf> {
+struct FileRestoreGuard {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl FileRestoreGuard {
+    fn new(path: PathBuf) -> io::Result<Self> {
+        let contents = match fs::read(&path) {
+            Ok(contents) => Some(contents),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+            Err(err) => return Err(err),
+        };
+        Ok(Self { path, contents })
+    }
+}
+
+impl Drop for FileRestoreGuard {
+    fn drop(&mut self) {
+        let result = match &self.contents {
+            Some(contents) => fs::write(&self.path, contents),
+            None => match fs::remove_file(&self.path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(err),
+            },
+        };
+        if let Err(err) = result {
+            eprintln!("Unable to restore {}: {err}", self.path.display());
+        }
+    }
+}
+
+fn build_runtime(workspace: &Path, target_dir: &Path) -> Result<PathBuf> {
+    // Historical manifests can make Cargo normalize their checked-in lockfile.
+    // Restore it before size-history checks out the next commit.
+    let _cargo_lock = FileRestoreGuard::new(workspace.join("Cargo.lock"))?;
+
     // FPGA does not have a `*-devel.toml` manifest variant (HW-fixed SRAM);
     // still exercise the `release` cargo feature / `release` cargo profile
     // against its single 512 KB layout so size regressions and
@@ -177,7 +213,7 @@ impl CaliptraElfSizeGenerator {
         let target_dir = workspace.join("target");
 
         if self.build {
-            build_runtime(&target_dir).map_err(other_err)?;
+            build_runtime(workspace, &target_dir).map_err(other_err)?;
         }
 
         let elf_bytes = get_elf_bytes(&target_dir, self.fwid)?;
@@ -221,7 +257,7 @@ impl SramOverflowGenerator {
     fn measure(&self, workspace: &Path) -> Option<u64> {
         let target_dir = workspace.join("target");
 
-        match build_runtime(&target_dir) {
+        match build_runtime(workspace, &target_dir) {
             Ok(_) => Some(0), // Fits in SRAM
             Err(e) => {
                 let msg = format!("{:?}", e);
@@ -258,5 +294,29 @@ impl ArtifactBuilder for SramOverflowGenerator {
 
     fn build_and_measure(&self, workspace: &Path) -> Option<u64> {
         self.measure(workspace)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_restore_guard_restores_original_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let existing = temp.path().join("existing.lock");
+        fs::write(&existing, b"original").unwrap();
+        {
+            let _guard = FileRestoreGuard::new(existing.clone()).unwrap();
+            fs::write(&existing, b"modified").unwrap();
+        }
+        assert_eq!(fs::read(&existing).unwrap(), b"original");
+
+        let absent = temp.path().join("absent.lock");
+        {
+            let _guard = FileRestoreGuard::new(absent.clone()).unwrap();
+            fs::write(&absent, b"created").unwrap();
+        }
+        assert!(!absent.exists());
     }
 }


### PR DESCRIPTION
## Summary

Refactor only — no wire-format or mailbox behavioral changes.

- Move vendor PK-hash provisioning, minimum Caliptra SVN increase, vendor public-key revocation, and vendor PK-hash-slot revocation out of private MCU mailbox handlers into the transport-neutral common command handler interface (`caliptra-common-commands`), alongside `program_field_entropy`.
- Keep MCU mailbox authorization and wire framing in the mailbox layer; delegate fuse policy to the emulator Caliptra command backend.
- All existing fuse policy is preserved unchanged: slot validity, idempotency, min-SVN bounds (nonzero, ≤128, ≤ running `FW_INFO.fw_svn`, no decrease), thermometer encoding, current-boot key/slot protection, and last-key-per-algorithm protection.

This is PR 1 of a 3-PR stack adding authorized fuse commands over SPDM VDM:
1. **#1910 (this PR)** — common policy extraction
2. #1911 — SPDM VDM responder subcommands
3. #1912 — host tooling + end-to-end validation

### Memory delta (`measure-memory.sh`, devel profile, vs `main`)

| Section | `main` | Stack head | Delta |
|---|---:|---:|---:|
| Kernel `.text`/`.data`/`.bss` | 150,392 / 36 / 24,536 | 150,392 / 36 / 24,536 | 0 |
| User-app FLASH | 260,384 | 267,252 | **+6,868 B** |
| User-app RAM | 78,136 | 78,776 | **+640 B** |
| SPDM task FLASH | 104,142 | 111,598 | **+7,456 B** |
| SPDM task RAM | 29,853 | 30,501 | **+648 B** |
| Runtime bundle | 412,160 | 419,072 | **+6,912 B** |
