### PR TITLE
spdm-lite: add authorized fuse VDM commands

### DIFF
--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitflags 2.11.1",
  "caliptra-api-types",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -485,17 +485,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-util-host"

--- a/caliptra-util-host/apps/spdm/client/src/config.rs
+++ b/caliptra-util-host/apps/spdm/client/src/config.rs
@@ -16,11 +16,23 @@ pub struct TestConfig {
     #[serde(default)]
     pub spdm: SpdmTestConfig,
     #[serde(default)]
+    pub validation: ValidationConfig,
+    #[serde(default)]
     pub export_attested_csr: ExportAttestedCsrConfig,
     #[serde(default)]
     pub debug_unlock: DebugUnlockConfig,
     #[serde(default)]
+    pub authorized_commands: AuthorizedCommandsConfig,
+    #[serde(default)]
     pub fe_prog: FeProgConfig,
+    #[serde(default)]
+    pub provision_vendor_pk_hash: ProvisionVendorPkHashConfig,
+    #[serde(default)]
+    pub increase_caliptra_min_svn: IncreaseCaliptraMinSvnConfig,
+    #[serde(default)]
+    pub revoke_vendor_pub_key: RevokeVendorPubKeyConfig,
+    #[serde(default)]
+    pub revoke_vendor_pk_hash: RevokeVendorPkHashConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -45,6 +57,13 @@ fn default_server_address() -> String {
 pub struct SpdmTestConfig {
     #[serde(default)]
     pub slot_id: u8,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ValidationConfig {
+    /// Optional isolated validator suite selected by the integration harness.
+    #[serde(default)]
+    pub fuse_suite: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -102,11 +121,78 @@ impl Default for DebugUnlockConfig {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
-pub struct FeProgConfig {
-    #[serde(default)]
-    pub partition: u32,
+pub struct AuthorizedCommandsConfig {
     #[serde(default)]
     pub ecc_auth_key: Option<String>,
     #[serde(default)]
     pub mldsa_auth_key: Option<String>,
+    #[serde(default)]
+    pub negative_authorization_tests: bool,
+    #[serde(default)]
+    pub policy_rejection_tests: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FeProgConfig {
+    #[serde(default)]
+    pub partition: u32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+impl Default for FeProgConfig {
+    fn default() -> Self {
+        Self {
+            partition: 0,
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProvisionVendorPkHashConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub slot: u32,
+    #[serde(default)]
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct IncreaseCaliptraMinSvnConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub flags: u32,
+    #[serde(default)]
+    pub svn: u32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RevokeVendorPubKeyConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub reserved: u32,
+    #[serde(default)]
+    pub vendor_pk_hash_slot: u32,
+    #[serde(default)]
+    pub key_type: u32,
+    #[serde(default)]
+    pub key_index: u32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RevokeVendorPkHashConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub reserved: u32,
+    #[serde(default)]
+    pub vendor_pk_hash_slot: u32,
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -39,11 +39,15 @@ use caliptra_mcu_core_util_host_command_types::certificate::ExportAttestedCsrRes
 use caliptra_mcu_core_util_host_command_types::debug_unlock::{
     ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest, ProdDebugUnlockTokenResponse,
 };
+use caliptra_mcu_core_util_host_command_types::device_info::GetDeviceCapabilitiesResponse;
 use caliptra_mcu_core_util_host_command_types::fuse::{
-    FeProgResponse, GetAuthCmdChallengeResponse,
+    FeProgResponse, FuseIncreaseCaliptraMinSvnRequest, FuseIncreaseCaliptraMinSvnResponse,
+    FuseRevokeVendorPkHashRequest, FuseRevokeVendorPkHashResponse, FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse, GetAuthCmdChallengeResponse, ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
 };
 use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
-    SpdmVdmDriver, SpdmVdmTransport,
+    SpdmVdmDriver, SpdmVdmError, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
@@ -51,9 +55,13 @@ use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_
 use caliptra_util_host_commands::api::debug_unlock::{
     caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
 };
+use caliptra_util_host_commands::api::device_info::caliptra_cmd_get_device_capabilities;
 use caliptra_util_host_commands::api::fuse::{
-    caliptra_cmd_fe_prog, caliptra_cmd_get_auth_challenge,
+    caliptra_cmd_fe_prog, caliptra_cmd_fuse_increase_caliptra_min_svn,
+    caliptra_cmd_fuse_revoke_vendor_pk_hash, caliptra_cmd_fuse_revoke_vendor_pub_key,
+    caliptra_cmd_get_auth_challenge, caliptra_cmd_provision_vendor_pk_hash,
 };
+use caliptra_util_host_commands::api::{CaliptraApiError, CaliptraResult};
 use caliptra_util_host_session::CaliptraSession;
 
 /// High-level SPDM VDM Client for communicating with Caliptra devices.
@@ -83,6 +91,14 @@ impl<'a> SpdmVdmClient<'a> {
         self.transport
             .disconnect()
             .map_err(|e| anyhow::anyhow!("Failed to disconnect SPDM VDM transport: {:?}", e))
+    }
+
+    /// Read the responder's Caliptra device capabilities.
+    pub fn get_device_capabilities(&mut self) -> CaliptraResult<GetDeviceCapabilitiesResponse> {
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_get_device_capabilities(&mut session)
     }
 
     /// Execute the ExportAttestedCsr command.
@@ -129,10 +145,11 @@ impl<'a> SpdmVdmClient<'a> {
     }
 
     /// Request an authorization challenge for authorized commands (e.g., FE_PROG).
-    pub fn get_auth_challenge(&mut self) -> Result<GetAuthCmdChallengeResponse> {
-        let mut session = self.create_session()?;
+    pub fn get_auth_challenge(&mut self) -> CaliptraResult<GetAuthCmdChallengeResponse> {
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_get_auth_challenge(&mut session)
-            .map_err(|e| anyhow::anyhow!("GetAuthChallenge failed: {:?}", e))
     }
 
     /// Program field entropy for an OTP partition (authorized command).
@@ -154,7 +171,7 @@ impl<'a> SpdmVdmClient<'a> {
         ecc_pub_x: &[u8; 48],
         ecc_pub_y: &[u8; 48],
         mldsa_pub: &[u8; 2592],
-    ) -> Result<FeProgResponse> {
+    ) -> CaliptraResult<FeProgResponse> {
         use caliptra_mcu_core_util_host_command_types::fuse::FeProgRequest;
         let request = FeProgRequest {
             partition,
@@ -164,9 +181,123 @@ impl<'a> SpdmVdmClient<'a> {
             ecc_pub_y: *ecc_pub_y,
             mldsa_pub: *mldsa_pub,
         };
-        let mut session = self.create_session()?;
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_fe_prog(&mut session, &request)
-            .map_err(|e| anyhow::anyhow!("FeProg failed: {:?}", e))
+    }
+
+    pub fn provision_vendor_pk_hash(
+        &mut self,
+        slot: u32,
+        hash: &[u8; 48],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<ProvisionVendorPkHashResponse> {
+        let request = ProvisionVendorPkHashRequest {
+            slot,
+            hash: *hash,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_provision_vendor_pk_hash(&mut session, &request)
+    }
+
+    pub fn fuse_increase_caliptra_min_svn(
+        &mut self,
+        flags: u32,
+        svn: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseIncreaseCaliptraMinSvnResponse> {
+        let request = FuseIncreaseCaliptraMinSvnRequest {
+            flags,
+            svn,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_increase_caliptra_min_svn(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pub_key(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPubKeyResponse> {
+        let request = FuseRevokeVendorPubKeyRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            key_type,
+            key_index,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pub_key(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pk_hash(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPkHashResponse> {
+        let request = FuseRevokeVendorPkHashRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pk_hash(&mut session, &request)
+    }
+
+    /// Send an unencoded Caliptra VDM payload for responder-negative validation.
+    pub fn send_raw_vdm(
+        &mut self,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, SpdmVdmError> {
+        self.transport.send_raw_vdm(request, response)
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -46,6 +46,10 @@ struct Args {
     /// Debug unlock level (1-8)
     #[arg(long)]
     unlock_level: Option<u8>,
+
+    /// Run one isolated authorized-fuse validator suite.
+    #[arg(long, value_name = "SUITE")]
+    fuse_suite: Option<String>,
 }
 
 impl Args {
@@ -77,6 +81,9 @@ impl Args {
         if let Some(unlock_level) = self.unlock_level {
             config.debug_unlock.unlock_level = unlock_level;
         }
+        if let Some(fuse_suite) = self.fuse_suite {
+            config.validation.fuse_suite = Some(fuse_suite);
+        }
 
         Ok(config)
     }
@@ -103,9 +110,9 @@ fn main() -> Result<()> {
         };
     let config = args.into_config()?;
 
-    let fe_prog_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> = match (
-        &config.fe_prog.ecc_auth_key,
-        &config.fe_prog.mldsa_auth_key,
+    let command_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> = match (
+        &config.authorized_commands.ecc_auth_key,
+        &config.authorized_commands.mldsa_auth_key,
     ) {
         (Some(hex_ecc), Some(hex_mldsa)) => {
             let ecc_key = hex::decode(hex_ecc)?;
@@ -148,20 +155,19 @@ fn main() -> Result<()> {
             &mut client,
             &config,
             debug_unlock_signer.as_deref(),
-            fe_prog_authorizer.as_deref(),
+            command_authorizer.as_deref(),
             true,
         )
     };
     validator::print_summary(&results);
 
+    if !validator::all_passed(&results) {
+        anyhow::bail!("Some tests FAILED");
+    }
+
     println!("[caliptra-spdm-validator] Sending STOP to bridge");
     stop_io.send_stop()?;
-
-    if validator::all_passed(&results) {
-        Ok(())
-    } else {
-        anyhow::bail!("Some tests FAILED")
-    }
+    Ok(())
 }
 
 fn parse_key_ids(s: &str) -> Result<Vec<u32>> {

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -15,8 +15,22 @@ use crate::config::TestConfig;
 use crate::SpdmVdmClient;
 use caliptra_mcu_command_auth_challenge_signer::CommandAuthChallengeSigner;
 use caliptra_mcu_core_util_host_command_types::certificate::AttestedCsrValidationError;
-use caliptra_mcu_core_util_host_command_types::fuse::MC_FE_PROG_CANONICAL_CMD_ID;
+use caliptra_mcu_core_util_host_command_types::fuse::{
+    MC_FE_PROG_CANONICAL_CMD_ID, MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+    MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID, MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+    MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+};
+use caliptra_mcu_core_util_host_transport::{CaliptraVdmCommand, CaliptraVdmCompletionCode};
 use caliptra_mcu_debug_unlock_signer::{DebugUnlockSigner, ProdDebugUnlockChallenge};
+use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
+use caliptra_util_host_commands::api::CaliptraApiError;
+
+const IMPLEMENTED_AUTHORIZED_SUBCOMMANDS: u32 = (1 << 0)
+    | (1 << 1)
+    | (1 << 2)
+    | (1 << 3)
+    | (1 << 4)
+    | (1 << 5);
 
 /// Result of a single validation check.
 #[derive(Debug, Clone)]
@@ -100,9 +114,13 @@ pub fn run_all(
     client: &mut SpdmVdmClient,
     config: &TestConfig,
     debug_unlock_signer: Option<&dyn DebugUnlockSigner>,
-    fe_prog_authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    command_authorizer: Option<&dyn CommandAuthChallengeSigner>,
     verbose: bool,
 ) -> Vec<ValidationResult> {
+    if let Some(suite) = config.validation.fuse_suite.as_deref() {
+        return run_fuse_suite(client, suite, command_authorizer, verbose);
+    }
+
     let mut results = Vec::new();
 
     results.extend(run_export_attested_csr(
@@ -121,12 +139,70 @@ pub fn run_all(
         ));
     }
 
-    results.push(run_fe_prog(
-        client,
-        config.fe_prog.partition,
-        fe_prog_authorizer,
-        verbose,
-    ));
+    if config.authorized_commands.negative_authorization_tests {
+        results.extend(run_authorization_negative_tests(
+            client,
+            command_authorizer,
+            verbose,
+        ));
+    }
+
+    if config.authorized_commands.policy_rejection_tests {
+        results.extend(run_fuse_policy_rejection_tests(
+            client,
+            command_authorizer,
+            verbose,
+        ));
+    }
+
+    if config.provision_vendor_pk_hash.enabled {
+        results.push(run_provision_vendor_pk_hash(
+            client,
+            config.provision_vendor_pk_hash.slot,
+            &config.provision_vendor_pk_hash.hash,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.increase_caliptra_min_svn.enabled {
+        results.push(run_increase_caliptra_min_svn(
+            client,
+            config.increase_caliptra_min_svn.flags,
+            config.increase_caliptra_min_svn.svn,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.fe_prog.enabled {
+        results.push(run_fe_prog(
+            client,
+            config.fe_prog.partition,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.revoke_vendor_pub_key.enabled {
+        let cfg = &config.revoke_vendor_pub_key;
+        results.push(run_revoke_vendor_pub_key(
+            client,
+            cfg.reserved,
+            cfg.vendor_pk_hash_slot,
+            cfg.key_type,
+            cfg.key_index,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.revoke_vendor_pk_hash.enabled {
+        let cfg = &config.revoke_vendor_pk_hash;
+        results.push(run_revoke_vendor_pk_hash(
+            client,
+            cfg.reserved,
+            cfg.vendor_pk_hash_slot,
+            command_authorizer,
+            verbose,
+        ));
+    }
 
     results
 }
@@ -259,12 +335,831 @@ pub fn run_prod_debug_unlock(
     }
 }
 
+struct AuthorizedCommandAuthorization {
+    sig: HybridSignature,
+    nonce: [u8; AUTH_CMD_NONCE_LEN],
+    ecc_pub_x: [u8; 48],
+    ecc_pub_y: [u8; 48],
+    mldsa_pub: [u8; 2592],
+}
+
+fn authorize_command(
+    client: &mut SpdmVdmClient,
+    command_id: u32,
+    payload: &[u8],
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+) -> Result<AuthorizedCommandAuthorization, String> {
+    let authorizer = authorizer.ok_or_else(|| "no command authorizer provided".to_string())?;
+    let challenge = client
+        .get_auth_challenge()
+        .map_err(|e| format!("Failed to get auth challenge: {e}"))?;
+    let sig = authorizer
+        .authorize(command_id, payload, &challenge.challenge)
+        .map_err(|e| format!("Authorization failed: {e}"))?;
+    let (ecc_pub_x, ecc_pub_y, mldsa_pub) = authorizer
+        .public_keys()
+        .map_err(|e| format!("public_keys() failed: {e}"))?;
+    Ok(AuthorizedCommandAuthorization {
+        sig,
+        nonce: challenge.challenge,
+        ecc_pub_x,
+        ecc_pub_y,
+        mldsa_pub,
+    })
+}
+
+pub fn run_provision_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    hash_hex: &str,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("ProvisionVendorPkHash(slot={slot})");
+    let hash_vec = match hex::decode(hash_hex) {
+        Ok(hash) if hash.len() == 48 => hash,
+        Ok(hash) => {
+            return ValidationResult::fail(
+                test_name,
+                format!("hash must be 48 bytes, got {}", hash.len()),
+            )
+        }
+        Err(e) => return ValidationResult::fail(test_name, format!("invalid hash hex: {e}")),
+    };
+    let hash: [u8; 48] = hash_vec.try_into().unwrap();
+    let mut payload = Vec::with_capacity(52);
+    payload.extend_from_slice(&slot.to_le_bytes());
+    payload.extend_from_slice(&hash);
+    let auth = match authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.provision_vendor_pk_hash(
+        slot,
+        &hash,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "hash provisioned"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_increase_caliptra_min_svn(
+    client: &mut SpdmVdmClient,
+    flags: u32,
+    svn: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("FuseIncreaseCaliptraMinSvn(svn={svn})");
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&flags.to_le_bytes());
+    payload.extend_from_slice(&svn.to_le_bytes());
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_increase_caliptra_min_svn(
+        flags,
+        svn,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "minimum SVN updated"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_revoke_vendor_pub_key(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    key_type: u32,
+    key_index: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name =
+        format!("FuseRevokeVendorPubKey(slot={slot},type={key_type},index={key_index})");
+    let mut payload = Vec::with_capacity(16);
+    for value in [reserved, slot, key_type, key_index] {
+        payload.extend_from_slice(&value.to_le_bytes());
+    }
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_revoke_vendor_pub_key(
+        reserved,
+        slot,
+        key_type,
+        key_index,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "key revoked"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_revoke_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("FuseRevokeVendorPkHash(slot={slot})");
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&reserved.to_le_bytes());
+    payload.extend_from_slice(&slot.to_le_bytes());
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_revoke_vendor_pk_hash(
+        reserved,
+        slot,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "PK-hash slot revoked"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+#[derive(Debug)]
+enum AuthorizedCommandError {
+    Preparation(String),
+    Command(CaliptraApiError),
+}
+
+fn signed_provision_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    hash: &[u8; 48],
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(52);
+    payload.extend_from_slice(&slot.to_le_bytes());
+    payload.extend_from_slice(hash);
+    let auth = authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .provision_vendor_pk_hash(
+            slot,
+            hash,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_increase_caliptra_min_svn(
+    client: &mut SpdmVdmClient,
+    flags: u32,
+    svn: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&flags.to_le_bytes());
+    payload.extend_from_slice(&svn.to_le_bytes());
+    let auth = authorize_command(
+        client,
+        MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_increase_caliptra_min_svn(
+            flags,
+            svn,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_revoke_vendor_pub_key(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    key_type: u32,
+    key_index: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(16);
+    for field in [reserved, slot, key_type, key_index] {
+        payload.extend_from_slice(&field.to_le_bytes());
+    }
+    let auth = authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_revoke_vendor_pub_key(
+            reserved,
+            slot,
+            key_type,
+            key_index,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_revoke_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&reserved.to_le_bytes());
+    payload.extend_from_slice(&slot.to_le_bytes());
+    let auth = authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_revoke_vendor_pk_hash(
+            reserved,
+            slot,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn expect_success(test_name: &str, result: Result<(), AuthorizedCommandError>) -> ValidationResult {
+    match result {
+        Ok(()) => ValidationResult::pass(test_name, "accepted"),
+        Err(error) => ValidationResult::fail(test_name, format!("{error:?}")),
+    }
+}
+
+fn expect_completion(
+    test_name: &str,
+    result: Result<(), AuthorizedCommandError>,
+    expected: CaliptraVdmCompletionCode,
+) -> ValidationResult {
+    match result {
+        Err(AuthorizedCommandError::Command(CaliptraApiError::DeviceError(code)))
+            if code == expected as u8 =>
+        {
+            ValidationResult::pass(test_name, format!("completion code {code:#04x}"))
+        }
+        Err(AuthorizedCommandError::Command(CaliptraApiError::DeviceError(code))) => {
+            ValidationResult::fail(
+                test_name,
+                format!("expected {:#04x}, got {code:#04x}", expected as u8),
+            )
+        }
+        Err(AuthorizedCommandError::Preparation(error)) => {
+            ValidationResult::fail(test_name, format!("authorization setup failed: {error}"))
+        }
+        Err(AuthorizedCommandError::Command(error)) => {
+            ValidationResult::fail(test_name, format!("non-device command failure: {error}"))
+        }
+        Ok(()) => ValidationResult::fail(test_name, "request was unexpectedly accepted"),
+    }
+}
+
+fn expect_api_completion<T>(
+    test_name: &str,
+    result: Result<T, CaliptraApiError>,
+    expected: CaliptraVdmCompletionCode,
+) -> ValidationResult {
+    match result {
+        Err(CaliptraApiError::DeviceError(code)) if code == expected as u8 => {
+            ValidationResult::pass(test_name, format!("completion code {code:#04x}"))
+        }
+        Err(CaliptraApiError::DeviceError(code)) => ValidationResult::fail(
+            test_name,
+            format!("expected {:#04x}, got {code:#04x}", expected as u8),
+        ),
+        Err(error) => {
+            ValidationResult::fail(test_name, format!("non-device command failure: {error}"))
+        }
+        Ok(_) => ValidationResult::fail(test_name, "request was unexpectedly accepted"),
+    }
+}
+
+fn run_fe_prog_tamper_test<F>(
+    client: &mut SpdmVdmClient,
+    authorizer: &dyn CommandAuthChallengeSigner,
+    test_name: &str,
+    signed_partition: u32,
+    submitted_partition: u32,
+    mutate: F,
+) -> ValidationResult
+where
+    F: FnOnce(&mut AuthorizedCommandAuthorization),
+{
+    let payload = signed_partition.to_le_bytes();
+    let mut auth = match authorize_command(
+        client,
+        MC_FE_PROG_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    ) {
+        Ok(auth) => auth,
+        Err(error) => return ValidationResult::fail(test_name, error),
+    };
+    mutate(&mut auth);
+    expect_api_completion(
+        test_name,
+        client.fe_prog(
+            submitted_partition,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    )
+}
+
+fn run_raw_malformed_request_tests(client: &mut SpdmVdmClient) -> Vec<ValidationResult> {
+    let signature_len = core::mem::size_of::<HybridSignature>();
+    let mut exact = vec![1, CaliptraVdmCommand::AuthorizedCommand as u8];
+    exact.extend_from_slice(&MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID.to_le_bytes());
+    exact.extend_from_slice(&1u32.to_le_bytes());
+    exact.extend_from_slice(&[0xA5; 48]);
+    exact.resize(exact.len() + signature_len, 0);
+
+    let missing_signature = exact[..exact.len() - signature_len].to_vec();
+    let truncated = exact[..exact.len() - 1].to_vec();
+    let mut oversized = exact;
+    oversized.push(0);
+
+    [
+        (
+            "AuthorizedCommand rejects missing signature",
+            missing_signature,
+        ),
+        ("AuthorizedCommand rejects truncated request", truncated),
+        ("AuthorizedCommand rejects oversized request", oversized),
+    ]
+    .into_iter()
+    .map(|(name, request)| {
+        let mut response = [0u8; 16];
+        match client.send_raw_vdm(&request, &mut response) {
+            Ok(3)
+                if response[..3]
+                    == [
+                        1,
+                        CaliptraVdmCommand::AuthorizedCommand as u8,
+                        CaliptraVdmCompletionCode::InvalidPayloadSize as u8,
+                    ] =>
+            {
+                ValidationResult::pass(name, "responder returned InvalidPayloadSize")
+            }
+            Ok(len) => ValidationResult::fail(
+                name,
+                format!("unexpected raw response {:02x?}", &response[..len]),
+            ),
+            Err(error) => ValidationResult::fail(name, format!("transport failure: {error:?}")),
+        }
+    })
+    .collect()
+}
+
+pub fn run_fuse_policy_rejection_tests(
+    client: &mut SpdmVdmClient,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::skip(
+            "Authorized fuse policy rejections",
+            "no command authorizer provided",
+        )];
+    };
+    vec![
+        expect_completion(
+            "ProvisionVendorPkHash rejects invalid slot",
+            signed_provision_vendor_pk_hash(client, 16, &[0xA5; 48], authorizer),
+            CaliptraVdmCompletionCode::OperationFailed,
+        ),
+        expect_completion(
+            "FuseIncreaseCaliptraMinSvn rejects nonzero reserved flags",
+            signed_increase_caliptra_min_svn(client, 1, 1, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseIncreaseCaliptraMinSvn rejects zero SVN",
+            signed_increase_caliptra_min_svn(client, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPubKey rejects nonzero reserved field",
+            signed_revoke_vendor_pub_key(client, 1, 1, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPubKey rejects current-boot key",
+            signed_revoke_vendor_pub_key(client, 0, 0, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPkHash rejects nonzero reserved field",
+            signed_revoke_vendor_pk_hash(client, 1, 1, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPkHash rejects current-boot slot",
+            signed_revoke_vendor_pk_hash(client, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+    ]
+}
+
+fn run_authorized_subcommand_capability_test(
+    client: &mut SpdmVdmClient,
+) -> ValidationResult {
+    match client.get_device_capabilities() {
+        Ok(capabilities) => {
+            let advertised = capabilities.authorized_subcommand_capabilities();
+            if advertised & IMPLEMENTED_AUTHORIZED_SUBCOMMANDS
+                == IMPLEMENTED_AUTHORIZED_SUBCOMMANDS
+            {
+                ValidationResult::pass(
+                    "Authorized fuse capability advertisement",
+                    format!("authorized_subcommands={advertised:#010x}"),
+                )
+            } else {
+                ValidationResult::fail(
+                    "Authorized fuse capability advertisement",
+                    format!(
+                        "expected bits {IMPLEMENTED_AUTHORIZED_SUBCOMMANDS:#010x}, got {advertised:#010x}"
+                    ),
+                )
+            }
+        }
+        Err(error) => ValidationResult::fail(
+            "Authorized fuse capability advertisement",
+            format!("GetDeviceCapabilities failed: {error}"),
+        ),
+    }
+}
+
+fn run_fuse_suite(
+    client: &mut SpdmVdmClient,
+    suite: &str,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::fail(
+            suite,
+            "no command authorizer provided",
+        )];
+    };
+    let hash = [0xA5; 48];
+    let other_hash = [0x5A; 48];
+    let mut results = vec![run_authorized_subcommand_capability_test(client)];
+
+    results.extend(match suite {
+        "authorization" => {
+            let mut results = run_raw_malformed_request_tests(client);
+            results.extend(run_authorization_negative_tests(
+                client,
+                Some(authorizer),
+                verbose,
+            ));
+            results
+        }
+        "provision-vendor-pk-hash" => vec![
+            expect_completion(
+                "PVPK invalid slot",
+                signed_provision_vendor_pk_hash(client, 16, &hash, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_success(
+                "PVPK programs and reads back slot",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_success(
+                "PVPK same hash is idempotent",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_completion(
+                "PVPK conflicting hash rejected",
+                signed_provision_vendor_pk_hash(client, 1, &other_hash, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+        ],
+        "increase-min-svn" => vec![
+            expect_completion(
+                "MCMS rejects nonzero reserved flags",
+                signed_increase_caliptra_min_svn(client, 1, 5, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MCMS rejects zero SVN",
+                signed_increase_caliptra_min_svn(client, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MCMS rejects SVN above encoding bound",
+                signed_increase_caliptra_min_svn(client, 0, 129, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MCMS rejects SVN above running firmware",
+                signed_increase_caliptra_min_svn(client, 0, 8, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MCMS increases minimum SVN",
+                signed_increase_caliptra_min_svn(client, 0, 5, authorizer),
+            ),
+            expect_success(
+                "MCMS equal SVN is idempotent",
+                signed_increase_caliptra_min_svn(client, 0, 5, authorizer),
+            ),
+            expect_completion(
+                "MCMS rejects decrease",
+                signed_increase_caliptra_min_svn(client, 0, 4, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+        ],
+        "revoke-vendor-pub-key" => vec![
+            expect_completion(
+                "MRVK rejects nonzero reserved field",
+                signed_revoke_vendor_pub_key(client, 1, 1, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MRVK rejects unprovisioned slot",
+                signed_revoke_vendor_pub_key(client, 0, 1, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MRVK prerequisite slot provisioning",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_completion(
+                "MRVK rejects invalid key type",
+                signed_revoke_vendor_pub_key(client, 0, 1, 99, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MRVK rejects invalid key index",
+                signed_revoke_vendor_pub_key(client, 0, 1, 0, 4, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_completion(
+                "MRVK rejects current-boot key",
+                signed_revoke_vendor_pub_key(client, 0, 0, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MRVK revokes inactive key",
+                signed_revoke_vendor_pub_key(client, 0, 1, 0, 0, authorizer),
+            ),
+            expect_completion(
+                "MRVK rejects last algorithm key",
+                signed_revoke_vendor_pub_key(client, 0, 1, 0, 3, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+        ],
+        "revoke-vendor-pk-hash" => vec![
+            expect_completion(
+                "RVKH rejects nonzero reserved field",
+                signed_revoke_vendor_pk_hash(client, 1, 1, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "RVKH rejects unprovisioned slot",
+                signed_revoke_vendor_pk_hash(client, 0, 1, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_completion(
+                "RVKH rejects current-boot slot",
+                signed_revoke_vendor_pk_hash(client, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "RVKH prerequisite slot provisioning",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_success(
+                "RVKH revokes inactive slot",
+                signed_revoke_vendor_pk_hash(client, 0, 1, authorizer),
+            ),
+            expect_success(
+                "RVKH repeated revocation is idempotent",
+                signed_revoke_vendor_pk_hash(client, 0, 1, authorizer),
+            ),
+        ],
+        _ => vec![ValidationResult::fail(
+            "Authorized fuse suite",
+            format!("unknown suite {suite:?}"),
+        )],
+    });
+    results
+}
+
+pub fn run_authorization_negative_tests(
+    client: &mut SpdmVdmClient,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::skip(
+            "AuthorizedCommand negative authorization",
+            "no command authorizer provided",
+        )];
+    };
+    let partition = 0u32;
+    let payload = partition.to_le_bytes();
+    let mut results = Vec::new();
+
+    let challenge = match client.get_auth_challenge() {
+        Ok(challenge) => challenge,
+        Err(e) => {
+            return vec![ValidationResult::fail(
+                "AuthorizedCommand bad signature",
+                e.to_string(),
+            )]
+        }
+    };
+    let valid =
+        match authorizer.authorize(MC_FE_PROG_CANONICAL_CMD_ID, &payload, &challenge.challenge) {
+            Ok(auth) => auth,
+            Err(e) => {
+                return vec![ValidationResult::fail(
+                    "AuthorizedCommand bad signature",
+                    e.to_string(),
+                )]
+            }
+        };
+    let (ecc_pub_x, ecc_pub_y, mldsa_pub) = match authorizer.public_keys() {
+        Ok(keys) => keys,
+        Err(e) => {
+            return vec![ValidationResult::fail(
+                "AuthorizedCommand public keys",
+                e.to_string(),
+            )]
+        }
+    };
+    results.push(expect_api_completion(
+        "AuthorizedCommand bad signature",
+        client.fe_prog(
+            partition,
+            &HybridSignature::default(),
+            &challenge.challenge,
+            &ecc_pub_x,
+            &ecc_pub_y,
+            &mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+    results.push(expect_api_completion(
+        "AuthorizedCommand reused challenge",
+        client.fe_prog(
+            partition,
+            &valid,
+            &challenge.challenge,
+            &ecc_pub_x,
+            &ecc_pub_y,
+            &mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+
+    let wrong_sig = match authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    ) {
+        Ok(auth) => auth,
+        Err(e) => {
+            results.push(ValidationResult::fail(
+                "AuthorizedCommand wrong-command signature",
+                e,
+            ));
+            return results;
+        }
+    };
+    results.push(expect_api_completion(
+        "AuthorizedCommand wrong-command signature",
+        client.fe_prog(
+            partition,
+            &wrong_sig.sig,
+            &wrong_sig.nonce,
+            &wrong_sig.ecc_pub_x,
+            &wrong_sig.ecc_pub_y,
+            &wrong_sig.mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+    results.push(run_fe_prog_tamper_test(
+        client,
+        authorizer,
+        "AuthorizedCommand rejects tampered payload",
+        0,
+        1,
+        |_| {},
+    ));
+    results.push(run_fe_prog_tamper_test(
+        client,
+        authorizer,
+        "AuthorizedCommand rejects unanchored public key",
+        0,
+        0,
+        |auth| auth.ecc_pub_x[0] ^= 1,
+    ));
+    results.push(run_fe_prog_tamper_test(
+        client,
+        authorizer,
+        "AuthorizedCommand rejects tampered ECC signature",
+        0,
+        0,
+        |auth| auth.sig.ecc_sig_r[0] ^= 1,
+    ));
+    results.push(run_fe_prog_tamper_test(
+        client,
+        authorizer,
+        "AuthorizedCommand rejects tampered ML-DSA signature",
+        0,
+        0,
+        |auth| auth.sig.mldsa_sig[0] ^= 1,
+    ));
+    results
+}
+
 /// Validate Field Entropy Programming (FE_PROG) via SPDM VDM.
 ///
 /// When a [`CommandAuthChallengeSigner`] is provided, performs the full authorized flow:
 /// 1. Request an auth challenge
-/// 2. Ask the authorizer to produce the MAC
-/// 3. Submit FE_PROG with the MAC
+/// 2. Ask the authorizer to produce the hybrid signature
+/// 3. Submit FE_PROG with the signature
 ///
 /// Without an authorizer the test is skipped.
 pub fn run_fe_prog(
@@ -308,7 +1203,7 @@ pub fn run_fe_prog(
     let cmd_id = MC_FE_PROG_CANONICAL_CMD_ID;
     let sig =
         match authorizer.authorize(cmd_id, &partition.to_le_bytes(), &challenge_resp.challenge) {
-            Ok(sig) => sig,
+            Ok(auth) => auth,
             Err(e) => {
                 return ValidationResult::fail(test_name, format!("Authorization failed: {}", e));
             }

--- a/caliptra-util-host/apps/spdm/test-config.toml
+++ b/caliptra-util-host/apps/spdm/test-config.toml
@@ -20,9 +20,40 @@ key_ids = [1, 2, 3]
 # ECC384 = 1, MlDsa87 = 2
 algorithm = 1
 
-[fe_prog]
-partition = 0
-# Hex-encoded ECC private key (P-384) and ML-DSA seed (32 bytes) for FE_PROG authorization.
-# Must match keys in the MCU firmware.
+[authorized_commands]
+# Test-only authorization keys. Production integrations must provide their own key source.
 ecc_auth_key = "3da9e680aff5a1cea96a3e89810286fb3b3030a9c924ad2f2031a07d294052a97cafa1fc6ea760a43db763ca9f2f7036"
 mldsa_auth_key = "63616c69707472612d6d63752d74657374696e672d6d6c6473612d736565642d"
+# The integration harness selects isolated suites with --fuse-suite. Keep the
+# aggregate switches disabled so destructive operations cannot accidentally run
+# together when this config is used directly.
+negative_authorization_tests = false
+policy_rejection_tests = false
+
+[provision_vendor_pk_hash]
+enabled = false
+slot = 1
+hash = "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"
+
+[increase_caliptra_min_svn]
+# The integration test boots disposable Caliptra firmware with SVN 7.
+enabled = false
+flags = 0
+svn = 7
+
+[fe_prog]
+# FE_PROG is not part of the fuse VDM validation sequence.
+enabled = false
+partition = 0
+
+[revoke_vendor_pub_key]
+enabled = false
+reserved = 0
+vendor_pk_hash_slot = 1
+key_type = 0
+key_index = 0
+
+[revoke_vendor_pk_hash]
+enabled = false
+reserved = 0
+vendor_pk_hash_slot = 1

--- a/caliptra-util-host/command-types/src/fuse.rs
+++ b/caliptra-util-host/command-types/src/fuse.rs
@@ -44,6 +44,12 @@ pub const MC_GET_AUTH_CMD_CHALLENGE_CANONICAL_CMD_ID: u32 = 0x4D41_4343;
 /// transports (SPDM VDM and MCU mailbox) to ensure interoperability.
 pub const MC_FE_PROG_CANONICAL_CMD_ID: u32 = 0x4D43_4650;
 
+/// Canonical FOURCC command identifiers used for authorized fuse operations.
+pub const MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID: u32 = 0x5056_504B;
+pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID: u32 = 0x4D43_4D53;
+pub const MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID: u32 = 0x4D52_564B;
+pub const MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID: u32 = 0x5256_4B48;
+
 // ---- Get Authorization Command Challenge ----
 
 /// Request a challenge nonce for authorizing privileged commands.
@@ -170,6 +176,64 @@ impl CommandRequest for FeProgRequest {
 }
 
 impl CommandResponse for FeProgResponse {}
+
+macro_rules! authorized_fuse_command {
+    ($request:ident, $response:ident, $command_id:ident, { $($field:ident: $ty:ty),+ $(,)? }) => {
+        #[repr(C)]
+        #[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+        pub struct $request {
+            $(pub $field: $ty,)+
+            pub nonce: [u8; AUTH_CMD_CHALLENGE_SIZE],
+            pub ecc_pub_x: [u8; AUTH_PUB_ECC_COORD_SIZE],
+            pub ecc_pub_y: [u8; AUTH_PUB_ECC_COORD_SIZE],
+            pub mldsa_pub: [u8; AUTH_PUB_MLDSA_SIZE],
+            pub sig: HybridSignature,
+        }
+
+        #[repr(C)]
+        #[derive(Debug, Default, Clone, IntoBytes, FromBytes, Immutable)]
+        pub struct $response {
+            pub common: CommonResponse,
+        }
+
+        impl CommandRequest for $request {
+            type Response = $response;
+            const COMMAND_ID: CaliptraCommandId = CaliptraCommandId::$command_id;
+        }
+
+        impl CommandResponse for $response {}
+    };
+}
+
+authorized_fuse_command!(
+    ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
+    ProvisionVendorPkHash,
+    { slot: u32, hash: [u8; 48] }
+);
+authorized_fuse_command!(
+    FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse,
+    FuseIncreaseCaliptraMinSvn,
+    { flags: u32, svn: u32 }
+);
+authorized_fuse_command!(
+    FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse,
+    FuseRevokeVendorPubKey,
+    {
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32
+    }
+);
+authorized_fuse_command!(
+    FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse,
+    FuseRevokeVendorPkHash,
+    { reserved: u32, vendor_pk_hash_slot: u32 }
+);
 
 // ---- Placeholder fuse commands ----
 

--- a/caliptra-util-host/command-types/src/lib.rs
+++ b/caliptra-util-host/command-types/src/lib.rs
@@ -121,6 +121,10 @@ pub enum CaliptraCommandId {
     // Authorized Commands (0x8010-0x801F)
     GetAuthCmdChallenge = 0x8010,
     FeProg = 0x8011,
+    ProvisionVendorPkHash = 0x8012,
+    FuseIncreaseCaliptraMinSvn = 0x8013,
+    FuseRevokeVendorPubKey = 0x8014,
+    FuseRevokeVendorPkHash = 0x8015,
 }
 
 /// Common response header for all commands

--- a/caliptra-util-host/commands/src/api/fuse.rs
+++ b/caliptra-util-host/commands/src/api/fuse.rs
@@ -2,28 +2,37 @@
 
 //! Fuse and Authorized Command API functions
 //!
-//! High-level functions for authorized command operations including
-//! field entropy programming (FE_PROG).
+//! High-level functions for challenge-authorized fuse operations.
 //!
 //! ## Authorization Flow
 //!
 //! Authorized commands follow a challenge-response pattern:
-//! 1. Call `caliptra_cmd_get_auth_challenge` to obtain a 32-byte nonce
-//! 2. Compute HMAC-SHA384 over `cmd_id(BE) || cmd_body || challenge`
-//! 3. Call the authorized command (e.g., `caliptra_cmd_fe_prog`) which
-//!    internally appends the MAC to the request
+//! 1. Call `caliptra_cmd_get_auth_challenge` to obtain a one-use 48-byte nonce
+//! 2. Sign `cmd_id(BE) || cmd_body || challenge` with ECC P-384 and ML-DSA-87
+//! 3. Append the hybrid signature to the authorized command request
 
 use crate::api::{CaliptraApiError, CaliptraResult};
 use caliptra_mcu_core_util_host_command_types::fuse::{
-    FeProgRequest, FeProgResponse, GetAuthCmdChallengeRequest, GetAuthCmdChallengeResponse,
+    FeProgRequest, FeProgResponse, FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse, FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse, FuseRevokeVendorPubKeyRequest, FuseRevokeVendorPubKeyResponse,
+    GetAuthCmdChallengeRequest, GetAuthCmdChallengeResponse, ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
 };
 use caliptra_mcu_core_util_host_command_types::CaliptraCommandId;
-use caliptra_util_host_session::CaliptraSession;
+use caliptra_util_host_session::{CaliptraSession, SessionError};
+
+fn map_session_error(error: SessionError, context: &'static str) -> CaliptraApiError {
+    match error {
+        SessionError::DeviceError(code) => CaliptraApiError::DeviceError(code),
+        _ => CaliptraApiError::SessionError(context),
+    }
+}
 
 /// Request an authorization challenge nonce.
 ///
-/// Returns a 32-byte random challenge that must be included in the HMAC
-/// computation for the next authorized command. The challenge is single-use:
+/// Returns a 48-byte random challenge that must be included in the signed
+/// pre-image for the next authorized command. The challenge is single-use:
 /// it is consumed by the device after one authorized command.
 ///
 /// # Parameters
@@ -32,7 +41,7 @@ use caliptra_util_host_session::CaliptraSession;
 ///
 /// # Returns
 ///
-/// - `Ok(GetAuthCmdChallengeResponse)` containing the 32-byte challenge
+/// - `Ok(GetAuthCmdChallengeResponse)` containing the 48-byte challenge
 /// - `Err(CaliptraApiError)` on failure
 pub fn caliptra_cmd_get_auth_challenge(
     session: &mut CaliptraSession,
@@ -40,7 +49,7 @@ pub fn caliptra_cmd_get_auth_challenge(
     let request = GetAuthCmdChallengeRequest::default();
     session
         .execute_command_with_id(CaliptraCommandId::GetAuthCmdChallenge, &request)
-        .map_err(|_| CaliptraApiError::SessionError("Get auth command challenge execution failed"))
+        .map_err(|error| map_session_error(error, "Get auth command challenge execution failed"))
 }
 
 /// Program field entropy for an OTP partition.
@@ -64,5 +73,47 @@ pub fn caliptra_cmd_fe_prog(
 ) -> CaliptraResult<FeProgResponse> {
     session
         .execute_command_with_id(CaliptraCommandId::FeProg, request)
-        .map_err(|_| CaliptraApiError::SessionError("FE_PROG command execution failed"))
+        .map_err(|error| map_session_error(error, "FE_PROG command execution failed"))
 }
+
+macro_rules! authorized_fuse_api {
+    ($fn_name:ident, $request:ty, $response:ty, $command:ident, $error:literal) => {
+        pub fn $fn_name(
+            session: &mut CaliptraSession,
+            request: &$request,
+        ) -> CaliptraResult<$response> {
+            session
+                .execute_command_with_id(CaliptraCommandId::$command, request)
+                .map_err(|error| map_session_error(error, $error))
+        }
+    };
+}
+
+authorized_fuse_api!(
+    caliptra_cmd_provision_vendor_pk_hash,
+    ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
+    ProvisionVendorPkHash,
+    "ProvisionVendorPkHash command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_increase_caliptra_min_svn,
+    FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse,
+    FuseIncreaseCaliptraMinSvn,
+    "FuseIncreaseCaliptraMinSvn command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_revoke_vendor_pub_key,
+    FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse,
+    FuseRevokeVendorPubKey,
+    "FuseRevokeVendorPubKey command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_revoke_vendor_pk_hash,
+    FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse,
+    FuseRevokeVendorPkHash,
+    "FuseRevokeVendorPkHash command execution failed"
+);

--- a/caliptra-util-host/commands/src/api/mod.rs
+++ b/caliptra-util-host/commands/src/api/mod.rs
@@ -50,6 +50,8 @@ pub enum CaliptraApiError {
     TransportNotAvailable,
     /// Command execution failed
     CommandFailed(&'static str),
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
     /// Session error (generic session layer error)
     SessionError(&'static str),
 }
@@ -80,6 +82,9 @@ impl core::fmt::Display for CaliptraApiError {
             CaliptraApiError::SessionNotInitialized => write!(f, "Session not initialized"),
             CaliptraApiError::TransportNotAvailable => write!(f, "Transport not available"),
             CaliptraApiError::CommandFailed(msg) => write!(f, "Command failed: {}", msg),
+            CaliptraApiError::DeviceError(code) => {
+                write!(f, "Device completion code: {code:#04x}")
+            }
             CaliptraApiError::SessionError(msg) => write!(f, "Session error: {}", msg),
         }
     }

--- a/caliptra-util-host/session/src/lib.rs
+++ b/caliptra-util-host/session/src/lib.rs
@@ -10,7 +10,7 @@ use caliptra_mcu_core_util_host_command_types::{
     CaliptraCommandId, CommandRequest, CommandResponse,
 };
 use caliptra_mcu_core_util_host_osal::time::{sleep, Duration, Instant};
-use caliptra_mcu_core_util_host_transport::Transport;
+use caliptra_mcu_core_util_host_transport::{Transport, TransportError};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Maximum size for command packets
@@ -51,6 +51,9 @@ pub enum SessionError {
 
     /// Transport layer error
     TransportError(&'static str),
+
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
 
     /// OSAL error
     OsalError(&'static str),
@@ -426,7 +429,10 @@ impl<'t> CaliptraSession<'t> {
             // Send the command with command_id as separate parameter
             transport
                 .send(command_id as u32, request_bytes)
-                .map_err(|_| SessionError::TransportError("Send failed"))?;
+                .map_err(|err| match err {
+                    TransportError::DeviceError(code) => SessionError::DeviceError(code),
+                    _ => SessionError::TransportError("Send failed"),
+                })?;
 
             // Receive the response
             let mut response_buffer = [0u8; MAX_COMMAND_PACKET_SIZE];

--- a/caliptra-util-host/transport/src/error.rs
+++ b/caliptra-util-host/transport/src/error.rs
@@ -60,6 +60,9 @@ pub enum TransportError {
     /// OSAL error
     OsalError(OsalError),
 
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
+
     /// Custom transport error
     Custom(&'static str),
 }
@@ -102,6 +105,9 @@ impl fmt::Display for TransportError {
             TransportError::MessageTooLarge(msg) => write!(f, "Message too large: {}", msg),
             TransportError::ParseError(msg) => write!(f, "Parse error: {}", msg),
             TransportError::PluginError(msg) => write!(f, "Plugin error: {}", msg),
+            TransportError::DeviceError(code) => {
+                write!(f, "Device completion code: {code:#04x}")
+            }
             TransportError::Custom(msg) => write!(f, "Custom error: {}", msg),
         }
     }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -23,6 +23,7 @@ use super::protocol::{
 };
 use super::transport::{SpdmVdmDriver, SpdmVdmError};
 use crate::TransportError;
+use alloc::vec::Vec;
 use caliptra_mcu_core_util_host_command_types::debug_unlock::{
     ProdDebugUnlockReqRequest, ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest,
     ProdDebugUnlockTokenResponse, DEBUG_UNLOCK_CHALLENGE_SIZE, UNIQUE_DEVICE_ID_SIZE,
@@ -146,10 +147,10 @@ pub fn handle_export_attested_csr(
 // GetAuthCmdChallenge (CaliptraCommandId::GetAuthCmdChallenge)
 // ---------------------------------------------------------------------------
 
-/// Handle GetAuthChallenge sub-command — request a challenge nonce for HMAC authorization.
+/// Handle GetAuthChallenge sub-command — request a one-use authorization nonce.
 ///
 /// VDM wire format request:  [version, 0x12 (AuthorizedCommand), sub_cmd_id=0x4D41_4343 (4 LE)]
-/// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code, challenge(32)]
+/// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code, challenge(48)]
 pub fn handle_get_auth_challenge(
     _payload: &[u8],
     driver: &mut dyn SpdmVdmDriver,
@@ -169,9 +170,9 @@ pub fn handle_get_auth_challenge(
         &mut resp_buf,
     )?;
 
-    // Response data: [challenge(32)]
+    // Response data: [challenge(48)]
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
-    if data.len() < AUTH_CMD_CHALLENGE_SIZE {
+    if data.len() != AUTH_CMD_CHALLENGE_SIZE {
         return Err(TransportError::InvalidMessage);
     }
 
@@ -181,59 +182,110 @@ pub fn handle_get_auth_challenge(
         .copy_from_slice(&data[..AUTH_CMD_CHALLENGE_SIZE]);
 
     let resp_bytes = internal_resp.as_bytes();
-    let copy_len = resp_bytes.len().min(response_buffer.len());
-    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
-    Ok(copy_len)
+    if response_buffer.len() < resp_bytes.len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..resp_bytes.len()].copy_from_slice(resp_bytes);
+    Ok(resp_bytes.len())
+}
+
+fn handle_authorized_fuse_command(
+    command_id: u32,
+    request: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let mut vdm_payload = Vec::with_capacity(4 + request.len());
+    vdm_payload.extend_from_slice(&command_id.to_le_bytes());
+    vdm_payload.extend_from_slice(request);
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let resp_len = send_vdm_request(
+        CaliptraVdmCommand::AuthorizedCommand,
+        &vdm_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+    if resp_len != VDM_RESPONSE_HEADER_SIZE {
+        return Err(TransportError::InvalidMessage);
+    }
+    let response = CommonResponse { fips_status: 0 };
+    if response_buffer.len() < response.as_bytes().len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..response.as_bytes().len()].copy_from_slice(response.as_bytes());
+    Ok(response.as_bytes().len())
 }
 
 // ---------------------------------------------------------------------------
-// ProgramFieldEntropy (CaliptraCommandId::FeProg)
+// Authorized fuse commands
 // ---------------------------------------------------------------------------
 
 /// Handle ProgramFieldEntropy (FE_PROG) authorized sub-command.
 ///
-/// VDM wire format request:  [version, 0x12 (AuthorizedCommand),
-///   sub_cmd_id=0x4D43_4650 (4 LE), partition(4 LE),
-///   nonce(48), ecc_pub_x(48), ecc_pub_y(48), mldsa_pub(2592),
-///   ecc_sig(r 48 || s 48), mldsa_sig(4628)]
-/// Signatures come LAST. The nonce and public keys are fields of `FeProgRequest`,
-/// so they are carried automatically by `req.as_bytes()` below — no manual
-/// serialization here.
+/// VDM wire format request: [version, 0x12, sub_cmd_id, partition,
+/// nonce, ECC public key, ML-DSA public key, HybridSignature].
 /// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code]
 pub fn handle_fe_prog(
     payload: &[u8],
     driver: &mut dyn SpdmVdmDriver,
     response_buffer: &mut [u8],
 ) -> Result<usize, TransportError> {
-    use alloc::vec::Vec;
     use caliptra_mcu_core_util_host_command_types::fuse::{FeProgRequest, FeProgResponse};
-
     let req = FeProgRequest::from_bytes(payload).map_err(|_| TransportError::InvalidMessage)?;
-
-    // VDM payload: sub_cmd_id(4 LE) || FeProgRequest bytes
-    //   = sub_cmd_id || partition(4 LE) || nonce(48) || ecc_pub_x(48) || ecc_pub_y(48) || mldsa_pub(2592) || ecc_sig(96) || mldsa_sig(4628)
     let mut vdm_payload = Vec::with_capacity(4 + size_of::<FeProgRequest>());
     vdm_payload.extend_from_slice(&MC_FE_PROG_CANONICAL_CMD_ID.to_le_bytes());
     vdm_payload.extend_from_slice(req.as_bytes());
-
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
-    let _resp_len = send_vdm_request(
+    send_vdm_request(
         CaliptraVdmCommand::AuthorizedCommand,
         &vdm_payload,
         driver,
         &mut resp_buf,
     )?;
-
-    // Response is header-only (completion code checked by send_vdm_request)
-    let internal_resp = FeProgResponse {
+    let response = FeProgResponse {
         common: CommonResponse { fips_status: 0 },
     };
-
-    let resp_bytes = internal_resp.as_bytes();
-    let copy_len = resp_bytes.len().min(response_buffer.len());
-    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
-    Ok(copy_len)
+    let bytes = response.as_bytes();
+    if response_buffer.len() < bytes.len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..bytes.len()].copy_from_slice(bytes);
+    Ok(bytes.len())
 }
+
+macro_rules! authorized_fuse_handler {
+    ($name:ident, $request:ty, $command_id:expr) => {
+        pub fn $name(
+            payload: &[u8],
+            driver: &mut dyn SpdmVdmDriver,
+            response_buffer: &mut [u8],
+        ) -> Result<usize, TransportError> {
+            let req =
+                <$request>::from_bytes(payload).map_err(|_| TransportError::InvalidMessage)?;
+            handle_authorized_fuse_command($command_id, req.as_bytes(), driver, response_buffer)
+        }
+    };
+}
+authorized_fuse_handler!(
+    handle_provision_vendor_pk_hash,
+    fuse::ProvisionVendorPkHashRequest,
+    fuse::MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_increase_caliptra_min_svn,
+    fuse::FuseIncreaseCaliptraMinSvnRequest,
+    fuse::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_revoke_vendor_pub_key,
+    fuse::FuseRevokeVendorPubKeyRequest,
+    fuse::MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_revoke_vendor_pk_hash,
+    fuse::FuseRevokeVendorPkHashRequest,
+    fuse::MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID
+);
 
 // ---------------------------------------------------------------------------
 // RequestDebugUnlock (CaliptraCommandId::ProdDebugUnlockReq)
@@ -415,6 +467,188 @@ mod tests {
             TransportError::BufferError(msg) => assert!(msg.contains("maximum CSR size")),
             other => panic!("unexpected error: {:?}", other),
         }
+    }
+
+    #[test]
+    fn authorized_fuse_commands_preserve_exact_wire_layout() {
+        let mut sig = caliptra_mcu_mbox_common::messages::HybridSignature::default();
+        sig.ecc_sig_r.fill(0x11);
+        sig.ecc_sig_s.fill(0x22);
+        sig.mldsa_sig.fill(0x33);
+
+        let pvpk = fuse::ProvisionVendorPkHashRequest {
+            slot: 0x0102_0304,
+            hash: [0xA5; 48],
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mcms = fuse::FuseIncreaseCaliptraMinSvnRequest {
+            flags: 0x1122_3344,
+            svn: 0x5566_7788,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mrvk = fuse::FuseRevokeVendorPubKeyRequest {
+            reserved: 0x0102_0304,
+            vendor_pk_hash_slot: 0x1112_1314,
+            key_type: 0x2122_2324,
+            key_index: 0x3132_3334,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let rvkh = fuse::FuseRevokeVendorPkHashRequest {
+            reserved: 0x4142_4344,
+            vendor_pk_hash_slot: 0x5152_5354,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+
+        let signature_bytes = {
+            let mut bytes = vec![0x11; 48];
+            bytes.extend_from_slice(&[0x22; 48]);
+            bytes.extend_from_slice(&vec![0x33; sig.mldsa_sig.len()]);
+            bytes
+        };
+        let make_golden = |command_id: u32, fields: &[u8]| {
+            let mut packet = vec![
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizedCommand as u8,
+            ];
+            packet.extend_from_slice(&command_id.to_le_bytes());
+            packet.extend_from_slice(fields);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_CMD_CHALLENGE_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_ECC_COORD_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_ECC_COORD_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_MLDSA_SIZE]);
+            packet.extend_from_slice(&signature_bytes);
+            packet
+        };
+
+        let mut pvpk_fields = 0x0102_0304u32.to_le_bytes().to_vec();
+        pvpk_fields.extend_from_slice(&[0xA5; 48]);
+        let mut mcms_fields = 0x1122_3344u32.to_le_bytes().to_vec();
+        mcms_fields.extend_from_slice(&0x5566_7788u32.to_le_bytes());
+        let mut mrvk_fields = Vec::new();
+        for field in [0x0102_0304u32, 0x1112_1314, 0x2122_2324, 0x3132_3334] {
+            mrvk_fields.extend_from_slice(&field.to_le_bytes());
+        }
+        let mut rvkh_fields = 0x4142_4344u32.to_le_bytes().to_vec();
+        rvkh_fields.extend_from_slice(&0x5152_5354u32.to_le_bytes());
+
+        let cases: Vec<(&[u8], Vec<u8>, VdmCommandHandlerFnForTest)> = vec![
+            (
+                pvpk.as_bytes(),
+                make_golden(
+                    fuse::MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+                    &pvpk_fields,
+                ),
+                handle_provision_vendor_pk_hash,
+            ),
+            (
+                mcms.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+                    &mcms_fields,
+                ),
+                handle_fuse_increase_caliptra_min_svn,
+            ),
+            (
+                mrvk.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+                    &mrvk_fields,
+                ),
+                handle_fuse_revoke_vendor_pub_key,
+            ),
+            (
+                rvkh.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+                    &rvkh_fields,
+                ),
+                handle_fuse_revoke_vendor_pk_hash,
+            ),
+        ];
+
+        for (request, golden, handler) in cases {
+            let mut driver = FakeDriver {
+                response: success_response(CaliptraVdmCommand::AuthorizedCommand, &[]),
+                last_request: Vec::new(),
+            };
+            let mut response = [0u8; core::mem::size_of::<CommonResponse>()];
+            handler(request, &mut driver, &mut response).unwrap();
+            assert_eq!(driver.last_request, golden);
+
+            let err = handler(&request[..request.len() - 1], &mut driver, &mut response)
+                .expect_err("truncated hybrid signature must be rejected locally");
+            assert!(matches!(err, TransportError::InvalidMessage));
+
+            let mut oversized = request.to_vec();
+            oversized.push(0);
+            let err = handler(&oversized, &mut driver, &mut response)
+                .expect_err("trailing request bytes must be rejected locally");
+            assert!(matches!(err, TransportError::InvalidMessage));
+        }
+    }
+
+    type VdmCommandHandlerFnForTest =
+        fn(&[u8], &mut dyn SpdmVdmDriver, &mut [u8]) -> Result<usize, TransportError>;
+
+    #[test]
+    fn authorized_command_rejects_trailing_response_and_small_output_buffer() {
+        let req = fuse::FuseIncreaseCaliptraMinSvnRequest {
+            flags: 0,
+            svn: 1,
+            sig: Default::default(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::AuthorizedCommand, &[0xAA]),
+            last_request: Vec::new(),
+        };
+        let mut response = [0u8; core::mem::size_of::<CommonResponse>()];
+        assert!(matches!(
+            handle_fuse_increase_caliptra_min_svn(req.as_bytes(), &mut driver, &mut response),
+            Err(TransportError::InvalidMessage)
+        ));
+
+        driver.response = success_response(CaliptraVdmCommand::AuthorizedCommand, &[]);
+        assert!(matches!(
+            handle_fuse_increase_caliptra_min_svn(req.as_bytes(), &mut driver, &mut []),
+            Err(TransportError::BufferError(_))
+        ));
+    }
+
+    #[test]
+    fn get_auth_challenge_requires_exact_response_length() {
+        let challenge = [0x5A; fuse::AUTH_CMD_CHALLENGE_SIZE];
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::AuthorizedCommand, &challenge),
+            last_request: Vec::new(),
+        };
+        let mut response = [0u8; core::mem::size_of::<fuse::GetAuthCmdChallengeResponse>()];
+        handle_get_auth_challenge(&[], &mut driver, &mut response).unwrap();
+
+        driver.response.push(0);
+        assert!(matches!(
+            handle_get_auth_challenge(&[], &mut driver, &mut response),
+            Err(TransportError::InvalidMessage)
+        ));
     }
 
     #[test]

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -30,6 +30,18 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
             Some(commands::handle_prod_debug_unlock_token)
         }
         x if x == CaliptraCommandId::FeProg as u32 => Some(commands::handle_fe_prog),
+        x if x == CaliptraCommandId::ProvisionVendorPkHash as u32 => {
+            Some(commands::handle_provision_vendor_pk_hash)
+        }
+        x if x == CaliptraCommandId::FuseIncreaseCaliptraMinSvn as u32 => {
+            Some(commands::handle_fuse_increase_caliptra_min_svn)
+        }
+        x if x == CaliptraCommandId::FuseRevokeVendorPubKey as u32 => {
+            Some(commands::handle_fuse_revoke_vendor_pub_key)
+        }
+        x if x == CaliptraCommandId::FuseRevokeVendorPkHash as u32 => {
+            Some(commands::handle_fuse_revoke_vendor_pk_hash)
+        }
         x if x == CaliptraCommandId::GetAuthCmdChallenge as u32 => {
             Some(commands::handle_get_auth_challenge)
         }
@@ -50,6 +62,10 @@ mod tests {
             CaliptraCommandId::ProdDebugUnlockReq,
             CaliptraCommandId::ProdDebugUnlockToken,
             CaliptraCommandId::FeProg,
+            CaliptraCommandId::ProvisionVendorPkHash,
+            CaliptraCommandId::FuseIncreaseCaliptraMinSvn,
+            CaliptraCommandId::FuseRevokeVendorPubKey,
+            CaliptraCommandId::FuseRevokeVendorPkHash,
             CaliptraCommandId::GetAuthCmdChallenge,
         ];
 

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
@@ -130,7 +130,14 @@ pub fn command_id_to_vdm(command_id: u32) -> Option<CaliptraVdmCommand> {
         x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
             Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken)
         }
-        x if x == CaliptraCommandId::FeProg as u32 => Some(CaliptraVdmCommand::AuthorizedCommand),
+        x if x == CaliptraCommandId::FeProg as u32
+            || x == CaliptraCommandId::ProvisionVendorPkHash as u32
+            || x == CaliptraCommandId::FuseIncreaseCaliptraMinSvn as u32
+            || x == CaliptraCommandId::FuseRevokeVendorPubKey as u32
+            || x == CaliptraCommandId::FuseRevokeVendorPkHash as u32 =>
+        {
+            Some(CaliptraVdmCommand::AuthorizedCommand)
+        }
         x if x == CaliptraCommandId::GetAuthCmdChallenge as u32 => {
             Some(CaliptraVdmCommand::AuthorizedCommand)
         }
@@ -184,6 +191,19 @@ mod tests {
             command_id_to_vdm(CaliptraCommandId::ProdDebugUnlockReq as u32),
             Some(CaliptraVdmCommand::RequestDebugUnlock)
         );
+        for id in [
+            CaliptraCommandId::GetAuthCmdChallenge,
+            CaliptraCommandId::FeProg,
+            CaliptraCommandId::ProvisionVendorPkHash,
+            CaliptraCommandId::FuseIncreaseCaliptraMinSvn,
+            CaliptraCommandId::FuseRevokeVendorPubKey,
+            CaliptraCommandId::FuseRevokeVendorPkHash,
+        ] {
+            assert_eq!(
+                command_id_to_vdm(id as u32),
+                Some(CaliptraVdmCommand::AuthorizedCommand)
+            );
+        }
         // Unsupported command
         assert_eq!(command_id_to_vdm(CaliptraCommandId::HashInit as u32), None);
     }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/transport.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/transport.rs
@@ -78,9 +78,7 @@ impl From<SpdmVdmError> for TransportError {
                 TransportError::ConnectionFailed(Some("SPDM VDM communication error"))
             }
             SpdmVdmError::BufferOverflow => TransportError::BufferError("Buffer overflow"),
-            SpdmVdmError::DeviceError(_) => {
-                TransportError::ConnectionFailed(Some("SPDM VDM device error"))
-            }
+            SpdmVdmError::DeviceError(code) => TransportError::DeviceError(code),
             SpdmVdmError::CodecError => TransportError::InvalidMessage,
             SpdmVdmError::SessionError => {
                 TransportError::ConnectionFailed(Some("SPDM session error"))
@@ -112,6 +110,18 @@ impl<'a> SpdmVdmTransport<'a> {
             response_len: 0,
             has_response: false,
         }
+    }
+
+    /// Send a raw Caliptra VDM payload without local command encoding.
+    ///
+    /// This is intended for protocol validators that must exercise malformed
+    /// requests against the responder rather than rejecting them locally.
+    pub fn send_raw_vdm(
+        &mut self,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, SpdmVdmError> {
+        self.driver.send_receive_vdm(request, response)
     }
 
     /// Process a command: encode internal request → VDM payload, send, decode response.

--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -30,11 +30,11 @@ The following table describes the commands defined under this specification. The
 | Request Debug Unlock            | O   | SPDM VDM, MCI Mailbox | Request debug unlock in production environment.                                                                                      |
 | Authorize Debug Unlock Token    | O   | SPDM VDM, MCI Mailbox | Send debug unlock token to device for authorization.                                                                                 |
 | Export Attested CSR             | O   | SPDM VDM, MCI Mailbox | Export attested CSR for a Caliptra device identity key (LDevID, FMC Alias, or RT Alias).                                             |
-| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands. Authorization requirements and transport-specific authorization flows are TBD. |
+| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands. SPDM VDM uses a one-use challenge and hybrid signature.                        |
 
 ### Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately. For the MCI mailbox path, access control is governed by the mailbox security boundary and platform policy.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. SPDM VDM requests use the challenge and hybrid-signature flow described in [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow). For the MCI mailbox path, access control is governed by the mailbox security boundary and platform policy.
 
 | Subcommand Name                | Transport(s)               | Description                                        |
 | ------------------------------ | -------------------------- | -------------------------------------------------- |
@@ -45,7 +45,6 @@ The following subcommands are assigned to the SPDM VDM IANA authorization-gated 
 | Fuse Revoke Vendor Public Key  | SPDM VDM IANA, MCI Mailbox | Revoke vendor public key.                          |
 | Fuse Revoke Vendor PK Hash     | SPDM VDM IANA, MCI Mailbox | Revoke vendor public key hash.                     |
 | Fuse Lock Partition            | SPDM VDM IANA, MCI Mailbox | Lock fuse partition.                               |
-
 
 ## Command Definitions
 
@@ -244,7 +243,7 @@ Exports an attested Certificate Signing Request (CSR) for a specified device key
 
 ### Authorization-Gated Subcommand Wrapper
 
-Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VDM IANA authorization-gated path and the MCI mailbox path. Authorization requirements and transport-specific authorization flows are TBD. The SPDM VDM transport uses an `Authorized Command` wrapper to carry subcommands, but the wrapper does not define the authorization mechanism by itself.
+Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VDM IANA authorization-gated path and the MCI mailbox path. The SPDM VDM transport uses an `Authorized Command` wrapper. Its requester first obtains a one-use 48-byte challenge, then appends a hybrid signature over `sub_cmd_id(BE) || sub_payload || challenge`. See [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow) for the byte-exact transport payloads.
 
 #### Request Payload
 
@@ -262,55 +261,59 @@ Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VD
 
 The subcommands covered by this wrapper are listed in [Authorization-Gated Subcommands](#authorization-gated-subcommands).
 
-Subcommand-specific payloads are defined by the corresponding command specifications. Any additional SPDM authorization wrapper fields are TBD.
+Subcommand-specific payloads are defined by the corresponding command specifications and contain no mailbox request header.
 
 ### Get Auth Challenge
 
-Requests a challenge for authorization-gated commands.
+Requests a one-use challenge for authorization-gated commands.
 
-**Request Payload**: TBD
+**Request Payload**: Empty
 
-**Response Payload**: TBD
+**Response Payload**:
+
+| Byte(s) | Name      | Type   | Description                               |
+| ------- | --------- | ------ | ----------------------------------------- |
+| 0:47    | challenge | u8[48] | One-use command authorization challenge.  |
 
 ### Provision Vendor PK Hash
 
 Provisions the vendor public key hash.
 
-**Request Payload**: TBD
+**Request Payload**: `slot:u32 | hash:u8[48] | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Increase Caliptra Min SVN
 
 Increases the Caliptra minimum SVN.
 
-**Request Payload**: TBD
+**Request Payload**: `flags:u32 | svn:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Program Field Entropy
 
 Programs field entropy.
 
-**Request Payload**: TBD
+**Request Payload**: `partition:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Revoke Vendor Public Key
 
 Revokes a vendor public key.
 
-**Request Payload**: TBD
+**Request Payload**: `reserved:u32 | slot:u32 | key_type:u32 | key_index:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Revoke Vendor PK Hash
 
 Revokes a vendor public key hash.
 
-**Request Payload**: TBD
+**Request Payload**: `reserved:u32 | slot:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Lock Partition
 

--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -30,11 +30,11 @@ The following table describes the commands defined under this specification. The
 | Request Debug Unlock            | O   | SPDM VDM, MCI Mailbox | Request debug unlock in production environment.                                                                                      |
 | Authorize Debug Unlock Token    | O   | SPDM VDM, MCI Mailbox | Send debug unlock token to device for authorization.                                                                                 |
 | Export Attested CSR             | O   | SPDM VDM, MCI Mailbox | Export attested CSR for a Caliptra device identity key (LDevID, FMC Alias, or RT Alias).                                             |
-| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands. Authorization requirements and transport-specific authorization flows are TBD. |
+| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands. SPDM VDM uses a one-use challenge and hybrid signature.                        |
 
 ### Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately. For the MCI mailbox path, access control is governed by the mailbox security boundary and platform policy.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. SPDM VDM requests use the challenge and hybrid-signature flow described in [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow). For the MCI mailbox path, access control is governed by the mailbox security boundary and platform policy.
 
 | Subcommand Name                | Transport(s)               | Description                                        |
 | ------------------------------ | -------------------------- | -------------------------------------------------- |
@@ -45,7 +45,6 @@ The following subcommands are assigned to the SPDM VDM IANA authorization-gated 
 | Fuse Revoke Vendor Public Key  | SPDM VDM IANA, MCI Mailbox | Revoke vendor public key.                          |
 | Fuse Revoke Vendor PK Hash     | SPDM VDM IANA, MCI Mailbox | Revoke vendor public key hash.                     |
 | Fuse Lock Partition            | SPDM VDM IANA, MCI Mailbox | Lock fuse partition.                               |
-
 
 ## Command Definitions
 
@@ -179,7 +178,7 @@ Exports an attested Certificate Signing Request (CSR) for a specified device key
 
 ### Authorization-Gated Subcommand Wrapper
 
-Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VDM IANA authorization-gated path and the MCI mailbox path. Authorization requirements and transport-specific authorization flows are TBD. The SPDM VDM transport uses an `Authorized Command` wrapper to carry subcommands, but the wrapper does not define the authorization mechanism by itself.
+Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VDM IANA authorization-gated path and the MCI mailbox path. The SPDM VDM transport uses an `Authorized Command` wrapper. Its requester first obtains a one-use 48-byte challenge, then appends a hybrid signature over `sub_cmd_id(BE) || sub_payload || challenge`. See [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow) for the byte-exact transport payloads.
 
 #### Request Payload
 
@@ -197,55 +196,59 @@ Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VD
 
 The subcommands covered by this wrapper are listed in [Authorization-Gated Subcommands](#authorization-gated-subcommands).
 
-Subcommand-specific payloads are defined by the corresponding command specifications. Any additional SPDM authorization wrapper fields are TBD.
+Subcommand-specific payloads are defined by the corresponding command specifications and contain no mailbox request header.
 
 ### Get Auth Challenge
 
-Requests a challenge for authorization-gated commands.
+Requests a one-use challenge for authorization-gated commands.
 
-**Request Payload**: TBD
+**Request Payload**: Empty
 
-**Response Payload**: TBD
+**Response Payload**:
+
+| Byte(s) | Name      | Type   | Description                               |
+| ------- | --------- | ------ | ----------------------------------------- |
+| 0:47    | challenge | u8[48] | One-use command authorization challenge.  |
 
 ### Provision Vendor PK Hash
 
 Provisions the vendor public key hash.
 
-**Request Payload**: TBD
+**Request Payload**: `slot:u32 | hash:u8[48] | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Increase Caliptra Min SVN
 
 Increases the Caliptra minimum SVN.
 
-**Request Payload**: TBD
+**Request Payload**: `flags:u32 | svn:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Program Field Entropy
 
 Programs field entropy.
 
-**Request Payload**: TBD
+**Request Payload**: `partition:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Revoke Vendor Public Key
 
 Revokes a vendor public key.
 
-**Request Payload**: TBD
+**Request Payload**: `reserved:u32 | slot:u32 | key_type:u32 | key_index:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Revoke Vendor PK Hash
 
 Revokes a vendor public key hash.
 
-**Request Payload**: TBD
+**Request Payload**: `reserved:u32 | slot:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Fuse Lock Partition
 

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -36,7 +36,6 @@ For the unified software architecture shared between OOB (SPDM VDM) and in-band 
 
 Caliptra commands assigned to SPDM VDM are carried within SPDM `VENDOR_DEFINED_REQUEST` and `VENDOR_DEFINED_RESPONSE` messages using the OCP-assigned Vendor ID (`42623`). The command range `0x01`-`0x20` is [reserved in the OCP registry](https://github.com/opencomputeproject/ocp-registry/blob/main/command-registry.md) and defined by the Caliptra Working Group.
 
-
 ### OCP VDM Header
 
 The SPDM VDM standard header identifies the vendor organization:
@@ -83,7 +82,7 @@ These command codes are assigned from the Caliptra range reserved in the [OCP co
 | `0x06`       | RequestDebugUnlock        | O   | Request debug unlock in production environment.                            |
 | `0x07`       | AuthorizeDebugUnlockToken | O   | Send debug unlock token to device for authorization.                       |
 | `0x08`       | ExportAttestedCsr         | O   | Export attested CSR for a Caliptra device identity key.                    |
-| `0x12`       | AuthorizedCommand         | O   | Carry authorization-gated subcommands. The SPDM authorization flow is TBD. |
+| `0x12`       | AuthorizedCommand         | O   | Carry challenge-authorized provisioning and fuse subcommands.              |
 
 R = Required, O = Optional
 
@@ -91,14 +90,46 @@ Implemented commands are advertised in the `external_commands` field returned by
 
 ## Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. Only subcommands marked Supported are currently dispatched; requests for Planned subcommands return `InvalidParameter`. `AuthorizedCommand` does not define the authorization mechanism by itself. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. Multi-byte payload integers and the subcommand ID are encoded little-endian on the wire.
 
-| Subcommand ID          | Name                       | Status        | Description                                        |
-| ---------------------- | -------------------------- | ------------- | -------------------------------------------------- |
-| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Supported     | Challenge acquisition for authorization-gated use. |
-| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Planned (TBD) | Provision vendor public key hash.                  |
-| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Planned (TBD) | Increase Caliptra minimum SVN.                     |
-| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Supported     | Program field entropy.                             |
-| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Planned (TBD) | Revoke vendor public key.                          |
-| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Planned (TBD) | Revoke vendor public key hash.                     |
-| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Planned (TBD) | Lock fuse partition.                               |
+| Subcommand ID          | Name                       | Status        | Description                                         |
+| ---------------------- | -------------------------- | ------------- | --------------------------------------------------- |
+| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Supported     | Acquire a one-use 48-byte authorization challenge.  |
+| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Supported     | Provision vendor public key hash.                   |
+| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Supported     | Increase Caliptra minimum SVN.                      |
+| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Supported     | Program field entropy.                              |
+| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Supported     | Revoke vendor public key.                           |
+| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Supported     | Revoke vendor public key hash.                      |
+| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Planned (TBD) | Lock fuse partition.                                |
+
+### Authorization Flow
+
+1. Send `GetAuthChallenge` with an empty subcommand payload. The successful response data is a 48-byte challenge.
+2. Serialize the target subcommand payload exactly as listed below, excluding `HybridSignature`.
+3. Sign `subcommand_id(BE) || payload || challenge` with both the authorized ECC P-384 and ML-DSA-87 keys.
+4. Append `HybridSignature` (`ecc_sig_r[48] || ecc_sig_s[48] || mldsa_sig[4628]`) to the payload and submit it under `AuthorizedCommand`.
+
+The challenge is consumed by the verification attempt and cannot be reused. Requests must have the exact documented size; missing, truncated, and oversized signatures are rejected with `InvalidPayloadSize`, while failed authorization returns `AccessDenied`.
+
+### Implemented Subcommand Payloads
+
+Byte offsets below begin immediately after the four-byte `subcommand_id`.
+
+| Subcommand | Bytes | Field | Encoding |
+| ---------- | ----- | ----- | -------- |
+| PVPK | 0:3 | `slot` | u32, little-endian |
+| | 4:51 | `hash` | u8[48] |
+| | 52:4775 | `signature` | HybridSignature |
+| MCMS | 0:3 | `flags` | u32, little-endian |
+| | 4:7 | `svn` | u32, little-endian |
+| | 8:4731 | `signature` | HybridSignature |
+| MCFP | 0:3 | `partition` | u32, little-endian |
+| | 4:4727 | `signature` | HybridSignature |
+| MRVK | 0:3 | `reserved` | u32, little-endian |
+| | 4:7 | `slot` | u32, little-endian |
+| | 8:11 | `key_type` | u32, little-endian |
+| | 12:15 | `key_index` | u32, little-endian |
+| | 16:4739 | `signature` | HybridSignature |
+| RVKH | 0:3 | `reserved` | u32, little-endian |
+| | 4:7 | `slot` | u32, little-endian |
+| | 8:4731 | `signature` | HybridSignature |

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -36,7 +36,6 @@ For the unified software architecture shared between OOB (SPDM VDM) and in-band 
 
 Caliptra commands assigned to SPDM VDM are carried within SPDM `VENDOR_DEFINED_REQUEST` and `VENDOR_DEFINED_RESPONSE` messages using the OCP-assigned Vendor ID (`42623`). The command range `0x01`-`0x20` is [reserved in the OCP registry](https://github.com/opencomputeproject/ocp-registry/blob/main/command-registry.md) and defined by the Caliptra Working Group.
 
-
 ### OCP VDM Header
 
 The SPDM VDM standard header identifies the vendor organization:
@@ -83,20 +82,52 @@ These command codes are assigned from the Caliptra range reserved in the [OCP co
 | `0x06`       | RequestDebugUnlock        | O   | Request debug unlock in production environment.                            |
 | `0x07`       | AuthorizeDebugUnlockToken | O   | Send debug unlock token to device for authorization.                       |
 | `0x08`       | ExportAttestedCsr         | O   | Export attested CSR for a Caliptra device identity key.                    |
-| `0x12`       | AuthorizedCommand         | O   | Carry authorization-gated subcommands. The SPDM authorization flow is TBD. |
+| `0x12`       | AuthorizedCommand         | O   | Carry challenge-authorized provisioning and fuse subcommands.              |
 
 R = Required, O = Optional
 
 ## Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. Only subcommands marked Supported are currently dispatched; requests for Planned subcommands return `InvalidParameter`. `AuthorizedCommand` does not define the authorization mechanism by itself. The concrete SPDM authorization mechanism and message flow are still under design and will be specified separately.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are carried under `AuthorizedCommand`. Multi-byte payload integers and the subcommand ID are encoded little-endian on the wire.
 
-| Subcommand ID          | Name                       | Status        | Description                                        |
-| ---------------------- | -------------------------- | ------------- | -------------------------------------------------- |
-| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Supported     | Challenge acquisition for authorization-gated use. |
-| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Planned (TBD) | Provision vendor public key hash.                  |
-| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Planned (TBD) | Increase Caliptra minimum SVN.                     |
-| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Supported     | Program field entropy.                             |
-| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Planned (TBD) | Revoke vendor public key.                          |
-| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Planned (TBD) | Revoke vendor public key hash.                     |
-| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Planned (TBD) | Lock fuse partition.                               |
+| Subcommand ID          | Name                       | Status        | Description                                         |
+| ---------------------- | -------------------------- | ------------- | --------------------------------------------------- |
+| `0x4D41_4343` (`MACC`) | GetAuthChallenge           | Supported     | Acquire a one-use 48-byte authorization challenge.  |
+| `0x5056_504B` (`PVPK`) | ProvisionVendorPkHash      | Supported     | Provision vendor public key hash.                   |
+| `0x4D43_4D53` (`MCMS`) | FuseIncreaseCaliptraMinSvn | Supported     | Increase Caliptra minimum SVN.                      |
+| `0x4D43_4650` (`MCFP`) | ProgramFieldEntropy        | Supported     | Program field entropy.                              |
+| `0x4D52_564B` (`MRVK`) | FuseRevokeVendorPubKey     | Supported     | Revoke vendor public key.                           |
+| `0x5256_4B48` (`RVKH`) | FuseRevokeVendorPkHash     | Supported     | Revoke vendor public key hash.                      |
+| `0x4946_504B` (`IFPK`) | FuseLockPartition          | Planned (TBD) | Lock fuse partition.                                |
+
+### Authorization Flow
+
+1. Send `GetAuthChallenge` with an empty subcommand payload. The successful response data is a 48-byte challenge.
+2. Serialize the target subcommand payload exactly as listed below, excluding `HybridSignature`.
+3. Sign `subcommand_id(BE) || payload || challenge` with both the authorized ECC P-384 and ML-DSA-87 keys.
+4. Append `HybridSignature` (`ecc_sig_r[48] || ecc_sig_s[48] || mldsa_sig[4628]`) to the payload and submit it under `AuthorizedCommand`.
+
+The challenge is consumed by the verification attempt and cannot be reused. Requests must have the exact documented size; missing, truncated, and oversized signatures are rejected with `InvalidPayloadSize`, while failed authorization returns `AccessDenied`.
+
+### Implemented Subcommand Payloads
+
+Byte offsets below begin immediately after the four-byte `subcommand_id`.
+
+| Subcommand | Bytes | Field | Encoding |
+| ---------- | ----- | ----- | -------- |
+| PVPK | 0:3 | `slot` | u32, little-endian |
+| | 4:51 | `hash` | u8[48] |
+| | 52:4775 | `signature` | HybridSignature |
+| MCMS | 0:3 | `flags` | u32, little-endian |
+| | 4:7 | `svn` | u32, little-endian |
+| | 8:4731 | `signature` | HybridSignature |
+| MCFP | 0:3 | `partition` | u32, little-endian |
+| | 4:4727 | `signature` | HybridSignature |
+| MRVK | 0:3 | `reserved` | u32, little-endian |
+| | 4:7 | `slot` | u32, little-endian |
+| | 8:11 | `key_type` | u32, little-endian |
+| | 12:15 | `key_index` | u32, little-endian |
+| | 16:4739 | `signature` | HybridSignature |
+| RVKH | 0:3 | `reserved` | u32, little-endian |
+| | 4:7 | `slot` | u32, little-endian |
+| | 8:4731 | `signature` | HybridSignature |

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -10,7 +10,7 @@ For the unified software architecture shared between OOB (SPDM VDM) and in-band 
 
 ## Transport Stack
 
-```
+```text
 ┌─────────────────────────────────────────┐
 │        Caliptra VDM Commands            │
 │ (FirmwareVersion, ExportAttestedCsr, …) │
@@ -105,31 +105,57 @@ The following subcommands are assigned to the SPDM VDM IANA authorization-gated 
 ### Authorization Flow
 
 1. Send `GetAuthChallenge` with an empty subcommand payload. The successful response data is a 48-byte challenge.
-2. Serialize the target subcommand payload exactly as listed below, excluding `HybridSignature`.
-3. Sign `subcommand_id(BE) || payload || challenge` with both the authorized ECC P-384 and ML-DSA-87 keys.
-4. Append `HybridSignature` (`ecc_sig_r[48] || ecc_sig_s[48] || mldsa_sig[4628]`) to the payload and submit it under `AuthorizedCommand`.
+2. Serialize the target subcommand payload exactly as listed below, excluding the common authorization trailer.
+3. Sign `subcommand_id(BE) || payload || challenge` with both the authorized ECC P-384 and ML-DSA-87 keys. The signed command ID is big-endian even though the `AuthorizedCommand` wire field is little-endian.
+4. Append the common authorization trailer and submit the complete request under `AuthorizedCommand`.
 
-The challenge is consumed by the verification attempt and cannot be reused. Requests must have the exact documented size; missing, truncated, and oversized signatures are rejected with `InvalidPayloadSize`, while failed authorization returns `AccessDenied`.
+The common authorization trailer is:
+
+```text
+nonce[48] || ecc_pub_x[48] || ecc_pub_y[48] || mldsa_pub[2592] || HybridSignature
+```
+
+`nonce` echoes the challenge. `HybridSignature` is `ecc_sig_r[48] || ecc_sig_s[48] || mldsa_sig[4628]`. The challenge is consumed by the verification attempt and cannot be reused. Requests must have the exact documented size; missing, truncated, and oversized trailers are rejected with `InvalidPayloadSize`, while failed authorization returns `AccessDenied`.
 
 ### Implemented Subcommand Payloads
 
-Byte offsets below begin immediately after the four-byte `subcommand_id`.
+Byte offsets below begin immediately after the four-byte `subcommand_id` and include the complete authorization trailer.
 
 | Subcommand | Bytes | Field | Encoding |
 | ---------- | ----- | ----- | -------- |
 | PVPK | 0:3 | `slot` | u32, little-endian |
 | | 4:51 | `hash` | u8[48] |
-| | 52:4775 | `signature` | HybridSignature |
-| MCMS | 0:3 | `flags` | u32, little-endian |
+| | 52:99 | `nonce` | u8[48] |
+| | 100:147 | `ecc_pub_x` | u8[48] |
+| | 148:195 | `ecc_pub_y` | u8[48] |
+| | 196:2787 | `mldsa_pub` | u8[2592] |
+| | 2788:7511 | `signature` | HybridSignature |
+| MCMS | 0:3 | `flags` | u32, little-endian; must be zero |
 | | 4:7 | `svn` | u32, little-endian |
-| | 8:4731 | `signature` | HybridSignature |
+| | 8:55 | `nonce` | u8[48] |
+| | 56:103 | `ecc_pub_x` | u8[48] |
+| | 104:151 | `ecc_pub_y` | u8[48] |
+| | 152:2743 | `mldsa_pub` | u8[2592] |
+| | 2744:7467 | `signature` | HybridSignature |
 | MCFP | 0:3 | `partition` | u32, little-endian |
-| | 4:4727 | `signature` | HybridSignature |
-| MRVK | 0:3 | `reserved` | u32, little-endian |
+| | 4:51 | `nonce` | u8[48] |
+| | 52:99 | `ecc_pub_x` | u8[48] |
+| | 100:147 | `ecc_pub_y` | u8[48] |
+| | 148:2739 | `mldsa_pub` | u8[2592] |
+| | 2740:7463 | `signature` | HybridSignature |
+| MRVK | 0:3 | `reserved` | u32, little-endian; must be zero |
 | | 4:7 | `slot` | u32, little-endian |
 | | 8:11 | `key_type` | u32, little-endian |
 | | 12:15 | `key_index` | u32, little-endian |
-| | 16:4739 | `signature` | HybridSignature |
-| RVKH | 0:3 | `reserved` | u32, little-endian |
+| | 16:63 | `nonce` | u8[48] |
+| | 64:111 | `ecc_pub_x` | u8[48] |
+| | 112:159 | `ecc_pub_y` | u8[48] |
+| | 160:2751 | `mldsa_pub` | u8[2592] |
+| | 2752:7475 | `signature` | HybridSignature |
+| RVKH | 0:3 | `reserved` | u32, little-endian; must be zero |
 | | 4:7 | `slot` | u32, little-endian |
-| | 8:4731 | `signature` | HybridSignature |
+| | 8:55 | `nonce` | u8[48] |
+| | 56:103 | `ecc_pub_x` | u8[48] |
+| | 104:151 | `ecc_pub_y` | u8[48] |
+| | 152:2743 | `mldsa_pub` | u8[2592] |
+| | 2744:7467 | `signature` | HybridSignature |

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -270,12 +270,10 @@ Caliptra Core has loaded the runtime image into MCU SRAM.
 There is also an authorized runtime mailbox command,
 `MC_FUSE_INCREASE_CALIPTRA_MIN_SVN`, that advances the Caliptra firmware minimum
 SVN directly in the `CALIPTRA_FW_SVN` fuse. The reference runtime exposes this
-command through the in-band MCI mailbox path today and requires the runtime
-authorization flow. It rejects requests that are zero, above 128, lower than the
-current fuse floor, or higher than the currently running Caliptra firmware SVN
-reported by `FW_INFO`. Platforms that need BMC-originated workflows can route
-the command through a trusted SoC-side agent today, or through an OOB SPDM VDM
-path when that platform support is added.
+command through both the in-band MCI mailbox and OOB SPDM VDM paths and requires
+the runtime authorization flow. It rejects requests that are zero, above 128,
+lower than the current fuse floor, or higher than the currently running
+Caliptra firmware SVN reported by `FW_INFO`.
 
 ## Management Command Transport Expectations
 
@@ -285,17 +283,14 @@ treated as interchangeable:
 | Path | Who can use it | Privileged commands in that path |
 |---|---|---|
 | MCI mailbox runtime interface | A SoC-side agent with MCI mailbox access, or an explicit platform proxy to that agent | Runtime handlers exist for `MC_PROVISION_VENDOR_PK_HASH`, `MC_FUSE_REVOKE_VENDOR_PUB_KEY`, `MC_FUSE_REVOKE_VENDOR_PK_HASH`, `MC_FUSE_INCREASE_CALIPTRA_MIN_SVN`, `MC_FE_PROG`, and generic fuse read/write/lock commands. |
-| OOB SPDM VDM over MCTP/I3C | External BMC/OOB requester speaking the Caliptra SPDM VDM protocol | `Get Auth Challenge` and `Program Field Entropy` under the SPDM `Authorized Command` code today; platforms may add OOB wrappers for additional authorized commands as support lands. |
+| OOB SPDM VDM over MCTP/I3C | External BMC/OOB requester speaking the Caliptra SPDM VDM protocol | `Get Auth Challenge`, `Provision Vendor PK Hash`, `Fuse Increase Caliptra Min SVN`, `Program Field Entropy`, `Fuse Revoke Vendor Public Key`, and `Fuse Revoke Vendor PK Hash` under SPDM `AuthorizedCommand`. |
 
 The `caliptra-util-host` mailbox transport is a software abstraction that
 formats supported MCU mailbox commands through a platform-provided
 `MailboxDriver`; it does not give an external BMC native access to the MCI
 mailbox, and not every runtime MCI command is wrapped by the current host
-utility dispatch tables. If an OOB BMC must initiate MCI-only operations such
-as PK provisioning, PK revocation, or direct Caliptra SVN increment, the
-platform must provide a trusted SoC-side service or bridge that owns the MCI
-access, exposes the intended command wrappers, and enforces the deployment
-policy.
+utility dispatch tables. MCI-only operations still require a trusted SoC-side
+service or bridge that owns MCI access and enforces the deployment policy.
 
 ## Vendor Public Key Selection and Rotation
 Caliptra MCU supports a vendor public key selection and rotation scheme
@@ -348,12 +343,9 @@ New vendor PK hash slots can be provisioned in the field through
 `MC_PROVISION_VENDOR_PK_HASH`. The command writes a 48-byte SHA-384 vendor PK
 hash into the requested slot. It is idempotent if the slot already contains the
 same hash, and fails if the slot is invalid or contains a different nonzero
-hash. It is an authorized MCU Runtime mailbox command, so the requester must
-complete the runtime authorization flow before invoking it.
-
-This command is not exposed through the OOB SPDM VDM command set today. If the
-BMC owns the operational workflow, it must call a trusted SoC-side agent or
-platform proxy that has MCI mailbox access.
+hash. It is exposed through both the authorized MCU Runtime mailbox and OOB
+SPDM VDM `AuthorizedCommand` paths, so the requester must complete the runtime
+authorization flow before invoking it.
 
 ### Key Revocation
 
@@ -373,9 +365,8 @@ prevents a requester from bricking the current boot by revoking its own active
 trust path; revocation is intended to happen after the device has successfully
 booted with a replacement key or replacement PK hash slot.
 
-Like provisioning, these revocation commands are not exposed through the OOB
-SPDM VDM command set today. A BMC-originated field workflow therefore needs a
-SoC-side MCI mailbox agent or an explicit platform proxy.
+These revocation commands are exposed through the OOB SPDM VDM
+`AuthorizedCommand` path over MCTP/I3C as well as through the MCI mailbox path.
 
 #### Command Authorization Mechanism
 
@@ -383,13 +374,13 @@ Command authorization across both MCU mailbox and SPDM VDM transports uses an
 asymmetric challenge-response signature flow. To execute an authorized command
 (e.g., key revocation or field entropy programming), the requester must:
 
-1. Request a 32-byte challenge nonce from the device via `Get Auth Challenge`.
+1. Request a one-use 48-byte challenge nonce from the device via `Get Auth Challenge`.
 2. Compute dual asymmetric signatures (ECC P-384 and ML-DSA-87) over
-   `cmd_id(BE) || payload(LE) || challenge(32)`.
+   `cmd_id(BE) || payload(LE) || challenge(48)`.
 3. Submit the command payload accompanied by the resulting hybrid signature.
 
 Integrators configure the authorizer policy by implementing the platform
-authorizer trait (`CommandAuthorizer` for mailbox or `CaliptraVdmCommands` for
+authorizer trait (`CommandAuthorizer` for mailbox or `CaliptraVdmAuthorization` for
 SPDM VDM) and provisioning the corresponding verification public keys in OTP
 fuses, secure platform storage, or embedded in firmware directly.
 

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -293,27 +293,30 @@ utility dispatch tables. MCI-only operations still require a trusted SoC-side
 service or bridge that owns MCI access and enforces the deployment policy.
 
 ## Vendor Public Key Selection and Rotation
+
 Caliptra MCU supports a vendor public key selection and rotation scheme
 based on fuses and hardware strapping pins. This section describes how the ROM
 selects the active vendor public key slot and how integrators can manage
 rotation and revocation.
 
 ### Key Policy and Selection Process
+
 The ROM follows this process to select a vendor public key hash slot (out of 16
 available slots):
-1.  **Validity Check**: The ROM reads the `VENDOR_PK_HASH_VALID` fuse mask.
+
+1. **Validity Check**: The ROM reads the `VENDOR_PK_HASH_VALID` fuse mask.
     Each bit corresponds to a slot. If a bit is set to `1`, the slot is
     considered invalid and skipped.
-2.  **Revocation Check**: For each valid slot, the ROM checks the revocation
+2. **Revocation Check**: For each valid slot, the ROM checks the revocation
     status of the keys in the `CPTRA_CORE_ECC_REVOCATION_X`,
     `CPTRA_CORE_MLDSA_REVOCATION_X`, and `CPTRA_CORE_LMS_REVOCATION_X` fields:
-    -   **ECC Keys**: Checked against the ECC revocation fuses (4 bits per
+    - **ECC Keys**: Checked against the ECC revocation fuses (4 bits per
         slot).
-    -   **PQC Keys**: Checked against PQC revocation fuses (4 bits for MLDSA,
+    - **PQC Keys**: Checked against PQC revocation fuses (4 bits for MLDSA,
         16 bits for LMS).
     A slot is considered **functional** if it has at least one unrevoked ECC key
     AND at least one unrevoked PQC key.
-3.  **Default Selection**: By default, the ROM selects the **first functional
+3. **Default Selection**: By default, the ROM selects the **first functional
     slot** it encounters (searching from slot 0 to 15). However, this logic can
     be overridden by passing a different implementation of the `VendorKeyPolicy`
     into the ROM parameters.
@@ -352,11 +355,11 @@ authorization flow before invoking it.
 Keys can be revoked permanently by burning fuses. MCU Runtime exposes
 authorized MCI mailbox commands for the supported in-field flows:
 
--   `MC_FUSE_REVOKE_VENDOR_PUB_KEY` revokes an individual firmware
+- `MC_FUSE_REVOKE_VENDOR_PUB_KEY` revokes an individual firmware
     verification key within a vendor PK hash slot. The command supports ECC
     P-384, LMS, and MLDSA-87 key types and burns the corresponding bit in the
     slot's revocation field.
--   `MC_FUSE_REVOKE_VENDOR_PK_HASH` revokes an entire vendor PK hash slot by
+- `MC_FUSE_REVOKE_VENDOR_PK_HASH` revokes an entire vendor PK hash slot by
     setting the corresponding bit in `VENDOR_PK_HASH_VALID` to `1`.
 
 Both commands use the runtime authorization flow. They reject requests that
@@ -384,6 +387,30 @@ authorizer trait (`CommandAuthorizer` for mailbox or `CaliptraVdmAuthorization` 
 SPDM VDM) and provisioning the corresponding verification public keys in OTP
 fuses, secure platform storage, or embedded in firmware directly.
 
+The `caliptra-spdm-validator` host tool supports the four authorized fuse VDMs
+through the `[provision_vendor_pk_hash]`, `[increase_caliptra_min_svn]`,
+`[revoke_vendor_pub_key]`, and `[revoke_vendor_pk_hash]` configuration sections.
+All integer fields below are little-endian, and the signature covers exactly the
+bytes before `HybridSignature`:
+
+| Subcommand | Canonical ID | Authorized payload |
+|---|---:|---|
+| Provision Vendor PK Hash | `0x5056504b` (`PVPK`) | `slot:u32 \| hash:[u8;48] \| HybridSignature` |
+| Increase Caliptra Min SVN | `0x4d434d53` (`MCMS`) | `flags:u32 \| svn:u32 \| HybridSignature` |
+| Revoke Vendor Public Key | `0x4d52564b` (`MRVK`) | `reserved:u32 \| slot:u32 \| key_type:u32 \| key_index:u32 \| HybridSignature` |
+| Revoke Vendor PK Hash | `0x52564b48` (`RVKH`) | `reserved:u32 \| slot:u32 \| HybridSignature` |
+
+The shared `[authorized_commands]` section supplies the test signer keys. The
+integration harness selects `authorization`, `provision-vendor-pk-hash`,
+`increase-min-svn`, `revoke-vendor-pub-key`, or `revoke-vendor-pk-hash` with
+`--fuse-suite`; each destructive suite boots a separate emulator instance. It
+asserts responder completion codes for malformed, authorization, and policy
+failures rather than treating transport/session failures as expected rejection.
+These operations burn OTP state: validation must use disposable devices or a
+fresh emulator instance for each independently destructive scenario. The
+checked-in test keys are emulator fixtures only and must not be used as
+production authorization credentials.
+
 For per-key revocation, once all usable bits for a key type are burned in a
 slot, that key type is fully revoked in that slot. The last key index for a
 given key type cannot be revoked, matching Caliptra's requirement that a slot
@@ -401,10 +428,11 @@ revoked (e.g., moving to a new key version) but other keys within that PK hash
 remain trusted.
 
 **Process**:
-1.  Push a new Runtime (RT) firmware signed with a new key.
-2.  After the device boots with the replacement key, an authorized requester
+
+1. Push a new Runtime (RT) firmware signed with a new key.
+2. After the device boots with the replacement key, an authorized requester
     sends `MC_FUSE_REVOKE_VENDOR_PUB_KEY` to MCU Runtime for the old key.
-3.  MCU Runtime validates that the target key was not used for the current boot
+3. MCU Runtime validates that the target key was not used for the current boot
     and burns the corresponding revocation bit.
 
 ```mermaid
@@ -428,13 +456,14 @@ This flow is used when the entire PK hash slot is compromised or needs to be
 replaced, requiring a transition to a new PK hash slot.
 
 **Process**:
-1.  Provision the new vendor PK hash into an empty inactive slot if it was not
+
+1. Provision the new vendor PK hash into an empty inactive slot if it was not
     provisioned during manufacturing.
-2.  Push a new Runtime (RT) firmware signed with a key from the new PK hash slot.
-3.  Additionally assert the hardware strapping pin (bit 1 of
+2. Push a new Runtime (RT) firmware signed with a key from the new PK hash slot.
+3. Additionally assert the hardware strapping pin (bit 1 of
     `mci_reg_generic_input_wires[1]`) to enable rotation.
-4.  On reboot, the MCU ROM will select the new PK hash slot.
-5.  An authorized requester sends `MC_FUSE_REVOKE_VENDOR_PK_HASH` to MCU
+4. On reboot, the MCU ROM will select the new PK hash slot.
+5. An authorized requester sends `MC_FUSE_REVOKE_VENDOR_PK_HASH` to MCU
     Runtime to burn the old PK hash slot as invalid.
 
 ```mermaid
@@ -620,4 +649,3 @@ region, separate from the application RAM region.  Userspace processes
 cannot access it directly; they interact with the stored data only
 through the kernel capsule syscall interfaces
 (`DpeHandleStore` driver `0x8000_0020` and `PcrStore` driver `0x8000_0021`).
-

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -166,7 +166,14 @@ test-pldm-discovery = []
 test-pldm-fw-update = []
 test-pldm-fw-update-e2e = []
 test-pldm-streaming-boot = ["streaming-boot"]
-test-caliptra-util-host-spdm-vdm-validator = ["spdm"]
+# Authorized fuse VDM requests carry a 4.7 KiB hybrid signature and therefore
+# require bounded CHUNK_SEND reassembly before VDM dispatch. Keep this out of
+# the general SPDM feature so production and unrelated test bundles do not pay
+# the code-size and build-time cost.
+test-caliptra-util-host-spdm-vdm-validator = [
+  "spdm",
+  "caliptra-mcu-spdm-stack/generic-large-request",
+]
 test-mctp-spdm-attestation = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-tcb = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-mixed = ["spdm", "flash-boot"]

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -306,6 +306,12 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
     if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
         return Err(CaliptraCompletionCode::InvalidParameter);
     }
+    let pk_hash_from_slot = otp
+        .read_vendor_pk_hash(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    if pk_hash_from_slot.iter().all(|byte| *byte == 0) {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
 
     let caliptra_info = fw_info(alloc)
         .await
@@ -313,10 +319,6 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
     let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
         .read_vendor_pk_hash()
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-    let pk_hash_from_slot = otp
-        .read_vendor_pk_hash(vendor_pk_hash_slot)
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
     if booted_pk_hash == pk_hash_from_slot {
         const FW_VERIFICATION_PQC_TYPE_MLDSA: u32 = 1;
         const FW_VERIFICATION_PQC_TYPE_LMS: u32 = 3;
@@ -340,7 +342,19 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
 }
 
 pub fn revoke_vendor_pk_hash(vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+    const MAX_VENDOR_PK_HASH_SLOTS: u32 = 16;
+    if vendor_pk_hash_slot >= MAX_VENDOR_PK_HASH_SLOTS {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
     let otp = Otp::<DefaultSyscalls>::new();
+    // A cleared validity bit is the persistent indication that this slot was
+    // already revoked. Preserve the mailbox policy's idempotent behavior
+    // without attempting to read a now-invalid slot.
+    if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+        return Ok(());
+    }
+
     let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
         .read_vendor_pk_hash()
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -65,7 +65,11 @@ fn external_command_capabilities() -> ExternalCommandCapabilities {
 fn authorized_subcommand_capabilities() -> AuthorizedSubcommandCapabilities {
     if cfg!(feature = "spdm") {
         AuthorizedSubcommandCapabilities::GET_AUTH_CHALLENGE
+            | AuthorizedSubcommandCapabilities::PROVISION_VENDOR_PK_HASH
+            | AuthorizedSubcommandCapabilities::FUSE_INCREASE_CALIPTRA_MIN_SVN
             | AuthorizedSubcommandCapabilities::PROGRAM_FIELD_ENTROPY
+            | AuthorizedSubcommandCapabilities::FUSE_REVOKE_VENDOR_PUBLIC_KEY
+            | AuthorizedSubcommandCapabilities::FUSE_REVOKE_VENDOR_PK_HASH
     } else {
         AuthorizedSubcommandCapabilities::empty()
     }
@@ -302,7 +306,11 @@ mod tests {
         assert_eq!(
             authorized.contains(
                 AuthorizedSubcommandCapabilities::GET_AUTH_CHALLENGE
+                    | AuthorizedSubcommandCapabilities::PROVISION_VENDOR_PK_HASH
+                    | AuthorizedSubcommandCapabilities::FUSE_INCREASE_CALIPTRA_MIN_SVN
                     | AuthorizedSubcommandCapabilities::PROGRAM_FIELD_ENTROPY
+                    | AuthorizedSubcommandCapabilities::FUSE_REVOKE_VENDOR_PUBLIC_KEY
+                    | AuthorizedSubcommandCapabilities::FUSE_REVOKE_VENDOR_PK_HASH
             ),
             cfg!(feature = "spdm")
         );

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -160,7 +160,7 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
 
     async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
         &self,
-        _flags: u32,
+        flags: u32,
         svn: u32,
         payload: &[u8],
         sig: &HybridSignature,
@@ -183,6 +183,9 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
             )
             .await
             .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        if flags != 0 {
+            return Err(CaliptraCompletionCode::InvalidParameter);
+        }
         CaliptraCmdBackend
             .increase_caliptra_min_svn(scratch, svn)
             .await
@@ -226,7 +229,7 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
     #[allow(clippy::too_many_arguments)]
     async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
         &self,
-        _reserved: u32,
+        reserved: u32,
         slot: u32,
         key_type: u32,
         key_index: u32,
@@ -251,6 +254,9 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
             )
             .await
             .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        if reserved != 0 {
+            return Err(CaliptraCompletionCode::InvalidParameter);
+        }
         CaliptraCmdBackend
             .revoke_vendor_pub_key(scratch, slot, key_type, key_index)
             .await
@@ -259,7 +265,7 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
 
     async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
         &self,
-        _reserved: u32,
+        reserved: u32,
         slot: u32,
         payload: &[u8],
         sig: &HybridSignature,
@@ -282,6 +288,9 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
             )
             .await
             .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        if reserved != 0 {
+            return Err(CaliptraCompletionCode::InvalidParameter);
+        }
         CaliptraCmdBackend
             .revoke_vendor_pk_hash(slot)
             .await

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -11,6 +11,8 @@ use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::{
     CaliptraCompletionCode, CaliptraVdmAuthorization, CaliptraVdmResult, CaliptraVdmStreamOps,
+    FE_PROG_CMD_ID, INCREASE_CALIPTRA_MIN_SVN_CMD_ID, PROVISION_VENDOR_PK_HASH_CMD_ID,
+    REVOKE_VENDOR_PK_HASH_CMD_ID, REVOKE_VENDOR_PUB_KEY_CMD_ID,
 };
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
@@ -20,9 +22,6 @@ use mcu_caliptra_api_lite::{
 
 use crate::caliptra_cmd_handler::CaliptraCmdBackend;
 use crate::mcu_mbox::cmd_auth_mock;
-
-/// MC_FE_PROG sub-command (`MCFP`).
-const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
 
 // Kernel chunked-mailbox state rejects other processes; this flag serializes this
 // app's DebugUnlock stream and lets abort clean up the in-flight mailbox request.
@@ -128,6 +127,68 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
     }
 
     #[allow(clippy::too_many_arguments)]
+    async fn provision_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        slot: u32,
+        hash: &[u8; 48],
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer
+            .verify_signatures(
+                PROVISION_VENDOR_PK_HASH_CMD_ID,
+                payload,
+                nonce,
+                ecc_pub_x,
+                ecc_pub_y,
+                mldsa_pub,
+                sig,
+            )
+            .await
+            .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        CaliptraCmdBackend
+            .provision_vendor_pk_hash(slot, hash)
+            .await
+            .map_err(map_common_completion)
+    }
+
+    async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
+        &self,
+        _flags: u32,
+        svn: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer
+            .verify_signatures(
+                INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+                payload,
+                nonce,
+                ecc_pub_x,
+                ecc_pub_y,
+                mldsa_pub,
+                sig,
+            )
+            .await
+            .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        CaliptraCmdBackend
+            .increase_caliptra_min_svn(scratch, svn)
+            .await
+            .map_err(map_common_completion)
+    }
+
     async fn program_field_entropy<A: SpdmPalAlloc>(
         &self,
         partition: u32,
@@ -158,6 +219,71 @@ impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
             .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
         CaliptraCmdBackend
             .program_field_entropy(scratch, partition)
+            .await
+            .map_err(map_common_completion)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
+        &self,
+        _reserved: u32,
+        slot: u32,
+        key_type: u32,
+        key_index: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer
+            .verify_signatures(
+                REVOKE_VENDOR_PUB_KEY_CMD_ID,
+                payload,
+                nonce,
+                ecc_pub_x,
+                ecc_pub_y,
+                mldsa_pub,
+                sig,
+            )
+            .await
+            .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        CaliptraCmdBackend
+            .revoke_vendor_pub_key(scratch, slot, key_type, key_index)
+            .await
+            .map_err(map_common_completion)
+    }
+
+    async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        _reserved: u32,
+        slot: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer
+            .verify_signatures(
+                REVOKE_VENDOR_PK_HASH_CMD_ID,
+                payload,
+                nonce,
+                ecc_pub_x,
+                ecc_pub_y,
+                mldsa_pub,
+                sig,
+            )
+            .await
+            .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        CaliptraCmdBackend
+            .revoke_vendor_pk_hash(slot)
             .await
             .map_err(map_common_completion)
     }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
@@ -7,7 +7,7 @@ use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmAuthorization;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
-    CaliptraCompletionCode, CaliptraVdmCmdResult,
+    CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmResult,
 };
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
@@ -15,11 +15,6 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 const ECC_P384_COORD_SIZE: usize = 48;
 /// ML-DSA-87 public-key size (bytes).
 const MLDSA87_PUB_KEY_SIZE: usize = 2592;
-
-// Canonical wire layout (after the AUTHORIZED_COMMAND sub-command id):
-//   partition(4) | nonce(48) | ecc_pub_x(48) | ecc_pub_y(48) | mldsa_pub(2592) | sig(HybridSignature)
-// Signatures LAST (nonce + public keys precede them), matching the caliptra-sw
-// ProductionAuthDebugUnlockToken field order.
 #[repr(C)]
 #[derive(Debug, FromBytes, Immutable, KnownLayout)]
 struct FeProgVdmReq {
@@ -30,6 +25,10 @@ struct FeProgVdmReq {
     mldsa_pub: [u8; MLDSA87_PUB_KEY_SIZE],
     sig: HybridSignature,
 }
+const PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN: usize = 4 + 48;
+const INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN: usize = 4 + 4;
+const REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN: usize = 4 + 4 + 4 + 4;
+const REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN: usize = 4 + 4;
 
 const _: () = assert!(
     core::mem::size_of::<FeProgVdmReq>()
@@ -61,8 +60,16 @@ const _: () = assert!(
 
 /// MC_GET_AUTH_CMD_CHALLENGE sub-command (`MACC`).
 pub const GET_AUTH_CHALLENGE_CMD_ID: u32 = 0x4D41_4343;
+/// MC_PROVISION_VENDOR_PK_HASH sub-command (`PVPK`).
+pub const PROVISION_VENDOR_PK_HASH_CMD_ID: u32 = 0x5056_504B;
+/// MC_FUSE_INCREASE_CALIPTRA_MIN_SVN sub-command (`MCMS`).
+pub const INCREASE_CALIPTRA_MIN_SVN_CMD_ID: u32 = 0x4D43_4D53;
 /// MC_FE_PROG sub-command (`MCFP`).
 pub const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
+/// MC_FUSE_REVOKE_VENDOR_PUB_KEY sub-command (`MRVK`).
+pub const REVOKE_VENDOR_PUB_KEY_CMD_ID: u32 = 0x4D52_564B;
+/// MC_FUSE_REVOKE_VENDOR_PK_HASH sub-command (`RVKH`).
+pub const REVOKE_VENDOR_PK_HASH_CMD_ID: u32 = 0x5256_4B48;
 
 pub(crate) async fn handle<H, A>(
     cmds: &H,
@@ -86,7 +93,19 @@ where
     let payload = &req[4..];
     match sub_cmd {
         GET_AUTH_CHALLENGE_CMD_ID => handle_get_auth_challenge(cmds, payload, scratch, out).await,
+        PROVISION_VENDOR_PK_HASH_CMD_ID => {
+            handle_provision_vendor_pk_hash(cmds, payload, scratch, out).await
+        }
+        INCREASE_CALIPTRA_MIN_SVN_CMD_ID => {
+            handle_increase_caliptra_min_svn(cmds, payload, scratch, out).await
+        }
         FE_PROG_CMD_ID => handle_fe_prog(cmds, payload, scratch, out).await,
+        REVOKE_VENDOR_PUB_KEY_CMD_ID => {
+            handle_revoke_vendor_pub_key(cmds, payload, scratch, out).await
+        }
+        REVOKE_VENDOR_PK_HASH_CMD_ID => {
+            handle_revoke_vendor_pk_hash(cmds, payload, scratch, out).await
+        }
         _ => CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidParameter),
     }
 }
@@ -112,6 +131,61 @@ where
         Ok(n) => CaliptraVdmCmdResult::Response(1 + n),
         Err(code) => CaliptraVdmCmdResult::Error(code),
     }
+}
+
+async fn handle_provision_vendor_pk_hash<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let (payload, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, sig) =
+        match split_authorized_request(req, PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN) {
+            Ok(parsed) => parsed,
+            Err(code) => return CaliptraVdmCmdResult::Error(code),
+        };
+    let slot = read_u32_le(&payload[..4]);
+    let hash = match <&[u8; 48]>::try_from(&payload[4..]) {
+        Ok(hash) => hash,
+        Err(_) => return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidParameter),
+    };
+    finish_authorized_command(
+        cmds.provision_vendor_pk_hash(
+            slot, hash, payload, sig, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+async fn handle_increase_caliptra_min_svn<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let (payload, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, sig) =
+        match split_authorized_request(req, INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN) {
+            Ok(parsed) => parsed,
+            Err(code) => return CaliptraVdmCmdResult::Error(code),
+        };
+    let flags = read_u32_le(&payload[..4]);
+    let svn = read_u32_le(&payload[4..8]);
+    finish_authorized_command(
+        cmds.increase_caliptra_min_svn(
+            flags, svn, payload, sig, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, scratch,
+        )
+        .await,
+        out,
+    )
 }
 
 async fn handle_fe_prog<H, A>(
@@ -143,6 +217,117 @@ where
         )
         .await
     {
+        Ok(()) => match super::write_success(out) {
+            Ok(_) => CaliptraVdmCmdResult::Response(1),
+            Err(code) => CaliptraVdmCmdResult::Error(code),
+        },
+        Err(code) => CaliptraVdmCmdResult::Error(code),
+    }
+}
+
+async fn handle_revoke_vendor_pub_key<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let (payload, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, sig) =
+        match split_authorized_request(req, REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN) {
+            Ok(parsed) => parsed,
+            Err(code) => return CaliptraVdmCmdResult::Error(code),
+        };
+    let reserved = read_u32_le(&payload[..4]);
+    let slot = read_u32_le(&payload[4..8]);
+    let key_type = read_u32_le(&payload[8..12]);
+    let key_index = read_u32_le(&payload[12..16]);
+    finish_authorized_command(
+        cmds.revoke_vendor_pub_key(
+            reserved, slot, key_type, key_index, payload, sig, nonce, ecc_pub_x, ecc_pub_y,
+            mldsa_pub, scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+async fn handle_revoke_vendor_pk_hash<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let (payload, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, sig) =
+        match split_authorized_request(req, REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN) {
+            Ok(parsed) => parsed,
+            Err(code) => return CaliptraVdmCmdResult::Error(code),
+        };
+    let reserved = read_u32_le(&payload[..4]);
+    let slot = read_u32_le(&payload[4..8]);
+    finish_authorized_command(
+        cmds.revoke_vendor_pk_hash(
+            reserved, slot, payload, sig, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+fn split_authorized_request(
+    req: &[u8],
+    payload_len: usize,
+) -> Result<
+    (
+        &[u8],
+        &[u8; AUTH_CMD_NONCE_LEN],
+        &[u8; 48],
+        &[u8; 48],
+        &[u8; 2592],
+        &HybridSignature,
+    ),
+    CaliptraCompletionCode,
+> {
+    let auth_len = AUTH_CMD_NONCE_LEN + 48 + 48 + 2592 + core::mem::size_of::<HybridSignature>();
+    let expected_len = payload_len
+        .checked_add(auth_len)
+        .ok_or(CaliptraCompletionCode::InvalidPayloadSize)?;
+    if req.len() != expected_len {
+        return Err(CaliptraCompletionCode::InvalidPayloadSize);
+    }
+    let (payload, auth) = req.split_at(payload_len);
+    let (nonce, auth) = auth.split_at(AUTH_CMD_NONCE_LEN);
+    let (ecc_pub_x, auth) = auth.split_at(48);
+    let (ecc_pub_y, auth) = auth.split_at(48);
+    let (mldsa_pub, sig_bytes) = auth.split_at(2592);
+    let nonce = <&[u8; AUTH_CMD_NONCE_LEN]>::try_from(nonce)
+        .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    let ecc_pub_x =
+        <&[u8; 48]>::try_from(ecc_pub_x).map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    let ecc_pub_y =
+        <&[u8; 48]>::try_from(ecc_pub_y).map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    let mldsa_pub =
+        <&[u8; 2592]>::try_from(mldsa_pub).map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    let sig = HybridSignature::ref_from_bytes(sig_bytes)
+        .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    Ok((payload, nonce, ecc_pub_x, ecc_pub_y, mldsa_pub, sig))
+}
+
+fn read_u32_le(bytes: &[u8]) -> u32 {
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+fn finish_authorized_command(
+    result: CaliptraVdmResult<()>,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult {
+    match result {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
@@ -7,7 +7,7 @@ use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmAuthorization;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
-    CaliptraCompletionCode, CaliptraVdmCmdResult,
+    CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmResult,
 };
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
@@ -15,11 +15,6 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 const ECC_P384_COORD_SIZE: usize = 48;
 /// ML-DSA-87 public-key size (bytes).
 const MLDSA87_PUB_KEY_SIZE: usize = 2592;
-
-// Canonical wire layout (after the AUTHORIZED_COMMAND sub-command id):
-//   partition(4) | nonce(48) | ecc_pub_x(48) | ecc_pub_y(48) | mldsa_pub(2592) | sig(HybridSignature)
-// Signatures LAST (nonce + public keys precede them), matching the caliptra-sw
-// ProductionAuthDebugUnlockToken field order.
 #[repr(C)]
 #[derive(Debug, FromBytes, Immutable, KnownLayout)]
 struct FeProgVdmReq {
@@ -30,6 +25,10 @@ struct FeProgVdmReq {
     mldsa_pub: [u8; MLDSA87_PUB_KEY_SIZE],
     sig: HybridSignature,
 }
+const PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN: usize = 4 + 48;
+const INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN: usize = 4 + 4;
+const REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN: usize = 4 + 4 + 4 + 4;
+const REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN: usize = 4 + 4;
 
 const _: () = assert!(
     core::mem::size_of::<FeProgVdmReq>()
@@ -61,8 +60,16 @@ const _: () = assert!(
 
 /// MC_GET_AUTH_CMD_CHALLENGE sub-command (`MACC`).
 pub const GET_AUTH_CHALLENGE_CMD_ID: u32 = 0x4D41_4343;
+/// MC_PROVISION_VENDOR_PK_HASH sub-command (`PVPK`).
+pub const PROVISION_VENDOR_PK_HASH_CMD_ID: u32 = 0x5056_504B;
+/// MC_FUSE_INCREASE_CALIPTRA_MIN_SVN sub-command (`MCMS`).
+pub const INCREASE_CALIPTRA_MIN_SVN_CMD_ID: u32 = 0x4D43_4D53;
 /// MC_FE_PROG sub-command (`MCFP`).
 pub const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
+/// MC_FUSE_REVOKE_VENDOR_PUB_KEY sub-command (`MRVK`).
+pub const REVOKE_VENDOR_PUB_KEY_CMD_ID: u32 = 0x4D52_564B;
+/// MC_FUSE_REVOKE_VENDOR_PK_HASH sub-command (`RVKH`).
+pub const REVOKE_VENDOR_PK_HASH_CMD_ID: u32 = 0x5256_4B48;
 
 pub(crate) async fn handle<H, A>(
     cmds: &H,
@@ -86,7 +93,19 @@ where
     let payload = &req[4..];
     match sub_cmd {
         GET_AUTH_CHALLENGE_CMD_ID => handle_get_auth_challenge(cmds, payload, scratch, out).await,
+        PROVISION_VENDOR_PK_HASH_CMD_ID => {
+            handle_provision_vendor_pk_hash(cmds, payload, scratch, out).await
+        }
+        INCREASE_CALIPTRA_MIN_SVN_CMD_ID => {
+            handle_increase_caliptra_min_svn(cmds, payload, scratch, out).await
+        }
         FE_PROG_CMD_ID => handle_fe_prog(cmds, payload, scratch, out).await,
+        REVOKE_VENDOR_PUB_KEY_CMD_ID => {
+            handle_revoke_vendor_pub_key(cmds, payload, scratch, out).await
+        }
+        REVOKE_VENDOR_PK_HASH_CMD_ID => {
+            handle_revoke_vendor_pk_hash(cmds, payload, scratch, out).await
+        }
         _ => CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidParameter),
     }
 }
@@ -112,6 +131,75 @@ where
         Ok(n) => CaliptraVdmCmdResult::Response(1 + n),
         Err(code) => CaliptraVdmCmdResult::Error(code),
     }
+}
+
+async fn handle_provision_vendor_pk_hash<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let parsed = match split_authorized_request(req, PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN) {
+        Ok(parsed) => parsed,
+        Err(code) => return CaliptraVdmCmdResult::Error(code),
+    };
+    let slot = read_u32_le(&parsed.payload[..4]);
+    let hash = match <&[u8; ECC_P384_COORD_SIZE]>::try_from(&parsed.payload[4..]) {
+        Ok(hash) => hash,
+        Err(_) => return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidParameter),
+    };
+    finish_authorized_command(
+        cmds.provision_vendor_pk_hash(
+            slot,
+            hash,
+            parsed.payload,
+            parsed.sig,
+            parsed.nonce,
+            parsed.ecc_pub_x,
+            parsed.ecc_pub_y,
+            parsed.mldsa_pub,
+            scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+async fn handle_increase_caliptra_min_svn<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let parsed = match split_authorized_request(req, INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN) {
+        Ok(parsed) => parsed,
+        Err(code) => return CaliptraVdmCmdResult::Error(code),
+    };
+    let flags = read_u32_le(&parsed.payload[..4]);
+    let svn = read_u32_le(&parsed.payload[4..8]);
+    finish_authorized_command(
+        cmds.increase_caliptra_min_svn(
+            flags,
+            svn,
+            parsed.payload,
+            parsed.sig,
+            parsed.nonce,
+            parsed.ecc_pub_x,
+            parsed.ecc_pub_y,
+            parsed.mldsa_pub,
+            scratch,
+        )
+        .await,
+        out,
+    )
 }
 
 async fn handle_fe_prog<H, A>(
@@ -143,6 +231,135 @@ where
         )
         .await
     {
+        Ok(()) => match super::write_success(out) {
+            Ok(_) => CaliptraVdmCmdResult::Response(1),
+            Err(code) => CaliptraVdmCmdResult::Error(code),
+        },
+        Err(code) => CaliptraVdmCmdResult::Error(code),
+    }
+}
+
+async fn handle_revoke_vendor_pub_key<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let parsed = match split_authorized_request(req, REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN) {
+        Ok(parsed) => parsed,
+        Err(code) => return CaliptraVdmCmdResult::Error(code),
+    };
+    let reserved = read_u32_le(&parsed.payload[..4]);
+    let slot = read_u32_le(&parsed.payload[4..8]);
+    let key_type = read_u32_le(&parsed.payload[8..12]);
+    let key_index = read_u32_le(&parsed.payload[12..16]);
+    finish_authorized_command(
+        cmds.revoke_vendor_pub_key(
+            reserved,
+            slot,
+            key_type,
+            key_index,
+            parsed.payload,
+            parsed.sig,
+            parsed.nonce,
+            parsed.ecc_pub_x,
+            parsed.ecc_pub_y,
+            parsed.mldsa_pub,
+            scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+async fn handle_revoke_vendor_pk_hash<H, A>(
+    cmds: &H,
+    req: &[u8],
+    scratch: &A,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult
+where
+    H: CaliptraVdmAuthorization,
+    A: SpdmPalAlloc,
+{
+    let parsed = match split_authorized_request(req, REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN) {
+        Ok(parsed) => parsed,
+        Err(code) => return CaliptraVdmCmdResult::Error(code),
+    };
+    let reserved = read_u32_le(&parsed.payload[..4]);
+    let slot = read_u32_le(&parsed.payload[4..8]);
+    finish_authorized_command(
+        cmds.revoke_vendor_pk_hash(
+            reserved,
+            slot,
+            parsed.payload,
+            parsed.sig,
+            parsed.nonce,
+            parsed.ecc_pub_x,
+            parsed.ecc_pub_y,
+            parsed.mldsa_pub,
+            scratch,
+        )
+        .await,
+        out,
+    )
+}
+
+/// Borrowed view of an authorized request: the subcommand payload followed by
+/// the common authorization trailer (challenge nonce, hybrid public key, and
+/// hybrid signature).
+struct AuthorizedRequest<'a> {
+    payload: &'a [u8],
+    nonce: &'a [u8; AUTH_CMD_NONCE_LEN],
+    ecc_pub_x: &'a [u8; ECC_P384_COORD_SIZE],
+    ecc_pub_y: &'a [u8; ECC_P384_COORD_SIZE],
+    mldsa_pub: &'a [u8; MLDSA87_PUB_KEY_SIZE],
+    sig: &'a HybridSignature,
+}
+
+fn split_authorized_request(
+    req: &[u8],
+    payload_len: usize,
+) -> Result<AuthorizedRequest<'_>, CaliptraCompletionCode> {
+    let auth_len = AUTH_CMD_NONCE_LEN
+        + 2 * ECC_P384_COORD_SIZE
+        + MLDSA87_PUB_KEY_SIZE
+        + core::mem::size_of::<HybridSignature>();
+    let expected_len = payload_len
+        .checked_add(auth_len)
+        .ok_or(CaliptraCompletionCode::InvalidPayloadSize)?;
+    if req.len() != expected_len {
+        return Err(CaliptraCompletionCode::InvalidPayloadSize);
+    }
+    let (payload, auth) = req.split_at(payload_len);
+    let (nonce, auth) = auth.split_at(AUTH_CMD_NONCE_LEN);
+    let (ecc_pub_x, auth) = auth.split_at(ECC_P384_COORD_SIZE);
+    let (ecc_pub_y, auth) = auth.split_at(ECC_P384_COORD_SIZE);
+    let (mldsa_pub, sig_bytes) = auth.split_at(MLDSA87_PUB_KEY_SIZE);
+    const INVALID: CaliptraCompletionCode = CaliptraCompletionCode::InvalidParameter;
+    Ok(AuthorizedRequest {
+        payload,
+        nonce: <&[u8; AUTH_CMD_NONCE_LEN]>::try_from(nonce).map_err(|_| INVALID)?,
+        ecc_pub_x: <&[u8; ECC_P384_COORD_SIZE]>::try_from(ecc_pub_x).map_err(|_| INVALID)?,
+        ecc_pub_y: <&[u8; ECC_P384_COORD_SIZE]>::try_from(ecc_pub_y).map_err(|_| INVALID)?,
+        mldsa_pub: <&[u8; MLDSA87_PUB_KEY_SIZE]>::try_from(mldsa_pub).map_err(|_| INVALID)?,
+        sig: HybridSignature::ref_from_bytes(sig_bytes).map_err(|_| INVALID)?,
+    })
+}
+
+fn read_u32_le(bytes: &[u8]) -> u32 {
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+fn finish_authorized_command(
+    result: CaliptraVdmResult<()>,
+    out: &mut [u8],
+) -> CaliptraVdmCmdResult {
+    match result {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -22,6 +22,10 @@ pub use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmCommand, CaliptraVdmResult,
     CALIPTRA_VDM_COMMAND_VERSION, CALIPTRA_VENDOR_ID,
 };
+pub use commands::authorized_command::{
+    FE_PROG_CMD_ID, GET_AUTH_CHALLENGE_CMD_ID, INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+    PROVISION_VENDOR_PK_HASH_CMD_ID, REVOKE_VENDOR_PK_HASH_CMD_ID, REVOKE_VENDOR_PUB_KEY_CMD_ID,
+};
 
 /// Caliptra VDM message header length: `[command_version, command_code]`.
 const VDM_HEADER_LEN: usize = 2;
@@ -65,6 +69,10 @@ pub trait CaliptraVdmStreamOps {
 }
 
 /// Platform hook for the shared command-authorization service.
+///
+/// Each `payload` is the exact little-endian wire payload preceding `sig`.
+/// Implementations must verify `cmd_id(BE) || payload || challenge(48)` without
+/// re-encoding parsed fields.
 pub trait CaliptraVdmAuthorization {
     async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
@@ -72,15 +80,68 @@ pub trait CaliptraVdmAuthorization {
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize>;
 
-    /// Verifies `sig` for FE_PROG and programs field entropy for `partition`.
-    ///
-    /// The wire-carried `nonce` and verifier public keys are forwarded to the
-    /// single step-1/anchor gate; the device compares `nonce` to its stored
-    /// one-time challenge and hash-anchors the keys before verifying.
+    #[allow(clippy::too_many_arguments)]
+    async fn provision_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        slot: u32,
+        hash: &[u8; 48],
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
+        &self,
+        flags: u32,
+        svn: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
     #[allow(clippy::too_many_arguments)]
     async fn program_field_entropy<A: SpdmPalAlloc>(
         &self,
         partition: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
+        &self,
+        reserved: u32,
+        slot: u32,
+        key_type: u32,
+        key_index: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        reserved: u32,
+        slot: u32,
+        payload: &[u8],
         sig: &HybridSignature,
         nonce: &[u8; AUTH_CMD_NONCE_LEN],
         ecc_pub_x: &[u8; 48],
@@ -324,6 +385,7 @@ mod tests {
     use std::sync::Mutex;
     use std::vec;
     use std::vec::Vec;
+    use zerocopy::IntoBytes;
 
     use super::*;
 
@@ -423,10 +485,40 @@ mod tests {
 
     const DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE: usize = 32;
     const DEBUG_UNLOCK_CHALLENGE_SIZE: usize = 48;
+    const TEST_AUTH_CHALLENGE: [u8; 48] = [0xA5; 48];
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum AuthorizedOperation {
+        ProvisionVendorPkHash {
+            slot: u32,
+            hash: [u8; 48],
+        },
+        IncreaseCaliptraMinSvn {
+            flags: u32,
+            svn: u32,
+        },
+        ProgramFieldEntropy {
+            partition: u32,
+        },
+        RevokeVendorPubKey {
+            reserved: u32,
+            slot: u32,
+            key_type: u32,
+            key_index: u32,
+        },
+        RevokeVendorPkHash {
+            reserved: u32,
+            slot: u32,
+        },
+    }
 
     struct TestCommands {
         csr_len: usize,
         authorized_token: Mutex<Option<Vec<u8>>>,
+        authorized_operation: Mutex<Option<AuthorizedOperation>>,
+        authorization_error: Mutex<Option<CaliptraCompletionCode>>,
+        enforce_authorization: bool,
+        challenge: Mutex<Option<[u8; 48]>>,
     }
 
     impl TestCommands {
@@ -434,7 +526,54 @@ mod tests {
             Self {
                 csr_len,
                 authorized_token: Mutex::new(None),
+                authorized_operation: Mutex::new(None),
+                authorization_error: Mutex::new(None),
+                enforce_authorization: false,
+                challenge: Mutex::new(None),
             }
+        }
+
+        fn with_authorization(mut self) -> Self {
+            self.enforce_authorization = true;
+            self
+        }
+
+        fn verify_test_signature(
+            &self,
+            cmd_id: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+        ) -> CaliptraVdmResult<()> {
+            if !self.enforce_authorization {
+                return Ok(());
+            }
+            // Taking the challenge before verification matches the production
+            // one-use authorization path, including failed signature attempts.
+            let challenge = self
+                .challenge
+                .lock()
+                .unwrap()
+                .take()
+                .ok_or(CaliptraCompletionCode::AccessDenied)?;
+            let sig_bytes = sig.as_bytes();
+            let payload_end = 4 + payload.len();
+            let challenge_end = payload_end + challenge.len();
+            if sig_bytes[..4] != cmd_id.to_be_bytes()
+                || sig_bytes[4..payload_end] != *payload
+                || sig_bytes[payload_end..challenge_end] != challenge
+                || sig_bytes[challenge_end..].iter().any(|byte| *byte != 0x3C)
+            {
+                return Err(CaliptraCompletionCode::AccessDenied);
+            }
+            Ok(())
+        }
+
+        fn complete_authorized(&self, operation: AuthorizedOperation) -> CaliptraVdmResult<()> {
+            if let Some(code) = self.authorization_error.lock().unwrap().take() {
+                return Err(code);
+            }
+            self.authorized_operation.lock().unwrap().replace(operation);
+            Ok(())
         }
 
         fn write_csr(
@@ -522,13 +661,50 @@ mod tests {
             _scratch: &A,
             out: &mut [u8],
         ) -> CaliptraVdmResult<usize> {
-            if out.len() < 32 {
+            if out.len() < 48 {
                 return Err(CaliptraCompletionCode::InsufficientResources);
             }
-            out[..32].copy_from_slice(&[0xA5; 32]);
-            Ok(32)
+            out[..48].copy_from_slice(&TEST_AUTH_CHALLENGE);
+            *self.challenge.lock().unwrap() = Some(TEST_AUTH_CHALLENGE);
+            Ok(48)
         }
 
+        async fn provision_vendor_pk_hash<A: SpdmPalAlloc>(
+            &self,
+            slot: u32,
+            hash: &[u8; 48],
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(PROVISION_VENDOR_PK_HASH_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::ProvisionVendorPkHash {
+                slot,
+                hash: *hash,
+            })
+        }
+
+        async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
+            &self,
+            flags: u32,
+            svn: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::IncreaseCaliptraMinSvn { flags, svn })
+        }
+
+        #[allow(clippy::too_many_arguments)]
         #[allow(clippy::too_many_arguments)]
         async fn program_field_entropy<A: SpdmPalAlloc>(
             &self,
@@ -541,6 +717,45 @@ mod tests {
             _scratch: &A,
         ) -> CaliptraVdmResult<()> {
             Ok(())
+        }
+
+        async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
+            &self,
+            reserved: u32,
+            slot: u32,
+            key_type: u32,
+            key_index: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(REVOKE_VENDOR_PUB_KEY_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::RevokeVendorPubKey {
+                reserved,
+                slot,
+                key_type,
+                key_index,
+            })
+        }
+
+        async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
+            &self,
+            reserved: u32,
+            slot: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(REVOKE_VENDOR_PK_HASH_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::RevokeVendorPkHash { reserved, slot })
         }
     }
 
@@ -607,6 +822,50 @@ mod tests {
             VdmResponse::Large(len) => assert_eq!(len, expected_len),
             VdmResponse::Inline(_) => panic!("expected large response"),
         }
+    }
+
+    fn authorized_req_with_sig(sub_cmd: u32, payload: &[u8], sig: &HybridSignature) -> Vec<u8> {
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&sub_cmd.to_le_bytes());
+        req.extend_from_slice(payload);
+        req.extend_from_slice(&[0u8; AUTH_CMD_NONCE_LEN]);
+        req.extend_from_slice(&[0u8; 48]);
+        req.extend_from_slice(&[0u8; 48]);
+        req.extend_from_slice(&[0u8; 2592]);
+        req.extend_from_slice(sig.as_bytes());
+        req
+    }
+
+    fn authorized_req(sub_cmd: u32, payload: &[u8]) -> Vec<u8> {
+        authorized_req_with_sig(sub_cmd, payload, &HybridSignature::default())
+    }
+
+    /// Deterministic test signature containing the complete signed preimage.
+    /// The production verifier performs ECC and ML-DSA verification over this
+    /// same `cmd_id(BE) || payload || challenge(48)` byte sequence.
+    fn test_signature(cmd_id: u32, payload: &[u8], challenge: &[u8; 48]) -> HybridSignature {
+        let mut sig = HybridSignature::default();
+        sig.as_mut_bytes().fill(0x3C);
+        let preimage_len = 4 + payload.len() + challenge.len();
+        let preimage = &mut sig.as_mut_bytes()[..preimage_len];
+        preimage[..4].copy_from_slice(&cmd_id.to_be_bytes());
+        preimage[4..4 + payload.len()].copy_from_slice(payload);
+        preimage[4 + payload.len()..].copy_from_slice(challenge);
+        sig
+    }
+
+    fn issue_test_challenge(cmds: &TestCommands) {
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&GET_AUTH_CHALLENGE_CMD_ID.to_le_bytes());
+        let (response, inline, _) = dispatch(cmds, &req, 64, 0);
+        assert_inline(response, 51);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
     }
 
     fn export_attested_csr_req() -> Vec<u8> {
@@ -763,6 +1022,251 @@ mod tests {
 
         assert_inline(response, 3);
         assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+    }
+
+    #[test]
+    fn authorized_fuse_commands_parse_golden_packets() {
+        let cases = [
+            (
+                PROVISION_VENDOR_PK_HASH_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&2u32.to_le_bytes());
+                    payload.extend_from_slice(&[0x5A; 48]);
+                    payload
+                },
+                AuthorizedOperation::ProvisionVendorPkHash {
+                    slot: 2,
+                    hash: [0x5A; 48],
+                },
+            ),
+            (
+                INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0x1122_3344u32.to_le_bytes());
+                    payload.extend_from_slice(&17u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::IncreaseCaliptraMinSvn {
+                    flags: 0x1122_3344,
+                    svn: 17,
+                },
+            ),
+            (
+                REVOKE_VENDOR_PUB_KEY_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0xAABB_CCDDu32.to_le_bytes());
+                    payload.extend_from_slice(&3u32.to_le_bytes());
+                    payload.extend_from_slice(&2u32.to_le_bytes());
+                    payload.extend_from_slice(&7u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::RevokeVendorPubKey {
+                    reserved: 0xAABB_CCDD,
+                    slot: 3,
+                    key_type: 2,
+                    key_index: 7,
+                },
+            ),
+            (
+                REVOKE_VENDOR_PK_HASH_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0x5566_7788u32.to_le_bytes());
+                    payload.extend_from_slice(&4u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::RevokeVendorPkHash {
+                    reserved: 0x5566_7788,
+                    slot: 4,
+                },
+            ),
+        ];
+
+        for (sub_cmd, payload, expected) in cases {
+            let cmds = TestCommands::new(0).with_authorization();
+            issue_test_challenge(&cmds);
+            let sig = test_signature(sub_cmd, &payload, &TEST_AUTH_CHALLENGE);
+            let req = authorized_req_with_sig(sub_cmd, &payload, &sig);
+            assert_eq!(&req[2..6], &sub_cmd.to_le_bytes());
+            assert_eq!(&req[6..6 + payload.len()], payload.as_slice());
+
+            let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+            assert_inline(response, 3);
+            assert_eq!(
+                &inline[..3],
+                &[
+                    CALIPTRA_VDM_COMMAND_VERSION,
+                    CaliptraVdmCommand::AuthorizedCommand as u8,
+                    CaliptraCompletionCode::Success as u8,
+                ]
+            );
+            assert_eq!(
+                cmds.authorized_operation.lock().unwrap().take(),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_fuse_commands_reject_missing_truncated_and_oversized_signatures() {
+        let payloads = [
+            (PROVISION_VENDOR_PK_HASH_CMD_ID, vec![0u8; 52]),
+            (INCREASE_CALIPTRA_MIN_SVN_CMD_ID, vec![0u8; 8]),
+            (REVOKE_VENDOR_PUB_KEY_CMD_ID, vec![0u8; 16]),
+            (REVOKE_VENDOR_PK_HASH_CMD_ID, vec![0u8; 8]),
+        ];
+
+        for (sub_cmd, payload) in payloads {
+            let cmds = TestCommands::new(0);
+            let mut missing = vec![
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizedCommand as u8,
+            ];
+            missing.extend_from_slice(&sub_cmd.to_le_bytes());
+            missing.extend_from_slice(&payload);
+            for req in [
+                missing,
+                {
+                    let mut req = authorized_req(sub_cmd, &payload);
+                    req.pop();
+                    req
+                },
+                {
+                    let mut req = authorized_req(sub_cmd, &payload);
+                    req.push(0xA5);
+                    req
+                },
+            ] {
+                let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+                assert_inline(response, 3);
+                assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn authorized_command_rejects_bad_signature_and_consumes_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        let payload = [0u8; 8];
+        issue_test_challenge(&cmds);
+        let bad_req = authorized_req(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload);
+
+        let (response, inline, _) = dispatch(&cmds, &bad_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        // This signature is valid for the original challenge, but verification
+        // must fail because the bad attempt already consumed that challenge.
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let valid_req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &valid_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        // The same signed preimage succeeds after obtaining a fresh challenge.
+        issue_test_challenge(&cmds);
+        let (response, inline, _) = dispatch(&cmds, &valid_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_signature_for_wrong_command() {
+        let cmds = TestCommands::new(0).with_authorization();
+        issue_test_challenge(&cmds);
+        let payload = [0u8; 8];
+        let sig = test_signature(
+            PROVISION_VENDOR_PK_HASH_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_signature_for_wrong_payload_or_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        let payload = [0u8; 8];
+
+        issue_test_challenge(&cmds);
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &[1u8; 8],
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        issue_test_challenge(&cmds);
+        let sig = test_signature(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &[0x5A; 48]);
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_reused_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        issue_test_challenge(&cmds);
+        let payload = [0u8; 8];
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_maps_authorization_failures() {
+        let cmds = TestCommands::new(0);
+        cmds.authorization_error
+            .lock()
+            .unwrap()
+            .replace(CaliptraCompletionCode::AccessDenied);
+        let req = authorized_req(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &[0u8; 8]);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+        assert_eq!(*cmds.authorized_operation.lock().unwrap(), None);
+    }
+
+    #[test]
+    fn get_auth_challenge_returns_48_bytes() {
+        let cmds = TestCommands::new(0);
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&GET_AUTH_CHALLENGE_CMD_ID.to_le_bytes());
+
+        let (response, inline, _) = dispatch(&cmds, &req, 64, 0);
+        assert_inline(response, 3 + 48);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_eq!(&inline[3..51], &[0xA5; 48]);
     }
 
     #[test]

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -22,6 +22,10 @@ pub use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmCommand, CaliptraVdmResult,
     CALIPTRA_VDM_COMMAND_VERSION, CALIPTRA_VENDOR_ID,
 };
+pub use commands::authorized_command::{
+    FE_PROG_CMD_ID, GET_AUTH_CHALLENGE_CMD_ID, INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+    PROVISION_VENDOR_PK_HASH_CMD_ID, REVOKE_VENDOR_PK_HASH_CMD_ID, REVOKE_VENDOR_PUB_KEY_CMD_ID,
+};
 
 /// Caliptra VDM message header length: `[command_version, command_code]`.
 const VDM_HEADER_LEN: usize = 2;
@@ -65,6 +69,10 @@ pub trait CaliptraVdmStreamOps {
 }
 
 /// Platform hook for the shared command-authorization service.
+///
+/// Each `payload` is the exact little-endian wire payload preceding `sig`.
+/// Implementations must verify `cmd_id(BE) || payload || challenge(48)` without
+/// re-encoding parsed fields.
 pub trait CaliptraVdmAuthorization {
     async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
@@ -72,15 +80,68 @@ pub trait CaliptraVdmAuthorization {
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize>;
 
-    /// Verifies `sig` for FE_PROG and programs field entropy for `partition`.
-    ///
-    /// The wire-carried `nonce` and verifier public keys are forwarded to the
-    /// single step-1/anchor gate; the device compares `nonce` to its stored
-    /// one-time challenge and hash-anchors the keys before verifying.
+    #[allow(clippy::too_many_arguments)]
+    async fn provision_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        slot: u32,
+        hash: &[u8; 48],
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
+        &self,
+        flags: u32,
+        svn: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
     #[allow(clippy::too_many_arguments)]
     async fn program_field_entropy<A: SpdmPalAlloc>(
         &self,
         partition: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
+        &self,
+        reserved: u32,
+        slot: u32,
+        key_type: u32,
+        key_index: u32,
+        payload: &[u8],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+        scratch: &A,
+    ) -> CaliptraVdmResult<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
+        &self,
+        reserved: u32,
+        slot: u32,
+        payload: &[u8],
         sig: &HybridSignature,
         nonce: &[u8; AUTH_CMD_NONCE_LEN],
         ecc_pub_x: &[u8; 48],
@@ -324,6 +385,7 @@ mod tests {
     use std::sync::Mutex;
     use std::vec;
     use std::vec::Vec;
+    use zerocopy::IntoBytes;
 
     use super::*;
 
@@ -423,10 +485,37 @@ mod tests {
 
     const DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE: usize = 32;
     const DEBUG_UNLOCK_CHALLENGE_SIZE: usize = 48;
+    const TEST_AUTH_CHALLENGE: [u8; 48] = [0xA5; 48];
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum AuthorizedOperation {
+        ProvisionVendorPkHash {
+            slot: u32,
+            hash: [u8; 48],
+        },
+        IncreaseCaliptraMinSvn {
+            flags: u32,
+            svn: u32,
+        },
+        RevokeVendorPubKey {
+            reserved: u32,
+            slot: u32,
+            key_type: u32,
+            key_index: u32,
+        },
+        RevokeVendorPkHash {
+            reserved: u32,
+            slot: u32,
+        },
+    }
 
     struct TestCommands {
         csr_len: usize,
         authorized_token: Mutex<Option<Vec<u8>>>,
+        authorized_operation: Mutex<Option<AuthorizedOperation>>,
+        authorization_error: Mutex<Option<CaliptraCompletionCode>>,
+        enforce_authorization: bool,
+        challenge: Mutex<Option<[u8; 48]>>,
     }
 
     impl TestCommands {
@@ -434,7 +523,54 @@ mod tests {
             Self {
                 csr_len,
                 authorized_token: Mutex::new(None),
+                authorized_operation: Mutex::new(None),
+                authorization_error: Mutex::new(None),
+                enforce_authorization: false,
+                challenge: Mutex::new(None),
             }
+        }
+
+        fn with_authorization(mut self) -> Self {
+            self.enforce_authorization = true;
+            self
+        }
+
+        fn verify_test_signature(
+            &self,
+            cmd_id: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+        ) -> CaliptraVdmResult<()> {
+            if !self.enforce_authorization {
+                return Ok(());
+            }
+            // Taking the challenge before verification matches the production
+            // one-use authorization path, including failed signature attempts.
+            let challenge = self
+                .challenge
+                .lock()
+                .unwrap()
+                .take()
+                .ok_or(CaliptraCompletionCode::AccessDenied)?;
+            let sig_bytes = sig.as_bytes();
+            let payload_end = 4 + payload.len();
+            let challenge_end = payload_end + challenge.len();
+            if sig_bytes[..4] != cmd_id.to_be_bytes()
+                || sig_bytes[4..payload_end] != *payload
+                || sig_bytes[payload_end..challenge_end] != challenge
+                || sig_bytes[challenge_end..].iter().any(|byte| *byte != 0x3C)
+            {
+                return Err(CaliptraCompletionCode::AccessDenied);
+            }
+            Ok(())
+        }
+
+        fn complete_authorized(&self, operation: AuthorizedOperation) -> CaliptraVdmResult<()> {
+            if let Some(code) = self.authorization_error.lock().unwrap().take() {
+                return Err(code);
+            }
+            self.authorized_operation.lock().unwrap().replace(operation);
+            Ok(())
         }
 
         fn write_csr(
@@ -522,11 +658,47 @@ mod tests {
             _scratch: &A,
             out: &mut [u8],
         ) -> CaliptraVdmResult<usize> {
-            if out.len() < 32 {
+            if out.len() < 48 {
                 return Err(CaliptraCompletionCode::InsufficientResources);
             }
-            out[..32].copy_from_slice(&[0xA5; 32]);
-            Ok(32)
+            out[..48].copy_from_slice(&TEST_AUTH_CHALLENGE);
+            *self.challenge.lock().unwrap() = Some(TEST_AUTH_CHALLENGE);
+            Ok(48)
+        }
+
+        async fn provision_vendor_pk_hash<A: SpdmPalAlloc>(
+            &self,
+            slot: u32,
+            hash: &[u8; 48],
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(PROVISION_VENDOR_PK_HASH_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::ProvisionVendorPkHash {
+                slot,
+                hash: *hash,
+            })
+        }
+
+        async fn increase_caliptra_min_svn<A: SpdmPalAlloc>(
+            &self,
+            flags: u32,
+            svn: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::IncreaseCaliptraMinSvn { flags, svn })
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -541,6 +713,45 @@ mod tests {
             _scratch: &A,
         ) -> CaliptraVdmResult<()> {
             Ok(())
+        }
+
+        async fn revoke_vendor_pub_key<A: SpdmPalAlloc>(
+            &self,
+            reserved: u32,
+            slot: u32,
+            key_type: u32,
+            key_index: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(REVOKE_VENDOR_PUB_KEY_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::RevokeVendorPubKey {
+                reserved,
+                slot,
+                key_type,
+                key_index,
+            })
+        }
+
+        async fn revoke_vendor_pk_hash<A: SpdmPalAlloc>(
+            &self,
+            reserved: u32,
+            slot: u32,
+            payload: &[u8],
+            sig: &HybridSignature,
+            _nonce: &[u8; AUTH_CMD_NONCE_LEN],
+            _ecc_pub_x: &[u8; 48],
+            _ecc_pub_y: &[u8; 48],
+            _mldsa_pub: &[u8; 2592],
+            _scratch: &A,
+        ) -> CaliptraVdmResult<()> {
+            self.verify_test_signature(REVOKE_VENDOR_PK_HASH_CMD_ID, payload, sig)?;
+            self.complete_authorized(AuthorizedOperation::RevokeVendorPkHash { reserved, slot })
         }
     }
 
@@ -607,6 +818,50 @@ mod tests {
             VdmResponse::Large(len) => assert_eq!(len, expected_len),
             VdmResponse::Inline(_) => panic!("expected large response"),
         }
+    }
+
+    fn authorized_req_with_sig(sub_cmd: u32, payload: &[u8], sig: &HybridSignature) -> Vec<u8> {
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&sub_cmd.to_le_bytes());
+        req.extend_from_slice(payload);
+        req.extend_from_slice(&[0u8; AUTH_CMD_NONCE_LEN]);
+        req.extend_from_slice(&[0u8; 48]);
+        req.extend_from_slice(&[0u8; 48]);
+        req.extend_from_slice(&[0u8; 2592]);
+        req.extend_from_slice(sig.as_bytes());
+        req
+    }
+
+    fn authorized_req(sub_cmd: u32, payload: &[u8]) -> Vec<u8> {
+        authorized_req_with_sig(sub_cmd, payload, &HybridSignature::default())
+    }
+
+    /// Deterministic test signature containing the complete signed preimage.
+    /// The production verifier performs ECC and ML-DSA verification over this
+    /// same `cmd_id(BE) || payload || challenge(48)` byte sequence.
+    fn test_signature(cmd_id: u32, payload: &[u8], challenge: &[u8; 48]) -> HybridSignature {
+        let mut sig = HybridSignature::default();
+        sig.as_mut_bytes().fill(0x3C);
+        let preimage_len = 4 + payload.len() + challenge.len();
+        let preimage = &mut sig.as_mut_bytes()[..preimage_len];
+        preimage[..4].copy_from_slice(&cmd_id.to_be_bytes());
+        preimage[4..4 + payload.len()].copy_from_slice(payload);
+        preimage[4 + payload.len()..].copy_from_slice(challenge);
+        sig
+    }
+
+    fn issue_test_challenge(cmds: &TestCommands) {
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&GET_AUTH_CHALLENGE_CMD_ID.to_le_bytes());
+        let (response, inline, _) = dispatch(cmds, &req, 64, 0);
+        assert_inline(response, 51);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
     }
 
     fn export_attested_csr_req() -> Vec<u8> {
@@ -763,6 +1018,251 @@ mod tests {
 
         assert_inline(response, 3);
         assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+    }
+
+    #[test]
+    fn authorized_fuse_commands_parse_golden_packets() {
+        let cases = [
+            (
+                PROVISION_VENDOR_PK_HASH_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&2u32.to_le_bytes());
+                    payload.extend_from_slice(&[0x5A; 48]);
+                    payload
+                },
+                AuthorizedOperation::ProvisionVendorPkHash {
+                    slot: 2,
+                    hash: [0x5A; 48],
+                },
+            ),
+            (
+                INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0x1122_3344u32.to_le_bytes());
+                    payload.extend_from_slice(&17u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::IncreaseCaliptraMinSvn {
+                    flags: 0x1122_3344,
+                    svn: 17,
+                },
+            ),
+            (
+                REVOKE_VENDOR_PUB_KEY_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0xAABB_CCDDu32.to_le_bytes());
+                    payload.extend_from_slice(&3u32.to_le_bytes());
+                    payload.extend_from_slice(&2u32.to_le_bytes());
+                    payload.extend_from_slice(&7u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::RevokeVendorPubKey {
+                    reserved: 0xAABB_CCDD,
+                    slot: 3,
+                    key_type: 2,
+                    key_index: 7,
+                },
+            ),
+            (
+                REVOKE_VENDOR_PK_HASH_CMD_ID,
+                {
+                    let mut payload = vec![];
+                    payload.extend_from_slice(&0x5566_7788u32.to_le_bytes());
+                    payload.extend_from_slice(&4u32.to_le_bytes());
+                    payload
+                },
+                AuthorizedOperation::RevokeVendorPkHash {
+                    reserved: 0x5566_7788,
+                    slot: 4,
+                },
+            ),
+        ];
+
+        for (sub_cmd, payload, expected) in cases {
+            let cmds = TestCommands::new(0).with_authorization();
+            issue_test_challenge(&cmds);
+            let sig = test_signature(sub_cmd, &payload, &TEST_AUTH_CHALLENGE);
+            let req = authorized_req_with_sig(sub_cmd, &payload, &sig);
+            assert_eq!(&req[2..6], &sub_cmd.to_le_bytes());
+            assert_eq!(&req[6..6 + payload.len()], payload.as_slice());
+
+            let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+            assert_inline(response, 3);
+            assert_eq!(
+                &inline[..3],
+                &[
+                    CALIPTRA_VDM_COMMAND_VERSION,
+                    CaliptraVdmCommand::AuthorizedCommand as u8,
+                    CaliptraCompletionCode::Success as u8,
+                ]
+            );
+            assert_eq!(
+                cmds.authorized_operation.lock().unwrap().take(),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_fuse_commands_reject_missing_truncated_and_oversized_signatures() {
+        let payloads = [
+            (PROVISION_VENDOR_PK_HASH_CMD_ID, vec![0u8; 52]),
+            (INCREASE_CALIPTRA_MIN_SVN_CMD_ID, vec![0u8; 8]),
+            (REVOKE_VENDOR_PUB_KEY_CMD_ID, vec![0u8; 16]),
+            (REVOKE_VENDOR_PK_HASH_CMD_ID, vec![0u8; 8]),
+        ];
+
+        for (sub_cmd, payload) in payloads {
+            let cmds = TestCommands::new(0);
+            let mut missing = vec![
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizedCommand as u8,
+            ];
+            missing.extend_from_slice(&sub_cmd.to_le_bytes());
+            missing.extend_from_slice(&payload);
+            for req in [
+                missing,
+                {
+                    let mut req = authorized_req(sub_cmd, &payload);
+                    req.pop();
+                    req
+                },
+                {
+                    let mut req = authorized_req(sub_cmd, &payload);
+                    req.push(0xA5);
+                    req
+                },
+            ] {
+                let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+                assert_inline(response, 3);
+                assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn authorized_command_rejects_bad_signature_and_consumes_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        let payload = [0u8; 8];
+        issue_test_challenge(&cmds);
+        let bad_req = authorized_req(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload);
+
+        let (response, inline, _) = dispatch(&cmds, &bad_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        // This signature is valid for the original challenge, but verification
+        // must fail because the bad attempt already consumed that challenge.
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let valid_req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &valid_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        // The same signed preimage succeeds after obtaining a fresh challenge.
+        issue_test_challenge(&cmds);
+        let (response, inline, _) = dispatch(&cmds, &valid_req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_signature_for_wrong_command() {
+        let cmds = TestCommands::new(0).with_authorization();
+        issue_test_challenge(&cmds);
+        let payload = [0u8; 8];
+        let sig = test_signature(
+            PROVISION_VENDOR_PK_HASH_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_signature_for_wrong_payload_or_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        let payload = [0u8; 8];
+
+        issue_test_challenge(&cmds);
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &[1u8; 8],
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+
+        issue_test_challenge(&cmds);
+        let sig = test_signature(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &[0x5A; 48]);
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_rejects_reused_challenge() {
+        let cmds = TestCommands::new(0).with_authorization();
+        issue_test_challenge(&cmds);
+        let payload = [0u8; 8];
+        let sig = test_signature(
+            INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
+            &payload,
+            &TEST_AUTH_CHALLENGE,
+        );
+        let req = authorized_req_with_sig(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &payload, &sig);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+    }
+
+    #[test]
+    fn authorized_command_maps_authorization_failures() {
+        let cmds = TestCommands::new(0);
+        cmds.authorization_error
+            .lock()
+            .unwrap()
+            .replace(CaliptraCompletionCode::AccessDenied);
+        let req = authorized_req(INCREASE_CALIPTRA_MIN_SVN_CMD_ID, &[0u8; 8]);
+
+        let (response, inline, _) = dispatch(&cmds, &req, 16, 0);
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::AccessDenied as u8);
+        assert_eq!(*cmds.authorized_operation.lock().unwrap(), None);
+    }
+
+    #[test]
+    fn get_auth_challenge_returns_48_bytes() {
+        let cmds = TestCommands::new(0);
+        let mut req = vec![
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::AuthorizedCommand as u8,
+        ];
+        req.extend_from_slice(&GET_AUTH_CHALLENGE_CMD_ID.to_le_bytes());
+
+        let (response, inline, _) = dispatch(&cmds, &req, 64, 0);
+        assert_inline(response, 3 + 48);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_eq!(&inline[3..51], &[0xA5; 48]);
     }
 
     #[test]

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -1040,27 +1040,24 @@ mod tests {
                 INCREASE_CALIPTRA_MIN_SVN_CMD_ID,
                 {
                     let mut payload = vec![];
-                    payload.extend_from_slice(&0x1122_3344u32.to_le_bytes());
+                    payload.extend_from_slice(&0u32.to_le_bytes());
                     payload.extend_from_slice(&17u32.to_le_bytes());
                     payload
                 },
-                AuthorizedOperation::IncreaseCaliptraMinSvn {
-                    flags: 0x1122_3344,
-                    svn: 17,
-                },
+                AuthorizedOperation::IncreaseCaliptraMinSvn { flags: 0, svn: 17 },
             ),
             (
                 REVOKE_VENDOR_PUB_KEY_CMD_ID,
                 {
                     let mut payload = vec![];
-                    payload.extend_from_slice(&0xAABB_CCDDu32.to_le_bytes());
+                    payload.extend_from_slice(&0u32.to_le_bytes());
                     payload.extend_from_slice(&3u32.to_le_bytes());
                     payload.extend_from_slice(&2u32.to_le_bytes());
                     payload.extend_from_slice(&7u32.to_le_bytes());
                     payload
                 },
                 AuthorizedOperation::RevokeVendorPubKey {
-                    reserved: 0xAABB_CCDD,
+                    reserved: 0,
                     slot: 3,
                     key_type: 2,
                     key_index: 7,
@@ -1070,12 +1067,12 @@ mod tests {
                 REVOKE_VENDOR_PK_HASH_CMD_ID,
                 {
                     let mut payload = vec![];
-                    payload.extend_from_slice(&0x5566_7788u32.to_le_bytes());
+                    payload.extend_from_slice(&0u32.to_le_bytes());
                     payload.extend_from_slice(&4u32.to_le_bytes());
                     payload
                 },
                 AuthorizedOperation::RevokeVendorPkHash {
-                    reserved: 0x5566_7788,
+                    reserved: 0,
                     slot: 4,
                 },
             ),

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -3,12 +3,18 @@
 //! Integration test for Caliptra VDM commands over SPDM vendor-defined messages.
 //!
 //! This test spawns the `caliptra-spdm-validator` binary (from caliptra-spdm-vdm-client) which
-//! runs all Caliptra VDM commands against the MCU's SPDM responder.
+//! runs all Caliptra VDM commands against the MCU's SPDM responder. The checked-in
+//! config includes authorized-fuse success, authorization rejection, and fuse-policy
+//! rejection flows against inactive slot 1 in this disposable emulator model.
 
 #[cfg(test)]
 mod test {
-    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use crate::test::{
+        compile_runtime, finish_runtime_hw_model, start_runtime_hw_model, CustomCaliptraFw,
+        TestParams, TEST_LOCK,
+    };
     use caliptra_api::SocManager;
+    use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
     use caliptra_mcu_debug_unlock_signer::DebugUnlockKeys;
     use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
@@ -23,12 +29,42 @@ mod test {
     use random_port::PortPicker;
     use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::process::{exit, Command, Stdio};
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
     use zerocopy::IntoBytes;
 
     const TEST_NAME: &str = "SPDM-VDM";
+    const TEST_FEATURE: &str = "test-caliptra-util-host-spdm-vdm-validator";
+
+    fn caliptra_fw_svn7() -> CustomCaliptraFw {
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            return CustomCaliptraFw {
+                fw_bytes: binaries.caliptra_fw_svn7.clone(),
+                vendor_pk_hash: binaries.vendor_pk_hash().unwrap(),
+                soc_manifest: binaries.test_soc_manifest(TEST_FEATURE).unwrap().clone(),
+            };
+        }
+
+        let runtime = compile_runtime(Some(TEST_FEATURE), false);
+        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+            svn: Some(7),
+            mcu_firmware: Some(runtime),
+            ..Default::default()
+        });
+        let fw_bytes = std::fs::read(builder.get_caliptra_fw().unwrap()).unwrap();
+        let vendor_pk_hash: [u8; 48] = hex::decode(builder.get_vendor_pk_hash().unwrap())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let soc_manifest = std::fs::read(builder.get_soc_manifest(None).unwrap()).unwrap();
+        CustomCaliptraFw {
+            fw_bytes,
+            vendor_pk_hash,
+            soc_manifest,
+        }
+    }
 
     /// Reusable test harness for running the caliptra-spdm-validator binary against
     /// the MCU HW model's SPDM responder.
@@ -43,21 +79,27 @@ mod test {
         target_addr: DynamicI3cAddress,
         test_timeout: Duration,
         validator_args: &[&str],
-    ) {
+    ) -> Arc<AtomicBool> {
+        SERVER_LISTENING.store(false, Ordering::Relaxed);
         let bridge_port = PortPicker::new().pick().unwrap();
         let addr = SocketAddr::from(([127, 0, 0, 1], i3c_port));
         let stream = TcpStream::connect(addr).unwrap();
         let transport = MctpTransport::new(BufferedStream::new(stream), target_addr.into(), 1);
 
-        // Timeout watchdog
+        // Timeout watchdog. The completion flag prevents a finished suite's
+        // watchdog from terminating a later isolated emulator instance.
+        let completed = Arc::new(AtomicBool::new(false));
+        let watchdog_completed = completed.clone();
         thread::spawn(move || {
             thread::sleep(test_timeout);
-            println!(
-                "[{}] TIMED OUT AFTER {:?} SECONDS",
-                TEST_NAME,
-                test_timeout.as_secs()
-            );
-            exit(-1);
+            if !watchdog_completed.load(Ordering::Relaxed) {
+                println!(
+                    "[{}] TIMED OUT AFTER {:?} SECONDS",
+                    TEST_NAME,
+                    test_timeout.as_secs()
+                );
+                exit(-1);
+            }
         });
 
         let validator_args: Vec<String> = validator_args.iter().map(|s| s.to_string()).collect();
@@ -108,6 +150,7 @@ mod test {
 
             execute_spdm_validator(bridge_port, &validator_args);
         });
+        completed
     }
 
     /// Spawn the caliptra-spdm-validator binary as a subprocess.
@@ -196,9 +239,7 @@ mod test {
             .to_string()
     }
 
-    #[ignore]
-    #[test]
-    fn test_caliptra_util_host_spdm_vdm_validator() {
+    fn run_isolated_fuse_suite(suite: &str) {
         use caliptra_image_fake_keys::{
             VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
             VENDOR_MLDSA_KEY_0_PUBLIC,
@@ -256,7 +297,8 @@ mod test {
 
         // --- Start hw_model with keys provisioned in fuses ---
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-caliptra-util-host-spdm-vdm-validator"),
+            feature: Some(TEST_FEATURE),
+            custom_caliptra_fw: Some(caliptra_fw_svn7()),
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             debug_intent: true,
@@ -275,10 +317,10 @@ mod test {
             .write(|w| w.prod_dbg_unlock_req(true));
 
         let config_path = test_config_path();
-        run_spdm_vdm_test(
+        let completed = run_spdm_vdm_test(
             hw.i3c_port().unwrap(),
             hw.i3c_address().unwrap().into(),
-            Duration::from_secs(120),
+            Duration::from_secs(600),
             &[
                 "--config",
                 &config_path,
@@ -290,12 +332,46 @@ mod test {
                 &keys_path,
                 "--unlock-level",
                 &unlock_level.to_string(),
+                "--fuse-suite",
+                suite,
             ],
         );
 
         let test = finish_runtime_hw_model(&mut hw);
+        completed.store(true, Ordering::Relaxed);
         assert_eq!(0, test);
 
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
+
+    macro_rules! isolated_fuse_suite_test {
+        ($name:ident, $suite:literal) => {
+            #[ignore]
+            #[test]
+            fn $name() {
+                run_isolated_fuse_suite($suite);
+            }
+        };
+    }
+
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_authorization,
+        "authorization"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_provision_vendor_pk_hash,
+        "provision-vendor-pk-hash"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_increase_min_svn,
+        "increase-min-svn"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_revoke_vendor_pub_key,
+        "revoke-vendor-pub-key"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_revoke_vendor_pk_hash,
+        "revoke-vendor-pk-hash"
+    );
 }


### PR DESCRIPTION
## Summary

Adds the authorized fuse subcommands and their host tooling to the SPDM VDM `AuthorizedCommand` path.

| Subcommand | ID | Command payload |
|---|---|---|
| ProvisionVendorPkHash | `0x5056_504B` (`PVPK`) | `slot:u32 | hash:[u8;48]` |
| FuseIncreaseCaliptraMinSvn | `0x4D43_4D53` (`MCMS`) | `flags:u32 | svn:u32` |
| FuseRevokeVendorPubKey | `0x4D52_564B` (`MRVK`) | `reserved:u32 | slot:u32 | key_type:u32 | key_index:u32` |
| FuseRevokeVendorPkHash | `0x5256_4B48` (`RVKH`) | `reserved:u32 | slot:u32` |

Requests use the command payload followed by the one-use challenge, ECC and ML-DSA public keys, and hybrid signature. The signature covers `cmd_id(BE) || payload || challenge`.

The responder verifies authorization before dispatching to the transport-neutral fuse operations. The host stack adds typed requests, explicit little-endian encoders, completion-code preservation, bounded large-request reassembly, and isolated validator suites for destructive operations.

Review feedback addressed:

- Advertise all six implemented authorized subcommands through `DeviceCapabilities`.
- Document the complete authorization trailer and byte ranges.
- Require MCMS `flags` and MRVK/RVKH `reserved` fields to be zero.
- Exercise real signed requests and reject tampered payloads, command IDs, public-key anchors, ECC signatures, and ML-DSA signatures.

### Memory delta (`measure-memory.sh`, devel profile, vs `main`)

| Section | `main` | Stack head | Delta |
|---|---:|---:|---:|
| Kernel `.text`/`.data`/`.bss` | 150,392 / 36 / 24,536 | 150,392 / 36 / 24,536 | 0 |
| User-app FLASH | 260,384 | 267,252 | **+6,868 B** |
| User-app RAM | 78,136 | 78,776 | **+640 B** |
| SPDM task FLASH | 104,142 | 111,598 | **+7,456 B** |
| SPDM task RAM | 29,853 | 30,501 | **+648 B** |
| Runtime bundle | 412,160 | 419,072 | **+6,912 B** |
