### PR TITLE
caliptra-util-host: support authorized fuse VDM commands

### DIFF
--- a/.github/workflows/caliptra-util-host-validator.yml
+++ b/.github/workflows/caliptra-util-host-validator.yml
@@ -195,14 +195,12 @@ jobs:
           cargo test --package caliptra-mcu-tests-integration --lib -- test_mctp_vdm_validator::test::test_caliptra_util_host_mctp_vdm_validator --nocapture --include-ignored
           sccache --show-stats
 
-      - name: Run Caliptra Util Host SPDM VDM validator tests (production mode)
+      - name: Run Caliptra Util Host SPDM VDM authorized command suites
         run: |
-          cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator --exact --nocapture --include-ignored
-          sccache --show-stats
-
-      - name: Run Caliptra Util Host SPDM VDM validator tests (manufacturing mode)
-        run: |
-          cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator_mfg_mode --exact --nocapture --include-ignored
+          test_filter="test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator_"
+          test_count=$(cargo test --package caliptra-mcu-tests-integration --lib -- "$test_filter" --list | grep -c ': test$')
+          test "$test_count" -gt 0
+          cargo test --package caliptra-mcu-tests-integration --lib -- "$test_filter" --nocapture --include-ignored
           sccache --show-stats
 
       - name: Run OCP Device Identity provisioning test

--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "bitflags 2.11.1",
  "caliptra-api-types",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -485,17 +485,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb46b49818666d31e95873539e7c6759acddf278#fb46b49818666d31e95873539e7c6759acddf278"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a0bf91a33752368870000bf7255976452160db5a#a0bf91a33752368870000bf7255976452160db5a"
 
 [[package]]
 name = "caliptra-util-host"

--- a/caliptra-util-host/apps/spdm/client/src/config.rs
+++ b/caliptra-util-host/apps/spdm/client/src/config.rs
@@ -16,11 +16,23 @@ pub struct TestConfig {
     #[serde(default)]
     pub spdm: SpdmTestConfig,
     #[serde(default)]
+    pub validation: ValidationConfig,
+    #[serde(default)]
     pub export_attested_csr: ExportAttestedCsrConfig,
     #[serde(default)]
     pub debug_unlock: DebugUnlockConfig,
     #[serde(default)]
+    pub authorized_commands: AuthorizedCommandsConfig,
+    #[serde(default)]
     pub fe_prog: FeProgConfig,
+    #[serde(default)]
+    pub provision_vendor_pk_hash: ProvisionVendorPkHashConfig,
+    #[serde(default)]
+    pub increase_caliptra_min_svn: IncreaseCaliptraMinSvnConfig,
+    #[serde(default)]
+    pub revoke_vendor_pub_key: RevokeVendorPubKeyConfig,
+    #[serde(default)]
+    pub revoke_vendor_pk_hash: RevokeVendorPkHashConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -45,6 +57,13 @@ fn default_server_address() -> String {
 pub struct SpdmTestConfig {
     #[serde(default)]
     pub slot_id: u8,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ValidationConfig {
+    /// Optional isolated validator suite selected by the integration harness.
+    #[serde(default)]
+    pub fuse_suite: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -102,11 +121,78 @@ impl Default for DebugUnlockConfig {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
-pub struct FeProgConfig {
-    #[serde(default)]
-    pub partition: u32,
+pub struct AuthorizedCommandsConfig {
     #[serde(default)]
     pub ecc_auth_key: Option<String>,
     #[serde(default)]
     pub mldsa_auth_key: Option<String>,
+    #[serde(default)]
+    pub negative_authorization_tests: bool,
+    #[serde(default)]
+    pub policy_rejection_tests: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FeProgConfig {
+    #[serde(default)]
+    pub partition: u32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+impl Default for FeProgConfig {
+    fn default() -> Self {
+        Self {
+            partition: 0,
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProvisionVendorPkHashConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub slot: u32,
+    #[serde(default)]
+    pub hash: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct IncreaseCaliptraMinSvnConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub flags: u32,
+    #[serde(default)]
+    pub svn: u32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RevokeVendorPubKeyConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub reserved: u32,
+    #[serde(default)]
+    pub vendor_pk_hash_slot: u32,
+    #[serde(default)]
+    pub key_type: u32,
+    #[serde(default)]
+    pub key_index: u32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RevokeVendorPkHashConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub reserved: u32,
+    #[serde(default)]
+    pub vendor_pk_hash_slot: u32,
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -40,10 +40,13 @@ use caliptra_mcu_core_util_host_command_types::debug_unlock::{
     ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest, ProdDebugUnlockTokenResponse,
 };
 use caliptra_mcu_core_util_host_command_types::fuse::{
-    FeProgResponse, GetAuthCmdChallengeResponse,
+    FeProgResponse, FuseIncreaseCaliptraMinSvnRequest, FuseIncreaseCaliptraMinSvnResponse,
+    FuseRevokeVendorPkHashRequest, FuseRevokeVendorPkHashResponse, FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse, GetAuthCmdChallengeResponse, ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
 };
 use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
-    SpdmVdmDriver, SpdmVdmTransport,
+    SpdmVdmDriver, SpdmVdmError, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
@@ -52,8 +55,11 @@ use caliptra_util_host_commands::api::debug_unlock::{
     caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
 };
 use caliptra_util_host_commands::api::fuse::{
-    caliptra_cmd_fe_prog, caliptra_cmd_get_auth_challenge,
+    caliptra_cmd_fe_prog, caliptra_cmd_fuse_increase_caliptra_min_svn,
+    caliptra_cmd_fuse_revoke_vendor_pk_hash, caliptra_cmd_fuse_revoke_vendor_pub_key,
+    caliptra_cmd_get_auth_challenge, caliptra_cmd_provision_vendor_pk_hash,
 };
+use caliptra_util_host_commands::api::{CaliptraApiError, CaliptraResult};
 use caliptra_util_host_session::CaliptraSession;
 
 /// High-level SPDM VDM Client for communicating with Caliptra devices.
@@ -129,10 +135,11 @@ impl<'a> SpdmVdmClient<'a> {
     }
 
     /// Request an authorization challenge for authorized commands (e.g., FE_PROG).
-    pub fn get_auth_challenge(&mut self) -> Result<GetAuthCmdChallengeResponse> {
-        let mut session = self.create_session()?;
+    pub fn get_auth_challenge(&mut self) -> CaliptraResult<GetAuthCmdChallengeResponse> {
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_get_auth_challenge(&mut session)
-            .map_err(|e| anyhow::anyhow!("GetAuthChallenge failed: {:?}", e))
     }
 
     /// Program field entropy for an OTP partition (authorized command).
@@ -154,7 +161,7 @@ impl<'a> SpdmVdmClient<'a> {
         ecc_pub_x: &[u8; 48],
         ecc_pub_y: &[u8; 48],
         mldsa_pub: &[u8; 2592],
-    ) -> Result<FeProgResponse> {
+    ) -> CaliptraResult<FeProgResponse> {
         use caliptra_mcu_core_util_host_command_types::fuse::FeProgRequest;
         let request = FeProgRequest {
             partition,
@@ -164,9 +171,123 @@ impl<'a> SpdmVdmClient<'a> {
             ecc_pub_y: *ecc_pub_y,
             mldsa_pub: *mldsa_pub,
         };
-        let mut session = self.create_session()?;
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_fe_prog(&mut session, &request)
-            .map_err(|e| anyhow::anyhow!("FeProg failed: {:?}", e))
+    }
+
+    pub fn provision_vendor_pk_hash(
+        &mut self,
+        slot: u32,
+        hash: &[u8; 48],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<ProvisionVendorPkHashResponse> {
+        let request = ProvisionVendorPkHashRequest {
+            slot,
+            hash: *hash,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_provision_vendor_pk_hash(&mut session, &request)
+    }
+
+    pub fn fuse_increase_caliptra_min_svn(
+        &mut self,
+        flags: u32,
+        svn: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseIncreaseCaliptraMinSvnResponse> {
+        let request = FuseIncreaseCaliptraMinSvnRequest {
+            flags,
+            svn,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_increase_caliptra_min_svn(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pub_key(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPubKeyResponse> {
+        let request = FuseRevokeVendorPubKeyRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            key_type,
+            key_index,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pub_key(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pk_hash(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPkHashResponse> {
+        let request = FuseRevokeVendorPkHashRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pk_hash(&mut session, &request)
+    }
+
+    /// Send an unencoded Caliptra VDM payload for responder-negative validation.
+    pub fn send_raw_vdm(
+        &mut self,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, SpdmVdmError> {
+        self.transport.send_raw_vdm(request, response)
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -40,20 +40,26 @@ use caliptra_mcu_core_util_host_command_types::debug_unlock::{
     ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest, ProdDebugUnlockTokenResponse,
 };
 use caliptra_mcu_core_util_host_command_types::fuse::{
-    FeProgResponse, GetAuthCmdChallengeResponse,
+    FeProgResponse, FuseIncreaseCaliptraMinSvnRequest, FuseIncreaseCaliptraMinSvnResponse,
+    FuseRevokeVendorPkHashRequest, FuseRevokeVendorPkHashResponse, FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse, GetAuthCmdChallengeResponse, ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
 };
-use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
-    SpdmVdmDriver, SpdmVdmTransport,
+    SpdmVdmDriver, SpdmVdmError, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
+use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_csr;
 use caliptra_util_host_commands::api::debug_unlock::{
     caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
 };
 use caliptra_util_host_commands::api::fuse::{
-    caliptra_cmd_fe_prog, caliptra_cmd_get_auth_challenge,
+    caliptra_cmd_fe_prog, caliptra_cmd_fuse_increase_caliptra_min_svn,
+    caliptra_cmd_fuse_revoke_vendor_pk_hash, caliptra_cmd_fuse_revoke_vendor_pub_key,
+    caliptra_cmd_get_auth_challenge, caliptra_cmd_provision_vendor_pk_hash,
 };
+use caliptra_util_host_commands::api::{CaliptraApiError, CaliptraResult};
 use caliptra_util_host_session::CaliptraSession;
 
 /// High-level SPDM VDM Client for communicating with Caliptra devices.
@@ -129,10 +135,11 @@ impl<'a> SpdmVdmClient<'a> {
     }
 
     /// Request an authorization challenge for authorized commands (e.g., FE_PROG).
-    pub fn get_auth_challenge(&mut self) -> Result<GetAuthCmdChallengeResponse> {
-        let mut session = self.create_session()?;
+    pub fn get_auth_challenge(&mut self) -> CaliptraResult<GetAuthCmdChallengeResponse> {
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_get_auth_challenge(&mut session)
-            .map_err(|e| anyhow::anyhow!("GetAuthChallenge failed: {:?}", e))
     }
 
     /// Program field entropy for an OTP partition (authorized command).
@@ -154,7 +161,7 @@ impl<'a> SpdmVdmClient<'a> {
         ecc_pub_x: &[u8; 48],
         ecc_pub_y: &[u8; 48],
         mldsa_pub: &[u8; 2592],
-    ) -> Result<FeProgResponse> {
+    ) -> CaliptraResult<FeProgResponse> {
         use caliptra_mcu_core_util_host_command_types::fuse::FeProgRequest;
         let request = FeProgRequest {
             partition,
@@ -164,9 +171,123 @@ impl<'a> SpdmVdmClient<'a> {
             ecc_pub_y: *ecc_pub_y,
             mldsa_pub: *mldsa_pub,
         };
-        let mut session = self.create_session()?;
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
         caliptra_cmd_fe_prog(&mut session, &request)
-            .map_err(|e| anyhow::anyhow!("FeProg failed: {:?}", e))
+    }
+
+    pub fn provision_vendor_pk_hash(
+        &mut self,
+        slot: u32,
+        hash: &[u8; 48],
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<ProvisionVendorPkHashResponse> {
+        let request = ProvisionVendorPkHashRequest {
+            slot,
+            hash: *hash,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_provision_vendor_pk_hash(&mut session, &request)
+    }
+
+    pub fn fuse_increase_caliptra_min_svn(
+        &mut self,
+        flags: u32,
+        svn: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseIncreaseCaliptraMinSvnResponse> {
+        let request = FuseIncreaseCaliptraMinSvnRequest {
+            flags,
+            svn,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_increase_caliptra_min_svn(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pub_key(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPubKeyResponse> {
+        let request = FuseRevokeVendorPubKeyRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            key_type,
+            key_index,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pub_key(&mut session, &request)
+    }
+
+    pub fn fuse_revoke_vendor_pk_hash(
+        &mut self,
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        sig: &HybridSignature,
+        nonce: &[u8; AUTH_CMD_NONCE_LEN],
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8; 2592],
+    ) -> CaliptraResult<FuseRevokeVendorPkHashResponse> {
+        let request = FuseRevokeVendorPkHashRequest {
+            reserved,
+            vendor_pk_hash_slot,
+            sig: sig.clone(),
+            nonce: *nonce,
+            ecc_pub_x: *ecc_pub_x,
+            ecc_pub_y: *ecc_pub_y,
+            mldsa_pub: *mldsa_pub,
+        };
+        let mut session = self
+            .create_session()
+            .map_err(|_| CaliptraApiError::SessionError("Failed to create session"))?;
+        caliptra_cmd_fuse_revoke_vendor_pk_hash(&mut session, &request)
+    }
+
+    /// Send an unencoded Caliptra VDM payload for responder-negative validation.
+    pub fn send_raw_vdm(
+        &mut self,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, SpdmVdmError> {
+        self.transport.send_raw_vdm(request, response)
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -46,6 +46,10 @@ struct Args {
     /// Debug unlock level (1-8)
     #[arg(long)]
     unlock_level: Option<u8>,
+
+    /// Run one isolated authorized-fuse validator suite.
+    #[arg(long, value_name = "SUITE")]
+    fuse_suite: Option<String>,
 }
 
 impl Args {
@@ -77,6 +81,9 @@ impl Args {
         if let Some(unlock_level) = self.unlock_level {
             config.debug_unlock.unlock_level = unlock_level;
         }
+        if let Some(fuse_suite) = self.fuse_suite {
+            config.validation.fuse_suite = Some(fuse_suite);
+        }
 
         Ok(config)
     }
@@ -103,9 +110,9 @@ fn main() -> Result<()> {
         };
     let config = args.into_config()?;
 
-    let fe_prog_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> = match (
-        &config.fe_prog.ecc_auth_key,
-        &config.fe_prog.mldsa_auth_key,
+    let command_authorizer: Option<Box<dyn CommandAuthChallengeSigner>> = match (
+        &config.authorized_commands.ecc_auth_key,
+        &config.authorized_commands.mldsa_auth_key,
     ) {
         (Some(hex_ecc), Some(hex_mldsa)) => {
             let ecc_key = hex::decode(hex_ecc)?;
@@ -148,20 +155,19 @@ fn main() -> Result<()> {
             &mut client,
             &config,
             debug_unlock_signer.as_deref(),
-            fe_prog_authorizer.as_deref(),
+            command_authorizer.as_deref(),
             true,
         )
     };
     validator::print_summary(&results);
 
+    if !validator::all_passed(&results) {
+        anyhow::bail!("Some tests FAILED");
+    }
+
     println!("[caliptra-spdm-validator] Sending STOP to bridge");
     stop_io.send_stop()?;
-
-    if validator::all_passed(&results) {
-        Ok(())
-    } else {
-        anyhow::bail!("Some tests FAILED")
-    }
+    Ok(())
 }
 
 fn parse_key_ids(s: &str) -> Result<Vec<u32>> {

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -15,8 +15,15 @@ use crate::config::TestConfig;
 use crate::SpdmVdmClient;
 use caliptra_mcu_command_auth_challenge_signer::CommandAuthChallengeSigner;
 use caliptra_mcu_core_util_host_command_types::certificate::AttestedCsrValidationError;
-use caliptra_mcu_core_util_host_command_types::fuse::MC_FE_PROG_CANONICAL_CMD_ID;
+use caliptra_mcu_core_util_host_command_types::fuse::{
+    MC_FE_PROG_CANONICAL_CMD_ID, MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+    MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID, MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+    MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+};
+use caliptra_mcu_core_util_host_transport::{CaliptraVdmCommand, CaliptraVdmCompletionCode};
 use caliptra_mcu_debug_unlock_signer::{DebugUnlockSigner, ProdDebugUnlockChallenge};
+use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
+use caliptra_util_host_commands::api::CaliptraApiError;
 
 /// Result of a single validation check.
 #[derive(Debug, Clone)]
@@ -100,9 +107,13 @@ pub fn run_all(
     client: &mut SpdmVdmClient,
     config: &TestConfig,
     debug_unlock_signer: Option<&dyn DebugUnlockSigner>,
-    fe_prog_authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    command_authorizer: Option<&dyn CommandAuthChallengeSigner>,
     verbose: bool,
 ) -> Vec<ValidationResult> {
+    if let Some(suite) = config.validation.fuse_suite.as_deref() {
+        return run_fuse_suite(client, suite, command_authorizer, verbose);
+    }
+
     let mut results = Vec::new();
 
     results.extend(run_export_attested_csr(
@@ -121,12 +132,70 @@ pub fn run_all(
         ));
     }
 
-    results.push(run_fe_prog(
-        client,
-        config.fe_prog.partition,
-        fe_prog_authorizer,
-        verbose,
-    ));
+    if config.authorized_commands.negative_authorization_tests {
+        results.extend(run_authorization_negative_tests(
+            client,
+            command_authorizer,
+            verbose,
+        ));
+    }
+
+    if config.authorized_commands.policy_rejection_tests {
+        results.extend(run_fuse_policy_rejection_tests(
+            client,
+            command_authorizer,
+            verbose,
+        ));
+    }
+
+    if config.provision_vendor_pk_hash.enabled {
+        results.push(run_provision_vendor_pk_hash(
+            client,
+            config.provision_vendor_pk_hash.slot,
+            &config.provision_vendor_pk_hash.hash,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.increase_caliptra_min_svn.enabled {
+        results.push(run_increase_caliptra_min_svn(
+            client,
+            config.increase_caliptra_min_svn.flags,
+            config.increase_caliptra_min_svn.svn,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.fe_prog.enabled {
+        results.push(run_fe_prog(
+            client,
+            config.fe_prog.partition,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.revoke_vendor_pub_key.enabled {
+        let cfg = &config.revoke_vendor_pub_key;
+        results.push(run_revoke_vendor_pub_key(
+            client,
+            cfg.reserved,
+            cfg.vendor_pk_hash_slot,
+            cfg.key_type,
+            cfg.key_index,
+            command_authorizer,
+            verbose,
+        ));
+    }
+    if config.revoke_vendor_pk_hash.enabled {
+        let cfg = &config.revoke_vendor_pk_hash;
+        results.push(run_revoke_vendor_pk_hash(
+            client,
+            cfg.reserved,
+            cfg.vendor_pk_hash_slot,
+            command_authorizer,
+            verbose,
+        ));
+    }
 
     results
 }
@@ -259,12 +328,700 @@ pub fn run_prod_debug_unlock(
     }
 }
 
+struct AuthorizedCommandAuthorization {
+    sig: HybridSignature,
+    nonce: [u8; AUTH_CMD_NONCE_LEN],
+    ecc_pub_x: [u8; 48],
+    ecc_pub_y: [u8; 48],
+    mldsa_pub: [u8; 2592],
+}
+
+fn authorize_command(
+    client: &mut SpdmVdmClient,
+    command_id: u32,
+    payload: &[u8],
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+) -> Result<AuthorizedCommandAuthorization, String> {
+    let authorizer = authorizer.ok_or_else(|| "no command authorizer provided".to_string())?;
+    let challenge = client
+        .get_auth_challenge()
+        .map_err(|e| format!("Failed to get auth challenge: {e}"))?;
+    let sig = authorizer
+        .authorize(command_id, payload, &challenge.challenge)
+        .map_err(|e| format!("Authorization failed: {e}"))?;
+    let (ecc_pub_x, ecc_pub_y, mldsa_pub) = authorizer
+        .public_keys()
+        .map_err(|e| format!("public_keys() failed: {e}"))?;
+    Ok(AuthorizedCommandAuthorization {
+        sig,
+        nonce: challenge.challenge,
+        ecc_pub_x,
+        ecc_pub_y,
+        mldsa_pub,
+    })
+}
+
+pub fn run_provision_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    hash_hex: &str,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("ProvisionVendorPkHash(slot={slot})");
+    let hash_vec = match hex::decode(hash_hex) {
+        Ok(hash) if hash.len() == 48 => hash,
+        Ok(hash) => {
+            return ValidationResult::fail(
+                test_name,
+                format!("hash must be 48 bytes, got {}", hash.len()),
+            )
+        }
+        Err(e) => return ValidationResult::fail(test_name, format!("invalid hash hex: {e}")),
+    };
+    let hash: [u8; 48] = hash_vec.try_into().unwrap();
+    let mut payload = Vec::with_capacity(52);
+    payload.extend_from_slice(&slot.to_le_bytes());
+    payload.extend_from_slice(&hash);
+    let auth = match authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.provision_vendor_pk_hash(
+        slot,
+        &hash,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "hash provisioned"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_increase_caliptra_min_svn(
+    client: &mut SpdmVdmClient,
+    flags: u32,
+    svn: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("FuseIncreaseCaliptraMinSvn(svn={svn})");
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&flags.to_le_bytes());
+    payload.extend_from_slice(&svn.to_le_bytes());
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_increase_caliptra_min_svn(
+        flags,
+        svn,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "minimum SVN updated"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_revoke_vendor_pub_key(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    key_type: u32,
+    key_index: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name =
+        format!("FuseRevokeVendorPubKey(slot={slot},type={key_type},index={key_index})");
+    let mut payload = Vec::with_capacity(16);
+    for value in [reserved, slot, key_type, key_index] {
+        payload.extend_from_slice(&value.to_le_bytes());
+    }
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_revoke_vendor_pub_key(
+        reserved,
+        slot,
+        key_type,
+        key_index,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "key revoked"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+pub fn run_revoke_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    reserved: u32,
+    slot: u32,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> ValidationResult {
+    let test_name = format!("FuseRevokeVendorPkHash(slot={slot})");
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&reserved.to_le_bytes());
+    payload.extend_from_slice(&slot.to_le_bytes());
+    let auth = match authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        authorizer,
+    ) {
+        Ok(auth) => auth,
+        Err(e) => return ValidationResult::fail(test_name, e),
+    };
+    match client.fuse_revoke_vendor_pk_hash(
+        reserved,
+        slot,
+        &auth.sig,
+        &auth.nonce,
+        &auth.ecc_pub_x,
+        &auth.ecc_pub_y,
+        &auth.mldsa_pub,
+    ) {
+        Ok(_) => ValidationResult::pass(test_name, "PK-hash slot revoked"),
+        Err(e) => ValidationResult::fail(test_name, e.to_string()),
+    }
+}
+
+#[derive(Debug)]
+enum AuthorizedCommandError {
+    Preparation(String),
+    Command(CaliptraApiError),
+}
+
+fn signed_provision_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    hash: &[u8; 48],
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(52);
+    payload.extend_from_slice(&slot.to_le_bytes());
+    payload.extend_from_slice(hash);
+    let auth = authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .provision_vendor_pk_hash(
+            slot,
+            hash,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_increase_caliptra_min_svn(
+    client: &mut SpdmVdmClient,
+    flags: u32,
+    svn: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&flags.to_le_bytes());
+    payload.extend_from_slice(&svn.to_le_bytes());
+    let auth = authorize_command(
+        client,
+        MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_increase_caliptra_min_svn(
+            flags,
+            svn,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_revoke_vendor_pub_key(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    key_type: u32,
+    key_index: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(16);
+    for field in [0, slot, key_type, key_index] {
+        payload.extend_from_slice(&field.to_le_bytes());
+    }
+    let auth = authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_revoke_vendor_pub_key(
+            0,
+            slot,
+            key_type,
+            key_index,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn signed_revoke_vendor_pk_hash(
+    client: &mut SpdmVdmClient,
+    slot: u32,
+    authorizer: &dyn CommandAuthChallengeSigner,
+) -> Result<(), AuthorizedCommandError> {
+    let mut payload = Vec::with_capacity(8);
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    payload.extend_from_slice(&slot.to_le_bytes());
+    let auth = authorize_command(
+        client,
+        MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    )
+    .map_err(AuthorizedCommandError::Preparation)?;
+    client
+        .fuse_revoke_vendor_pk_hash(
+            0,
+            slot,
+            &auth.sig,
+            &auth.nonce,
+            &auth.ecc_pub_x,
+            &auth.ecc_pub_y,
+            &auth.mldsa_pub,
+        )
+        .map(|_| ())
+        .map_err(AuthorizedCommandError::Command)
+}
+
+fn expect_success(test_name: &str, result: Result<(), AuthorizedCommandError>) -> ValidationResult {
+    match result {
+        Ok(()) => ValidationResult::pass(test_name, "accepted"),
+        Err(error) => ValidationResult::fail(test_name, format!("{error:?}")),
+    }
+}
+
+fn expect_completion(
+    test_name: &str,
+    result: Result<(), AuthorizedCommandError>,
+    expected: CaliptraVdmCompletionCode,
+) -> ValidationResult {
+    match result {
+        Err(AuthorizedCommandError::Command(CaliptraApiError::DeviceError(code)))
+            if code == expected as u8 =>
+        {
+            ValidationResult::pass(test_name, format!("completion code {code:#04x}"))
+        }
+        Err(AuthorizedCommandError::Command(CaliptraApiError::DeviceError(code))) => {
+            ValidationResult::fail(
+                test_name,
+                format!("expected {:#04x}, got {code:#04x}", expected as u8),
+            )
+        }
+        Err(AuthorizedCommandError::Preparation(error)) => {
+            ValidationResult::fail(test_name, format!("authorization setup failed: {error}"))
+        }
+        Err(AuthorizedCommandError::Command(error)) => {
+            ValidationResult::fail(test_name, format!("non-device command failure: {error}"))
+        }
+        Ok(()) => ValidationResult::fail(test_name, "request was unexpectedly accepted"),
+    }
+}
+
+fn expect_api_completion<T>(
+    test_name: &str,
+    result: Result<T, CaliptraApiError>,
+    expected: CaliptraVdmCompletionCode,
+) -> ValidationResult {
+    match result {
+        Err(CaliptraApiError::DeviceError(code)) if code == expected as u8 => {
+            ValidationResult::pass(test_name, format!("completion code {code:#04x}"))
+        }
+        Err(CaliptraApiError::DeviceError(code)) => ValidationResult::fail(
+            test_name,
+            format!("expected {:#04x}, got {code:#04x}", expected as u8),
+        ),
+        Err(error) => {
+            ValidationResult::fail(test_name, format!("non-device command failure: {error}"))
+        }
+        Ok(_) => ValidationResult::fail(test_name, "request was unexpectedly accepted"),
+    }
+}
+
+fn run_raw_malformed_request_tests(client: &mut SpdmVdmClient) -> Vec<ValidationResult> {
+    let signature_len = core::mem::size_of::<HybridSignature>();
+    let mut exact = vec![1, CaliptraVdmCommand::AuthorizedCommand as u8];
+    exact.extend_from_slice(&MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID.to_le_bytes());
+    exact.extend_from_slice(&1u32.to_le_bytes());
+    exact.extend_from_slice(&[0xA5; 48]);
+    exact.resize(exact.len() + signature_len, 0);
+
+    let missing_signature = exact[..exact.len() - signature_len].to_vec();
+    let truncated = exact[..exact.len() - 1].to_vec();
+    let mut oversized = exact;
+    oversized.push(0);
+
+    [
+        (
+            "AuthorizedCommand rejects missing signature",
+            missing_signature,
+        ),
+        ("AuthorizedCommand rejects truncated request", truncated),
+        ("AuthorizedCommand rejects oversized request", oversized),
+    ]
+    .into_iter()
+    .map(|(name, request)| {
+        let mut response = [0u8; 16];
+        match client.send_raw_vdm(&request, &mut response) {
+            Ok(3)
+                if response[..3]
+                    == [
+                        1,
+                        CaliptraVdmCommand::AuthorizedCommand as u8,
+                        CaliptraVdmCompletionCode::InvalidPayloadSize as u8,
+                    ] =>
+            {
+                ValidationResult::pass(name, "responder returned InvalidPayloadSize")
+            }
+            Ok(len) => ValidationResult::fail(
+                name,
+                format!("unexpected raw response {:02x?}", &response[..len]),
+            ),
+            Err(error) => ValidationResult::fail(name, format!("transport failure: {error:?}")),
+        }
+    })
+    .collect()
+}
+
+pub fn run_fuse_policy_rejection_tests(
+    client: &mut SpdmVdmClient,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::skip(
+            "Authorized fuse policy rejections",
+            "no command authorizer provided",
+        )];
+    };
+    vec![
+        expect_completion(
+            "ProvisionVendorPkHash rejects invalid slot",
+            signed_provision_vendor_pk_hash(client, 16, &[0xA5; 48], authorizer),
+            CaliptraVdmCompletionCode::OperationFailed,
+        ),
+        expect_completion(
+            "FuseIncreaseCaliptraMinSvn rejects zero SVN",
+            signed_increase_caliptra_min_svn(client, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPubKey rejects current-boot key",
+            signed_revoke_vendor_pub_key(client, 0, 0, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+        expect_completion(
+            "FuseRevokeVendorPkHash rejects current-boot slot",
+            signed_revoke_vendor_pk_hash(client, 0, authorizer),
+            CaliptraVdmCompletionCode::InvalidParameter,
+        ),
+    ]
+}
+
+fn run_fuse_suite(
+    client: &mut SpdmVdmClient,
+    suite: &str,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::fail(
+            suite,
+            "no command authorizer provided",
+        )];
+    };
+    let hash = [0xA5; 48];
+    let other_hash = [0x5A; 48];
+
+    match suite {
+        "authorization" => {
+            let mut results = run_raw_malformed_request_tests(client);
+            results.extend(run_authorization_negative_tests(
+                client,
+                Some(authorizer),
+                verbose,
+            ));
+            results
+        }
+        "provision-vendor-pk-hash" => vec![
+            expect_completion(
+                "PVPK invalid slot",
+                signed_provision_vendor_pk_hash(client, 16, &hash, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_success(
+                "PVPK programs and reads back slot",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_success(
+                "PVPK same hash is idempotent",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_completion(
+                "PVPK conflicting hash rejected",
+                signed_provision_vendor_pk_hash(client, 1, &other_hash, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+        ],
+        "increase-min-svn" => vec![
+            expect_completion(
+                "MCMS rejects zero SVN",
+                signed_increase_caliptra_min_svn(client, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MCMS rejects SVN above encoding bound",
+                signed_increase_caliptra_min_svn(client, 0, 129, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MCMS rejects SVN above running firmware",
+                signed_increase_caliptra_min_svn(client, 0, 8, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MCMS increases minimum SVN",
+                signed_increase_caliptra_min_svn(client, 0, 5, authorizer),
+            ),
+            expect_success(
+                "MCMS equal SVN is idempotent",
+                signed_increase_caliptra_min_svn(client, 0, 5, authorizer),
+            ),
+            expect_completion(
+                "MCMS rejects decrease",
+                signed_increase_caliptra_min_svn(client, 0, 4, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+        ],
+        "revoke-vendor-pub-key" => vec![
+            expect_completion(
+                "MRVK rejects unprovisioned slot",
+                signed_revoke_vendor_pub_key(client, 1, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MRVK prerequisite slot provisioning",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_completion(
+                "MRVK rejects invalid key type",
+                signed_revoke_vendor_pub_key(client, 1, 99, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_completion(
+                "MRVK rejects invalid key index",
+                signed_revoke_vendor_pub_key(client, 1, 0, 4, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_completion(
+                "MRVK rejects current-boot key",
+                signed_revoke_vendor_pub_key(client, 0, 0, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "MRVK revokes inactive key",
+                signed_revoke_vendor_pub_key(client, 1, 0, 0, authorizer),
+            ),
+            expect_completion(
+                "MRVK rejects last algorithm key",
+                signed_revoke_vendor_pub_key(client, 1, 0, 3, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+        ],
+        "revoke-vendor-pk-hash" => vec![
+            expect_completion(
+                "RVKH rejects unprovisioned slot",
+                signed_revoke_vendor_pk_hash(client, 1, authorizer),
+                CaliptraVdmCompletionCode::OperationFailed,
+            ),
+            expect_completion(
+                "RVKH rejects current-boot slot",
+                signed_revoke_vendor_pk_hash(client, 0, authorizer),
+                CaliptraVdmCompletionCode::InvalidParameter,
+            ),
+            expect_success(
+                "RVKH prerequisite slot provisioning",
+                signed_provision_vendor_pk_hash(client, 1, &hash, authorizer),
+            ),
+            expect_success(
+                "RVKH revokes inactive slot",
+                signed_revoke_vendor_pk_hash(client, 1, authorizer),
+            ),
+            expect_success(
+                "RVKH repeated revocation is idempotent",
+                signed_revoke_vendor_pk_hash(client, 1, authorizer),
+            ),
+        ],
+        _ => vec![ValidationResult::fail(
+            "Authorized fuse suite",
+            format!("unknown suite {suite:?}"),
+        )],
+    }
+}
+
+pub fn run_authorization_negative_tests(
+    client: &mut SpdmVdmClient,
+    authorizer: Option<&dyn CommandAuthChallengeSigner>,
+    _verbose: bool,
+) -> Vec<ValidationResult> {
+    let Some(authorizer) = authorizer else {
+        return vec![ValidationResult::skip(
+            "AuthorizedCommand negative authorization",
+            "no command authorizer provided",
+        )];
+    };
+    let partition = 0u32;
+    let payload = partition.to_le_bytes();
+    let mut results = Vec::new();
+
+    let challenge = match client.get_auth_challenge() {
+        Ok(challenge) => challenge,
+        Err(e) => {
+            return vec![ValidationResult::fail(
+                "AuthorizedCommand bad signature",
+                e.to_string(),
+            )]
+        }
+    };
+    let valid =
+        match authorizer.authorize(MC_FE_PROG_CANONICAL_CMD_ID, &payload, &challenge.challenge) {
+            Ok(auth) => auth,
+            Err(e) => {
+                return vec![ValidationResult::fail(
+                    "AuthorizedCommand bad signature",
+                    e.to_string(),
+                )]
+            }
+        };
+    let (ecc_pub_x, ecc_pub_y, mldsa_pub) = match authorizer.public_keys() {
+        Ok(keys) => keys,
+        Err(e) => {
+            return vec![ValidationResult::fail(
+                "AuthorizedCommand public keys",
+                e.to_string(),
+            )]
+        }
+    };
+    results.push(expect_api_completion(
+        "AuthorizedCommand bad signature",
+        client.fe_prog(
+            partition,
+            &HybridSignature::default(),
+            &challenge.challenge,
+            &ecc_pub_x,
+            &ecc_pub_y,
+            &mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+    results.push(expect_api_completion(
+        "AuthorizedCommand reused challenge",
+        client.fe_prog(
+            partition,
+            &valid,
+            &challenge.challenge,
+            &ecc_pub_x,
+            &ecc_pub_y,
+            &mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+
+    let wrong_sig = match authorize_command(
+        client,
+        MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+        &payload,
+        Some(authorizer),
+    ) {
+        Ok(auth) => auth,
+        Err(e) => {
+            results.push(ValidationResult::fail(
+                "AuthorizedCommand wrong-command signature",
+                e,
+            ));
+            return results;
+        }
+    };
+    results.push(expect_api_completion(
+        "AuthorizedCommand wrong-command signature",
+        client.fe_prog(
+            partition,
+            &wrong_sig.sig,
+            &wrong_sig.nonce,
+            &wrong_sig.ecc_pub_x,
+            &wrong_sig.ecc_pub_y,
+            &wrong_sig.mldsa_pub,
+        ),
+        CaliptraVdmCompletionCode::AccessDenied,
+    ));
+    results
+}
+
 /// Validate Field Entropy Programming (FE_PROG) via SPDM VDM.
 ///
 /// When a [`CommandAuthChallengeSigner`] is provided, performs the full authorized flow:
 /// 1. Request an auth challenge
-/// 2. Ask the authorizer to produce the MAC
-/// 3. Submit FE_PROG with the MAC
+/// 2. Ask the authorizer to produce the hybrid signature
+/// 3. Submit FE_PROG with the signature
 ///
 /// Without an authorizer the test is skipped.
 pub fn run_fe_prog(
@@ -308,7 +1065,7 @@ pub fn run_fe_prog(
     let cmd_id = MC_FE_PROG_CANONICAL_CMD_ID;
     let sig =
         match authorizer.authorize(cmd_id, &partition.to_le_bytes(), &challenge_resp.challenge) {
-            Ok(sig) => sig,
+            Ok(auth) => auth,
             Err(e) => {
                 return ValidationResult::fail(test_name, format!("Authorization failed: {}", e));
             }

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -802,6 +802,7 @@ fn run_fuse_suite(
             ));
             results
         }
+        "fe-prog" => vec![run_fe_prog(client, 0, Some(authorizer), verbose)],
         "provision-vendor-pk-hash" => vec![
             expect_completion(
                 "PVPK invalid slot",

--- a/caliptra-util-host/apps/spdm/test-config.toml
+++ b/caliptra-util-host/apps/spdm/test-config.toml
@@ -20,9 +20,40 @@ key_ids = [1, 2, 3]
 # ECC384 = 1, MlDsa87 = 2
 algorithm = 1
 
-[fe_prog]
-partition = 0
-# Hex-encoded ECC private key (P-384) and ML-DSA seed (32 bytes) for FE_PROG authorization.
-# Must match keys in the MCU firmware.
+[authorized_commands]
+# Test-only authorization keys. Production integrations must provide their own key source.
 ecc_auth_key = "3da9e680aff5a1cea96a3e89810286fb3b3030a9c924ad2f2031a07d294052a97cafa1fc6ea760a43db763ca9f2f7036"
 mldsa_auth_key = "63616c69707472612d6d63752d74657374696e672d6d6c6473612d736565642d"
+# The integration harness selects isolated suites with --fuse-suite. Keep the
+# aggregate switches disabled so destructive operations cannot accidentally run
+# together when this config is used directly.
+negative_authorization_tests = false
+policy_rejection_tests = false
+
+[provision_vendor_pk_hash]
+enabled = false
+slot = 1
+hash = "a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5"
+
+[increase_caliptra_min_svn]
+# The integration test boots disposable Caliptra firmware with SVN 7.
+enabled = false
+flags = 0
+svn = 7
+
+[fe_prog]
+# FE_PROG is not part of the fuse VDM validation sequence.
+enabled = false
+partition = 0
+
+[revoke_vendor_pub_key]
+enabled = false
+reserved = 0
+vendor_pk_hash_slot = 1
+key_type = 0
+key_index = 0
+
+[revoke_vendor_pk_hash]
+enabled = false
+reserved = 0
+vendor_pk_hash_slot = 1

--- a/caliptra-util-host/apps/spdm/test-config.toml
+++ b/caliptra-util-host/apps/spdm/test-config.toml
@@ -42,7 +42,7 @@ flags = 0
 svn = 7
 
 [fe_prog]
-# FE_PROG is not part of the fuse VDM validation sequence.
+# FE_PROG runs only in the isolated "fe-prog" suite.
 enabled = false
 partition = 0
 

--- a/caliptra-util-host/command-types/src/fuse.rs
+++ b/caliptra-util-host/command-types/src/fuse.rs
@@ -44,6 +44,12 @@ pub const MC_GET_AUTH_CMD_CHALLENGE_CANONICAL_CMD_ID: u32 = 0x4D41_4343;
 /// transports (SPDM VDM and MCU mailbox) to ensure interoperability.
 pub const MC_FE_PROG_CANONICAL_CMD_ID: u32 = 0x4D43_4650;
 
+/// Canonical FOURCC command identifiers used for authorized fuse operations.
+pub const MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID: u32 = 0x5056_504B;
+pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID: u32 = 0x4D43_4D53;
+pub const MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID: u32 = 0x4D52_564B;
+pub const MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID: u32 = 0x5256_4B48;
+
 // ---- Get Authorization Command Challenge ----
 
 /// Request a challenge nonce for authorizing privileged commands.
@@ -170,6 +176,64 @@ impl CommandRequest for FeProgRequest {
 }
 
 impl CommandResponse for FeProgResponse {}
+
+macro_rules! authorized_fuse_command {
+    ($request:ident, $response:ident, $command_id:ident, { $($field:ident: $ty:ty),+ $(,)? }) => {
+        #[repr(C)]
+        #[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+        pub struct $request {
+            $(pub $field: $ty,)+
+            pub nonce: [u8; AUTH_CMD_CHALLENGE_SIZE],
+            pub ecc_pub_x: [u8; AUTH_PUB_ECC_COORD_SIZE],
+            pub ecc_pub_y: [u8; AUTH_PUB_ECC_COORD_SIZE],
+            pub mldsa_pub: [u8; AUTH_PUB_MLDSA_SIZE],
+            pub sig: HybridSignature,
+        }
+
+        #[repr(C)]
+        #[derive(Debug, Default, Clone, IntoBytes, FromBytes, Immutable)]
+        pub struct $response {
+            pub common: CommonResponse,
+        }
+
+        impl CommandRequest for $request {
+            type Response = $response;
+            const COMMAND_ID: CaliptraCommandId = CaliptraCommandId::$command_id;
+        }
+
+        impl CommandResponse for $response {}
+    };
+}
+
+authorized_fuse_command!(
+    ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
+    ProvisionVendorPkHash,
+    { slot: u32, hash: [u8; 48] }
+);
+authorized_fuse_command!(
+    FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse,
+    FuseIncreaseCaliptraMinSvn,
+    { flags: u32, svn: u32 }
+);
+authorized_fuse_command!(
+    FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse,
+    FuseRevokeVendorPubKey,
+    {
+        reserved: u32,
+        vendor_pk_hash_slot: u32,
+        key_type: u32,
+        key_index: u32
+    }
+);
+authorized_fuse_command!(
+    FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse,
+    FuseRevokeVendorPkHash,
+    { reserved: u32, vendor_pk_hash_slot: u32 }
+);
 
 // ---- Placeholder fuse commands ----
 

--- a/caliptra-util-host/command-types/src/lib.rs
+++ b/caliptra-util-host/command-types/src/lib.rs
@@ -121,6 +121,10 @@ pub enum CaliptraCommandId {
     // Authorized Commands (0x8010-0x801F)
     GetAuthCmdChallenge = 0x8010,
     FeProg = 0x8011,
+    ProvisionVendorPkHash = 0x8012,
+    FuseIncreaseCaliptraMinSvn = 0x8013,
+    FuseRevokeVendorPubKey = 0x8014,
+    FuseRevokeVendorPkHash = 0x8015,
 }
 
 /// Common response header for all commands

--- a/caliptra-util-host/commands/src/api/fuse.rs
+++ b/caliptra-util-host/commands/src/api/fuse.rs
@@ -2,28 +2,37 @@
 
 //! Fuse and Authorized Command API functions
 //!
-//! High-level functions for authorized command operations including
-//! field entropy programming (FE_PROG).
+//! High-level functions for challenge-authorized fuse operations.
 //!
 //! ## Authorization Flow
 //!
 //! Authorized commands follow a challenge-response pattern:
-//! 1. Call `caliptra_cmd_get_auth_challenge` to obtain a 32-byte nonce
-//! 2. Compute HMAC-SHA384 over `cmd_id(BE) || cmd_body || challenge`
-//! 3. Call the authorized command (e.g., `caliptra_cmd_fe_prog`) which
-//!    internally appends the MAC to the request
+//! 1. Call `caliptra_cmd_get_auth_challenge` to obtain a one-use 48-byte nonce
+//! 2. Sign `cmd_id(BE) || cmd_body || challenge` with ECC P-384 and ML-DSA-87
+//! 3. Append the hybrid signature to the authorized command request
 
 use crate::api::{CaliptraApiError, CaliptraResult};
 use caliptra_mcu_core_util_host_command_types::fuse::{
-    FeProgRequest, FeProgResponse, GetAuthCmdChallengeRequest, GetAuthCmdChallengeResponse,
+    FeProgRequest, FeProgResponse, FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse, FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse, FuseRevokeVendorPubKeyRequest, FuseRevokeVendorPubKeyResponse,
+    GetAuthCmdChallengeRequest, GetAuthCmdChallengeResponse, ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
 };
 use caliptra_mcu_core_util_host_command_types::CaliptraCommandId;
-use caliptra_util_host_session::CaliptraSession;
+use caliptra_util_host_session::{CaliptraSession, SessionError};
+
+fn map_session_error(error: SessionError, context: &'static str) -> CaliptraApiError {
+    match error {
+        SessionError::DeviceError(code) => CaliptraApiError::DeviceError(code),
+        _ => CaliptraApiError::SessionError(context),
+    }
+}
 
 /// Request an authorization challenge nonce.
 ///
-/// Returns a 32-byte random challenge that must be included in the HMAC
-/// computation for the next authorized command. The challenge is single-use:
+/// Returns a 48-byte random challenge that must be included in the signed
+/// pre-image for the next authorized command. The challenge is single-use:
 /// it is consumed by the device after one authorized command.
 ///
 /// # Parameters
@@ -32,7 +41,7 @@ use caliptra_util_host_session::CaliptraSession;
 ///
 /// # Returns
 ///
-/// - `Ok(GetAuthCmdChallengeResponse)` containing the 32-byte challenge
+/// - `Ok(GetAuthCmdChallengeResponse)` containing the 48-byte challenge
 /// - `Err(CaliptraApiError)` on failure
 pub fn caliptra_cmd_get_auth_challenge(
     session: &mut CaliptraSession,
@@ -40,7 +49,7 @@ pub fn caliptra_cmd_get_auth_challenge(
     let request = GetAuthCmdChallengeRequest::default();
     session
         .execute_command_with_id(CaliptraCommandId::GetAuthCmdChallenge, &request)
-        .map_err(|_| CaliptraApiError::SessionError("Get auth command challenge execution failed"))
+        .map_err(|error| map_session_error(error, "Get auth command challenge execution failed"))
 }
 
 /// Program field entropy for an OTP partition.
@@ -64,5 +73,47 @@ pub fn caliptra_cmd_fe_prog(
 ) -> CaliptraResult<FeProgResponse> {
     session
         .execute_command_with_id(CaliptraCommandId::FeProg, request)
-        .map_err(|_| CaliptraApiError::SessionError("FE_PROG command execution failed"))
+        .map_err(|error| map_session_error(error, "FE_PROG command execution failed"))
 }
+
+macro_rules! authorized_fuse_api {
+    ($fn_name:ident, $request:ty, $response:ty, $command:ident, $error:literal) => {
+        pub fn $fn_name(
+            session: &mut CaliptraSession,
+            request: &$request,
+        ) -> CaliptraResult<$response> {
+            session
+                .execute_command_with_id(CaliptraCommandId::$command, request)
+                .map_err(|error| map_session_error(error, $error))
+        }
+    };
+}
+
+authorized_fuse_api!(
+    caliptra_cmd_provision_vendor_pk_hash,
+    ProvisionVendorPkHashRequest,
+    ProvisionVendorPkHashResponse,
+    ProvisionVendorPkHash,
+    "ProvisionVendorPkHash command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_increase_caliptra_min_svn,
+    FuseIncreaseCaliptraMinSvnRequest,
+    FuseIncreaseCaliptraMinSvnResponse,
+    FuseIncreaseCaliptraMinSvn,
+    "FuseIncreaseCaliptraMinSvn command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_revoke_vendor_pub_key,
+    FuseRevokeVendorPubKeyRequest,
+    FuseRevokeVendorPubKeyResponse,
+    FuseRevokeVendorPubKey,
+    "FuseRevokeVendorPubKey command execution failed"
+);
+authorized_fuse_api!(
+    caliptra_cmd_fuse_revoke_vendor_pk_hash,
+    FuseRevokeVendorPkHashRequest,
+    FuseRevokeVendorPkHashResponse,
+    FuseRevokeVendorPkHash,
+    "FuseRevokeVendorPkHash command execution failed"
+);

--- a/caliptra-util-host/commands/src/api/mod.rs
+++ b/caliptra-util-host/commands/src/api/mod.rs
@@ -50,6 +50,8 @@ pub enum CaliptraApiError {
     TransportNotAvailable,
     /// Command execution failed
     CommandFailed(&'static str),
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
     /// Session error (generic session layer error)
     SessionError(&'static str),
 }
@@ -80,6 +82,9 @@ impl core::fmt::Display for CaliptraApiError {
             CaliptraApiError::SessionNotInitialized => write!(f, "Session not initialized"),
             CaliptraApiError::TransportNotAvailable => write!(f, "Transport not available"),
             CaliptraApiError::CommandFailed(msg) => write!(f, "Command failed: {}", msg),
+            CaliptraApiError::DeviceError(code) => {
+                write!(f, "Device completion code: {code:#04x}")
+            }
             CaliptraApiError::SessionError(msg) => write!(f, "Session error: {}", msg),
         }
     }

--- a/caliptra-util-host/session/src/lib.rs
+++ b/caliptra-util-host/session/src/lib.rs
@@ -10,7 +10,7 @@ use caliptra_mcu_core_util_host_command_types::{
     CaliptraCommandId, CommandRequest, CommandResponse,
 };
 use caliptra_mcu_core_util_host_osal::time::{sleep, Duration, Instant};
-use caliptra_mcu_core_util_host_transport::Transport;
+use caliptra_mcu_core_util_host_transport::{Transport, TransportError};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Maximum size for command packets
@@ -51,6 +51,9 @@ pub enum SessionError {
 
     /// Transport layer error
     TransportError(&'static str),
+
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
 
     /// OSAL error
     OsalError(&'static str),
@@ -426,7 +429,10 @@ impl<'t> CaliptraSession<'t> {
             // Send the command with command_id as separate parameter
             transport
                 .send(command_id as u32, request_bytes)
-                .map_err(|_| SessionError::TransportError("Send failed"))?;
+                .map_err(|err| match err {
+                    TransportError::DeviceError(code) => SessionError::DeviceError(code),
+                    _ => SessionError::TransportError("Send failed"),
+                })?;
 
             // Receive the response
             let mut response_buffer = [0u8; MAX_COMMAND_PACKET_SIZE];

--- a/caliptra-util-host/transport/src/error.rs
+++ b/caliptra-util-host/transport/src/error.rs
@@ -60,6 +60,9 @@ pub enum TransportError {
     /// OSAL error
     OsalError(OsalError),
 
+    /// Device returned a protocol completion code.
+    DeviceError(u8),
+
     /// Custom transport error
     Custom(&'static str),
 }
@@ -102,6 +105,9 @@ impl fmt::Display for TransportError {
             TransportError::MessageTooLarge(msg) => write!(f, "Message too large: {}", msg),
             TransportError::ParseError(msg) => write!(f, "Parse error: {}", msg),
             TransportError::PluginError(msg) => write!(f, "Plugin error: {}", msg),
+            TransportError::DeviceError(code) => {
+                write!(f, "Device completion code: {code:#04x}")
+            }
             TransportError::Custom(msg) => write!(f, "Custom error: {}", msg),
         }
     }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -23,6 +23,7 @@ use super::protocol::{
 };
 use super::transport::{SpdmVdmDriver, SpdmVdmError};
 use crate::TransportError;
+use alloc::vec::Vec;
 use caliptra_mcu_core_util_host_command_types::debug_unlock::{
     ProdDebugUnlockReqRequest, ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest,
     ProdDebugUnlockTokenResponse, DEBUG_UNLOCK_CHALLENGE_SIZE, UNIQUE_DEVICE_ID_SIZE,
@@ -146,10 +147,10 @@ pub fn handle_export_attested_csr(
 // GetAuthCmdChallenge (CaliptraCommandId::GetAuthCmdChallenge)
 // ---------------------------------------------------------------------------
 
-/// Handle GetAuthChallenge sub-command — request a challenge nonce for HMAC authorization.
+/// Handle GetAuthChallenge sub-command — request a one-use authorization nonce.
 ///
 /// VDM wire format request:  [version, 0x12 (AuthorizedCommand), sub_cmd_id=0x4D41_4343 (4 LE)]
-/// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code, challenge(32)]
+/// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code, challenge(48)]
 pub fn handle_get_auth_challenge(
     _payload: &[u8],
     driver: &mut dyn SpdmVdmDriver,
@@ -169,9 +170,9 @@ pub fn handle_get_auth_challenge(
         &mut resp_buf,
     )?;
 
-    // Response data: [challenge(32)]
+    // Response data: [challenge(48)]
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
-    if data.len() < AUTH_CMD_CHALLENGE_SIZE {
+    if data.len() != AUTH_CMD_CHALLENGE_SIZE {
         return Err(TransportError::InvalidMessage);
     }
 
@@ -181,59 +182,110 @@ pub fn handle_get_auth_challenge(
         .copy_from_slice(&data[..AUTH_CMD_CHALLENGE_SIZE]);
 
     let resp_bytes = internal_resp.as_bytes();
-    let copy_len = resp_bytes.len().min(response_buffer.len());
-    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
-    Ok(copy_len)
+    if response_buffer.len() < resp_bytes.len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..resp_bytes.len()].copy_from_slice(resp_bytes);
+    Ok(resp_bytes.len())
+}
+
+fn handle_authorized_fuse_command(
+    command_id: u32,
+    request: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let mut vdm_payload = Vec::with_capacity(4 + request.len());
+    vdm_payload.extend_from_slice(&command_id.to_le_bytes());
+    vdm_payload.extend_from_slice(request);
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let resp_len = send_vdm_request(
+        CaliptraVdmCommand::AuthorizedCommand,
+        &vdm_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+    if resp_len != VDM_RESPONSE_HEADER_SIZE {
+        return Err(TransportError::InvalidMessage);
+    }
+    let response = CommonResponse { fips_status: 0 };
+    if response_buffer.len() < response.as_bytes().len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..response.as_bytes().len()].copy_from_slice(response.as_bytes());
+    Ok(response.as_bytes().len())
 }
 
 // ---------------------------------------------------------------------------
-// ProgramFieldEntropy (CaliptraCommandId::FeProg)
+// Authorized fuse commands
 // ---------------------------------------------------------------------------
 
 /// Handle ProgramFieldEntropy (FE_PROG) authorized sub-command.
 ///
-/// VDM wire format request:  [version, 0x12 (AuthorizedCommand),
-///   sub_cmd_id=0x4D43_4650 (4 LE), partition(4 LE),
-///   nonce(48), ecc_pub_x(48), ecc_pub_y(48), mldsa_pub(2592),
-///   ecc_sig(r 48 || s 48), mldsa_sig(4628)]
-/// Signatures come LAST. The nonce and public keys are fields of `FeProgRequest`,
-/// so they are carried automatically by `req.as_bytes()` below — no manual
-/// serialization here.
+/// VDM wire format request: [version, 0x12, sub_cmd_id, partition,
+/// nonce, ECC public key, ML-DSA public key, HybridSignature].
 /// VDM wire format response: [version, 0x12 (AuthorizedCommand), completion_code]
 pub fn handle_fe_prog(
     payload: &[u8],
     driver: &mut dyn SpdmVdmDriver,
     response_buffer: &mut [u8],
 ) -> Result<usize, TransportError> {
-    use alloc::vec::Vec;
     use caliptra_mcu_core_util_host_command_types::fuse::{FeProgRequest, FeProgResponse};
-
     let req = FeProgRequest::from_bytes(payload).map_err(|_| TransportError::InvalidMessage)?;
-
-    // VDM payload: sub_cmd_id(4 LE) || FeProgRequest bytes
-    //   = sub_cmd_id || partition(4 LE) || nonce(48) || ecc_pub_x(48) || ecc_pub_y(48) || mldsa_pub(2592) || ecc_sig(96) || mldsa_sig(4628)
     let mut vdm_payload = Vec::with_capacity(4 + size_of::<FeProgRequest>());
     vdm_payload.extend_from_slice(&MC_FE_PROG_CANONICAL_CMD_ID.to_le_bytes());
     vdm_payload.extend_from_slice(req.as_bytes());
-
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
-    let _resp_len = send_vdm_request(
+    send_vdm_request(
         CaliptraVdmCommand::AuthorizedCommand,
         &vdm_payload,
         driver,
         &mut resp_buf,
     )?;
-
-    // Response is header-only (completion code checked by send_vdm_request)
-    let internal_resp = FeProgResponse {
+    let response = FeProgResponse {
         common: CommonResponse { fips_status: 0 },
     };
-
-    let resp_bytes = internal_resp.as_bytes();
-    let copy_len = resp_bytes.len().min(response_buffer.len());
-    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
-    Ok(copy_len)
+    let bytes = response.as_bytes();
+    if response_buffer.len() < bytes.len() {
+        return Err(TransportError::BufferError("Response buffer too small"));
+    }
+    response_buffer[..bytes.len()].copy_from_slice(bytes);
+    Ok(bytes.len())
 }
+
+macro_rules! authorized_fuse_handler {
+    ($name:ident, $request:ty, $command_id:expr) => {
+        pub fn $name(
+            payload: &[u8],
+            driver: &mut dyn SpdmVdmDriver,
+            response_buffer: &mut [u8],
+        ) -> Result<usize, TransportError> {
+            let req =
+                <$request>::from_bytes(payload).map_err(|_| TransportError::InvalidMessage)?;
+            handle_authorized_fuse_command($command_id, req.as_bytes(), driver, response_buffer)
+        }
+    };
+}
+authorized_fuse_handler!(
+    handle_provision_vendor_pk_hash,
+    fuse::ProvisionVendorPkHashRequest,
+    fuse::MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_increase_caliptra_min_svn,
+    fuse::FuseIncreaseCaliptraMinSvnRequest,
+    fuse::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_revoke_vendor_pub_key,
+    fuse::FuseRevokeVendorPubKeyRequest,
+    fuse::MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID
+);
+authorized_fuse_handler!(
+    handle_fuse_revoke_vendor_pk_hash,
+    fuse::FuseRevokeVendorPkHashRequest,
+    fuse::MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID
+);
 
 // ---------------------------------------------------------------------------
 // RequestDebugUnlock (CaliptraCommandId::ProdDebugUnlockReq)
@@ -415,6 +467,188 @@ mod tests {
             TransportError::BufferError(msg) => assert!(msg.contains("maximum CSR size")),
             other => panic!("unexpected error: {:?}", other),
         }
+    }
+
+    #[test]
+    fn authorized_fuse_commands_preserve_exact_wire_layout() {
+        let mut sig = caliptra_mcu_mbox_common::messages::HybridSignature::default();
+        sig.ecc_sig_r.fill(0x11);
+        sig.ecc_sig_s.fill(0x22);
+        sig.mldsa_sig.fill(0x33);
+
+        let pvpk = fuse::ProvisionVendorPkHashRequest {
+            slot: 0x0102_0304,
+            hash: [0xA5; 48],
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mcms = fuse::FuseIncreaseCaliptraMinSvnRequest {
+            flags: 0x1122_3344,
+            svn: 0x5566_7788,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mrvk = fuse::FuseRevokeVendorPubKeyRequest {
+            reserved: 0x0102_0304,
+            vendor_pk_hash_slot: 0x1112_1314,
+            key_type: 0x2122_2324,
+            key_index: 0x3132_3334,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let rvkh = fuse::FuseRevokeVendorPkHashRequest {
+            reserved: 0x4142_4344,
+            vendor_pk_hash_slot: 0x5152_5354,
+            sig: sig.clone(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+
+        let signature_bytes = {
+            let mut bytes = vec![0x11; 48];
+            bytes.extend_from_slice(&[0x22; 48]);
+            bytes.extend_from_slice(&vec![0x33; sig.mldsa_sig.len()]);
+            bytes
+        };
+        let make_golden = |command_id: u32, fields: &[u8]| {
+            let mut packet = vec![
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizedCommand as u8,
+            ];
+            packet.extend_from_slice(&command_id.to_le_bytes());
+            packet.extend_from_slice(fields);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_CMD_CHALLENGE_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_ECC_COORD_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_ECC_COORD_SIZE]);
+            packet.extend_from_slice(&[0u8; fuse::AUTH_PUB_MLDSA_SIZE]);
+            packet.extend_from_slice(&signature_bytes);
+            packet
+        };
+
+        let mut pvpk_fields = 0x0102_0304u32.to_le_bytes().to_vec();
+        pvpk_fields.extend_from_slice(&[0xA5; 48]);
+        let mut mcms_fields = 0x1122_3344u32.to_le_bytes().to_vec();
+        mcms_fields.extend_from_slice(&0x5566_7788u32.to_le_bytes());
+        let mut mrvk_fields = Vec::new();
+        for field in [0x0102_0304u32, 0x1112_1314, 0x2122_2324, 0x3132_3334] {
+            mrvk_fields.extend_from_slice(&field.to_le_bytes());
+        }
+        let mut rvkh_fields = 0x4142_4344u32.to_le_bytes().to_vec();
+        rvkh_fields.extend_from_slice(&0x5152_5354u32.to_le_bytes());
+
+        let cases: Vec<(&[u8], Vec<u8>, VdmCommandHandlerFnForTest)> = vec![
+            (
+                pvpk.as_bytes(),
+                make_golden(
+                    fuse::MC_PROVISION_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+                    &pvpk_fields,
+                ),
+                handle_provision_vendor_pk_hash,
+            ),
+            (
+                mcms.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN_CANONICAL_CMD_ID,
+                    &mcms_fields,
+                ),
+                handle_fuse_increase_caliptra_min_svn,
+            ),
+            (
+                mrvk.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_REVOKE_VENDOR_PUB_KEY_CANONICAL_CMD_ID,
+                    &mrvk_fields,
+                ),
+                handle_fuse_revoke_vendor_pub_key,
+            ),
+            (
+                rvkh.as_bytes(),
+                make_golden(
+                    fuse::MC_FUSE_REVOKE_VENDOR_PK_HASH_CANONICAL_CMD_ID,
+                    &rvkh_fields,
+                ),
+                handle_fuse_revoke_vendor_pk_hash,
+            ),
+        ];
+
+        for (request, golden, handler) in cases {
+            let mut driver = FakeDriver {
+                response: success_response(CaliptraVdmCommand::AuthorizedCommand, &[]),
+                last_request: Vec::new(),
+            };
+            let mut response = [0u8; core::mem::size_of::<CommonResponse>()];
+            handler(request, &mut driver, &mut response).unwrap();
+            assert_eq!(driver.last_request, golden);
+
+            let err = handler(&request[..request.len() - 1], &mut driver, &mut response)
+                .expect_err("truncated hybrid signature must be rejected locally");
+            assert!(matches!(err, TransportError::InvalidMessage));
+
+            let mut oversized = request.to_vec();
+            oversized.push(0);
+            let err = handler(&oversized, &mut driver, &mut response)
+                .expect_err("trailing request bytes must be rejected locally");
+            assert!(matches!(err, TransportError::InvalidMessage));
+        }
+    }
+
+    type VdmCommandHandlerFnForTest =
+        fn(&[u8], &mut dyn SpdmVdmDriver, &mut [u8]) -> Result<usize, TransportError>;
+
+    #[test]
+    fn authorized_command_rejects_trailing_response_and_small_output_buffer() {
+        let req = fuse::FuseIncreaseCaliptraMinSvnRequest {
+            flags: 0,
+            svn: 1,
+            sig: Default::default(),
+            nonce: [0; fuse::AUTH_CMD_CHALLENGE_SIZE],
+            ecc_pub_x: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            ecc_pub_y: [0; fuse::AUTH_PUB_ECC_COORD_SIZE],
+            mldsa_pub: [0; fuse::AUTH_PUB_MLDSA_SIZE],
+        };
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::AuthorizedCommand, &[0xAA]),
+            last_request: Vec::new(),
+        };
+        let mut response = [0u8; core::mem::size_of::<CommonResponse>()];
+        assert!(matches!(
+            handle_fuse_increase_caliptra_min_svn(req.as_bytes(), &mut driver, &mut response),
+            Err(TransportError::InvalidMessage)
+        ));
+
+        driver.response = success_response(CaliptraVdmCommand::AuthorizedCommand, &[]);
+        assert!(matches!(
+            handle_fuse_increase_caliptra_min_svn(req.as_bytes(), &mut driver, &mut []),
+            Err(TransportError::BufferError(_))
+        ));
+    }
+
+    #[test]
+    fn get_auth_challenge_requires_exact_response_length() {
+        let challenge = [0x5A; fuse::AUTH_CMD_CHALLENGE_SIZE];
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::AuthorizedCommand, &challenge),
+            last_request: Vec::new(),
+        };
+        let mut response = [0u8; core::mem::size_of::<fuse::GetAuthCmdChallengeResponse>()];
+        handle_get_auth_challenge(&[], &mut driver, &mut response).unwrap();
+
+        driver.response.push(0);
+        assert!(matches!(
+            handle_get_auth_challenge(&[], &mut driver, &mut response),
+            Err(TransportError::InvalidMessage)
+        ));
     }
 
     #[test]

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -30,6 +30,18 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
             Some(commands::handle_prod_debug_unlock_token)
         }
         x if x == CaliptraCommandId::FeProg as u32 => Some(commands::handle_fe_prog),
+        x if x == CaliptraCommandId::ProvisionVendorPkHash as u32 => {
+            Some(commands::handle_provision_vendor_pk_hash)
+        }
+        x if x == CaliptraCommandId::FuseIncreaseCaliptraMinSvn as u32 => {
+            Some(commands::handle_fuse_increase_caliptra_min_svn)
+        }
+        x if x == CaliptraCommandId::FuseRevokeVendorPubKey as u32 => {
+            Some(commands::handle_fuse_revoke_vendor_pub_key)
+        }
+        x if x == CaliptraCommandId::FuseRevokeVendorPkHash as u32 => {
+            Some(commands::handle_fuse_revoke_vendor_pk_hash)
+        }
         x if x == CaliptraCommandId::GetAuthCmdChallenge as u32 => {
             Some(commands::handle_get_auth_challenge)
         }
@@ -50,6 +62,10 @@ mod tests {
             CaliptraCommandId::ProdDebugUnlockReq,
             CaliptraCommandId::ProdDebugUnlockToken,
             CaliptraCommandId::FeProg,
+            CaliptraCommandId::ProvisionVendorPkHash,
+            CaliptraCommandId::FuseIncreaseCaliptraMinSvn,
+            CaliptraCommandId::FuseRevokeVendorPubKey,
+            CaliptraCommandId::FuseRevokeVendorPkHash,
             CaliptraCommandId::GetAuthCmdChallenge,
         ];
 

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
@@ -130,7 +130,14 @@ pub fn command_id_to_vdm(command_id: u32) -> Option<CaliptraVdmCommand> {
         x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
             Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken)
         }
-        x if x == CaliptraCommandId::FeProg as u32 => Some(CaliptraVdmCommand::AuthorizedCommand),
+        x if x == CaliptraCommandId::FeProg as u32
+            || x == CaliptraCommandId::ProvisionVendorPkHash as u32
+            || x == CaliptraCommandId::FuseIncreaseCaliptraMinSvn as u32
+            || x == CaliptraCommandId::FuseRevokeVendorPubKey as u32
+            || x == CaliptraCommandId::FuseRevokeVendorPkHash as u32 =>
+        {
+            Some(CaliptraVdmCommand::AuthorizedCommand)
+        }
         x if x == CaliptraCommandId::GetAuthCmdChallenge as u32 => {
             Some(CaliptraVdmCommand::AuthorizedCommand)
         }
@@ -184,6 +191,19 @@ mod tests {
             command_id_to_vdm(CaliptraCommandId::ProdDebugUnlockReq as u32),
             Some(CaliptraVdmCommand::RequestDebugUnlock)
         );
+        for id in [
+            CaliptraCommandId::GetAuthCmdChallenge,
+            CaliptraCommandId::FeProg,
+            CaliptraCommandId::ProvisionVendorPkHash,
+            CaliptraCommandId::FuseIncreaseCaliptraMinSvn,
+            CaliptraCommandId::FuseRevokeVendorPubKey,
+            CaliptraCommandId::FuseRevokeVendorPkHash,
+        ] {
+            assert_eq!(
+                command_id_to_vdm(id as u32),
+                Some(CaliptraVdmCommand::AuthorizedCommand)
+            );
+        }
         // Unsupported command
         assert_eq!(command_id_to_vdm(CaliptraCommandId::HashInit as u32), None);
     }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/transport.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/transport.rs
@@ -78,9 +78,7 @@ impl From<SpdmVdmError> for TransportError {
                 TransportError::ConnectionFailed(Some("SPDM VDM communication error"))
             }
             SpdmVdmError::BufferOverflow => TransportError::BufferError("Buffer overflow"),
-            SpdmVdmError::DeviceError(_) => {
-                TransportError::ConnectionFailed(Some("SPDM VDM device error"))
-            }
+            SpdmVdmError::DeviceError(code) => TransportError::DeviceError(code),
             SpdmVdmError::CodecError => TransportError::InvalidMessage,
             SpdmVdmError::SessionError => {
                 TransportError::ConnectionFailed(Some("SPDM session error"))
@@ -112,6 +110,18 @@ impl<'a> SpdmVdmTransport<'a> {
             response_len: 0,
             has_response: false,
         }
+    }
+
+    /// Send a raw Caliptra VDM payload without local command encoding.
+    ///
+    /// This is intended for protocol validators that must exercise malformed
+    /// requests against the responder rather than rejecting them locally.
+    pub fn send_raw_vdm(
+        &mut self,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, SpdmVdmError> {
+        self.driver.send_receive_vdm(request, response)
     }
 
     /// Process a command: encode internal request → VDM payload, send, decode response.

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -293,27 +293,30 @@ utility dispatch tables. MCI-only operations still require a trusted SoC-side
 service or bridge that owns MCI access and enforces the deployment policy.
 
 ## Vendor Public Key Selection and Rotation
+
 Caliptra MCU supports a vendor public key selection and rotation scheme
 based on fuses and hardware strapping pins. This section describes how the ROM
 selects the active vendor public key slot and how integrators can manage
 rotation and revocation.
 
 ### Key Policy and Selection Process
+
 The ROM follows this process to select a vendor public key hash slot (out of 16
 available slots):
-1.  **Validity Check**: The ROM reads the `VENDOR_PK_HASH_VALID` fuse mask.
+
+1. **Validity Check**: The ROM reads the `VENDOR_PK_HASH_VALID` fuse mask.
     Each bit corresponds to a slot. If a bit is set to `1`, the slot is
     considered invalid and skipped.
-2.  **Revocation Check**: For each valid slot, the ROM checks the revocation
+2. **Revocation Check**: For each valid slot, the ROM checks the revocation
     status of the keys in the `CPTRA_CORE_ECC_REVOCATION_X`,
     `CPTRA_CORE_MLDSA_REVOCATION_X`, and `CPTRA_CORE_LMS_REVOCATION_X` fields:
-    -   **ECC Keys**: Checked against the ECC revocation fuses (4 bits per
+    - **ECC Keys**: Checked against the ECC revocation fuses (4 bits per
         slot).
-    -   **PQC Keys**: Checked against PQC revocation fuses (4 bits for MLDSA,
+    - **PQC Keys**: Checked against PQC revocation fuses (4 bits for MLDSA,
         16 bits for LMS).
     A slot is considered **functional** if it has at least one unrevoked ECC key
     AND at least one unrevoked PQC key.
-3.  **Default Selection**: By default, the ROM selects the **first functional
+3. **Default Selection**: By default, the ROM selects the **first functional
     slot** it encounters (searching from slot 0 to 15). However, this logic can
     be overridden by passing a different implementation of the `VendorKeyPolicy`
     into the ROM parameters.
@@ -352,11 +355,11 @@ authorization flow before invoking it.
 Keys can be revoked permanently by burning fuses. MCU Runtime exposes
 authorized MCI mailbox commands for the supported in-field flows:
 
--   `MC_FUSE_REVOKE_VENDOR_PUB_KEY` revokes an individual firmware
+- `MC_FUSE_REVOKE_VENDOR_PUB_KEY` revokes an individual firmware
     verification key within a vendor PK hash slot. The command supports ECC
     P-384, LMS, and MLDSA-87 key types and burns the corresponding bit in the
     slot's revocation field.
--   `MC_FUSE_REVOKE_VENDOR_PK_HASH` revokes an entire vendor PK hash slot by
+- `MC_FUSE_REVOKE_VENDOR_PK_HASH` revokes an entire vendor PK hash slot by
     setting the corresponding bit in `VENDOR_PK_HASH_VALID` to `1`.
 
 Both commands use the runtime authorization flow. They reject requests that
@@ -384,6 +387,30 @@ authorizer trait (`CommandAuthorizer` for mailbox or `CaliptraVdmAuthorization` 
 SPDM VDM) and provisioning the corresponding verification public keys in OTP
 fuses, secure platform storage, or embedded in firmware directly.
 
+The `caliptra-spdm-validator` host tool supports the four authorized fuse VDMs
+through the `[provision_vendor_pk_hash]`, `[increase_caliptra_min_svn]`,
+`[revoke_vendor_pub_key]`, and `[revoke_vendor_pk_hash]` configuration sections.
+All integer fields below are little-endian, and the signature covers exactly the
+bytes before `HybridSignature`:
+
+| Subcommand | Canonical ID | Authorized payload |
+|---|---:|---|
+| Provision Vendor PK Hash | `0x5056504b` (`PVPK`) | `slot:u32 \| hash:[u8;48] \| HybridSignature` |
+| Increase Caliptra Min SVN | `0x4d434d53` (`MCMS`) | `flags:u32 \| svn:u32 \| HybridSignature` |
+| Revoke Vendor Public Key | `0x4d52564b` (`MRVK`) | `reserved:u32 \| slot:u32 \| key_type:u32 \| key_index:u32 \| HybridSignature` |
+| Revoke Vendor PK Hash | `0x52564b48` (`RVKH`) | `reserved:u32 \| slot:u32 \| HybridSignature` |
+
+The shared `[authorized_commands]` section supplies the test signer keys. The
+integration harness selects `authorization`, `provision-vendor-pk-hash`,
+`increase-min-svn`, `revoke-vendor-pub-key`, or `revoke-vendor-pk-hash` with
+`--fuse-suite`; each destructive suite boots a separate emulator instance. It
+asserts responder completion codes for malformed, authorization, and policy
+failures rather than treating transport/session failures as expected rejection.
+These operations burn OTP state: validation must use disposable devices or a
+fresh emulator instance for each independently destructive scenario. The
+checked-in test keys are emulator fixtures only and must not be used as
+production authorization credentials.
+
 For per-key revocation, once all usable bits for a key type are burned in a
 slot, that key type is fully revoked in that slot. The last key index for a
 given key type cannot be revoked, matching Caliptra's requirement that a slot
@@ -401,10 +428,11 @@ revoked (e.g., moving to a new key version) but other keys within that PK hash
 remain trusted.
 
 **Process**:
-1.  Push a new Runtime (RT) firmware signed with a new key.
-2.  After the device boots with the replacement key, an authorized requester
+
+1. Push a new Runtime (RT) firmware signed with a new key.
+2. After the device boots with the replacement key, an authorized requester
     sends `MC_FUSE_REVOKE_VENDOR_PUB_KEY` to MCU Runtime for the old key.
-3.  MCU Runtime validates that the target key was not used for the current boot
+3. MCU Runtime validates that the target key was not used for the current boot
     and burns the corresponding revocation bit.
 
 ```mermaid
@@ -428,13 +456,14 @@ This flow is used when the entire PK hash slot is compromised or needs to be
 replaced, requiring a transition to a new PK hash slot.
 
 **Process**:
-1.  Provision the new vendor PK hash into an empty inactive slot if it was not
+
+1. Provision the new vendor PK hash into an empty inactive slot if it was not
     provisioned during manufacturing.
-2.  Push a new Runtime (RT) firmware signed with a key from the new PK hash slot.
-3.  Additionally assert the hardware strapping pin (bit 1 of
+2. Push a new Runtime (RT) firmware signed with a key from the new PK hash slot.
+3. Additionally assert the hardware strapping pin (bit 1 of
     `mci_reg_generic_input_wires[1]`) to enable rotation.
-4.  On reboot, the MCU ROM will select the new PK hash slot.
-5.  An authorized requester sends `MC_FUSE_REVOKE_VENDOR_PK_HASH` to MCU
+4. On reboot, the MCU ROM will select the new PK hash slot.
+5. An authorized requester sends `MC_FUSE_REVOKE_VENDOR_PK_HASH` to MCU
     Runtime to burn the old PK hash slot as invalid.
 
 ```mermaid
@@ -620,4 +649,3 @@ region, separate from the application RAM region.  Userspace processes
 cannot access it directly; they interact with the stored data only
 through the kernel capsule syscall interfaces
 (`DpeHandleStore` driver `0x8000_0020` and `PcrStore` driver `0x8000_0021`).
-

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -166,7 +166,14 @@ test-pldm-discovery = []
 test-pldm-fw-update = []
 test-pldm-fw-update-e2e = []
 test-pldm-streaming-boot = ["streaming-boot"]
-test-caliptra-util-host-spdm-vdm-validator = ["spdm"]
+# Authorized fuse VDM requests carry a 4.7 KiB hybrid signature and therefore
+# require bounded CHUNK_SEND reassembly before VDM dispatch. Keep this out of
+# the general SPDM feature so production and unrelated test bundles do not pay
+# the code-size and build-time cost.
+test-caliptra-util-host-spdm-vdm-validator = [
+  "spdm",
+  "caliptra-mcu-spdm-stack/generic-large-request",
+]
 test-mctp-spdm-attestation = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-tcb = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-mixed = ["spdm", "flash-boot"]

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -172,7 +172,14 @@ test-pldm-discovery = []
 test-pldm-fw-update = []
 test-pldm-fw-update-e2e = []
 test-pldm-streaming-boot = ["streaming-boot"]
-test-caliptra-util-host-spdm-vdm-validator = ["spdm"]
+# Authorized fuse VDM requests carry a 4.7 KiB hybrid signature and therefore
+# require bounded CHUNK_SEND reassembly before VDM dispatch. Keep this out of
+# the general SPDM feature so production and unrelated test bundles do not pay
+# the code-size and build-time cost.
+test-caliptra-util-host-spdm-vdm-validator = [
+  "spdm",
+  "caliptra-mcu-spdm-stack/generic-large-request",
+]
 test-mctp-spdm-attestation = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-tcb = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-mixed = ["spdm", "flash-boot"]

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -76,7 +76,10 @@ all-features = [
   "userspace-log",
   "mctp-vdm-service",
 ]
-spdm = ["mcu-mbox-service"]
+spdm = [
+  "mcu-mbox-service",
+  "caliptra-mcu-spdm-stack/generic-large-request",
+]
 streaming-boot = []
 flash-boot = []
 firmware-update = []
@@ -172,14 +175,7 @@ test-pldm-discovery = []
 test-pldm-fw-update = []
 test-pldm-fw-update-e2e = []
 test-pldm-streaming-boot = ["streaming-boot"]
-# Authorized fuse VDM requests carry a 4.7 KiB hybrid signature and therefore
-# require bounded CHUNK_SEND reassembly before VDM dispatch. Keep this out of
-# the general SPDM feature so production and unrelated test bundles do not pay
-# the code-size and build-time cost.
-test-caliptra-util-host-spdm-vdm-validator = [
-  "spdm",
-  "caliptra-mcu-spdm-stack/generic-large-request",
-]
+test-caliptra-util-host-spdm-vdm-validator = ["spdm"]
 test-mctp-spdm-attestation = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-tcb = ["spdm", "flash-boot"]
 test-mctp-spdm-attestation-mixed = ["spdm", "flash-boot"]

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -306,6 +306,12 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
     if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
         return Err(CaliptraCompletionCode::InvalidParameter);
     }
+    let pk_hash_from_slot = otp
+        .read_vendor_pk_hash(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+    if pk_hash_from_slot.iter().all(|byte| *byte == 0) {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
 
     let caliptra_info = fw_info(alloc)
         .await
@@ -313,10 +319,6 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
     let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
         .read_vendor_pk_hash()
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-    let pk_hash_from_slot = otp
-        .read_vendor_pk_hash(vendor_pk_hash_slot)
-        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-
     if booted_pk_hash == pk_hash_from_slot {
         const FW_VERIFICATION_PQC_TYPE_MLDSA: u32 = 1;
         const FW_VERIFICATION_PQC_TYPE_LMS: u32 = 3;
@@ -340,7 +342,19 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
 }
 
 pub fn revoke_vendor_pk_hash(vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> {
+    const MAX_VENDOR_PK_HASH_SLOTS: u32 = 16;
+    if vendor_pk_hash_slot >= MAX_VENDOR_PK_HASH_SLOTS {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
+
     let otp = Otp::<DefaultSyscalls>::new();
+    // A cleared validity bit is the persistent indication that this slot was
+    // already revoked. Preserve the mailbox policy's idempotent behavior
+    // without attempting to read a now-invalid slot.
+    if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+        return Ok(());
+    }
+
     let booted_pk_hash = caliptra::Caliptra::<DefaultSyscalls>::new()
         .read_vendor_pk_hash()
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -302,8 +302,14 @@ pub async fn revoke_vendor_pub_key<A: ApiAlloc>(
 ) -> CaliptraCmdResult<()> {
     let key_type = RevokeVendorPubKeyType::try_from(key_type)
         .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
+    if vendor_pk_hash_slot as usize >= otp::MAX_NUM_VENDOR_PK_HASH {
+        return Err(CaliptraCompletionCode::InvalidParameter);
+    }
     let otp = Otp::<DefaultSyscalls>::new();
-    if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+    if !otp
+        .vendor_pk_hash_slot_is_valid(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?
+    {
         return Err(CaliptraCompletionCode::InvalidParameter);
     }
     let pk_hash_from_slot = otp
@@ -351,7 +357,10 @@ pub fn revoke_vendor_pk_hash(vendor_pk_hash_slot: u32) -> CaliptraCmdResult<()> 
     // A cleared validity bit is the persistent indication that this slot was
     // already revoked. Preserve the mailbox policy's idempotent behavior
     // without attempting to read a now-invalid slot.
-    if !otp.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+    if !otp
+        .vendor_pk_hash_slot_is_valid(vendor_pk_hash_slot)
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?
+    {
         return Ok(());
     }
 

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -99,25 +99,26 @@ impl<S: Syscalls> Otp<S> {
         S::command(self.driver_num, cmd::OTP_WRITE_RAW, data, mask).to_result::<(), ErrorCode>()
     }
 
-    /// Check whether a given vendor pk hash slot is marked valid (has not been marked invalid).
-    ///
-    /// Also returns `false` if the slot ID is invalid or reading of the mask fails.
-    pub fn valid_vendor_pk_hash_slot(&self, slot: u32) -> bool {
+    /// Check whether a vendor PK hash slot is marked valid (not revoked).
+    pub fn vendor_pk_hash_slot_is_valid(&self, slot: u32) -> Result<bool, ErrorCode> {
         if slot as usize >= MAX_NUM_VENDOR_PK_HASH {
-            return false;
+            return Err(ErrorCode::Invalid);
         }
 
-        let Ok(valid_mask) = self.read(reg::VENDOR_PK_HASH_VALID, 0) else {
-            return false;
-        };
+        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0)?;
         // Bit value `1` means revoked
-        (valid_mask & (1 << slot)) == 0
+        Ok((valid_mask & (1 << slot)) == 0)
+    }
+
+    /// Check whether a vendor PK hash slot is valid, returning `false` on errors.
+    pub fn valid_vendor_pk_hash_slot(&self, slot: u32) -> bool {
+        self.vendor_pk_hash_slot_is_valid(slot).unwrap_or(false)
     }
 
     /// Read a vendor PK hash from fuses
     pub fn read_vendor_pk_hash(&self, slot: u32) -> Result<[u8; VENDOR_PK_HASH_SIZE], ErrorCode> {
         let reg = reg::vendor_pk_hash_reg_by_slot(slot).ok_or(ErrorCode::Invalid)?;
-        if !self.valid_vendor_pk_hash_slot(slot) {
+        if !self.vendor_pk_hash_slot_is_valid(slot)? {
             Err(ErrorCode::Invalid)?;
         }
 
@@ -138,7 +139,7 @@ impl<S: Syscalls> Otp<S> {
         key_type: RevokeVendorPubKeyType,
         key_index: u32,
     ) -> Result<(), ErrorCode> {
-        if !self.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+        if !self.vendor_pk_hash_slot_is_valid(vendor_pk_hash_slot)? {
             Err(ErrorCode::Invalid)?;
         }
 
@@ -184,7 +185,7 @@ impl<S: Syscalls> Otp<S> {
 
         let reg = reg::vendor_pk_hash_reg_by_slot(slot).ok_or(ErrorCode::Invalid)?;
 
-        if !self.valid_vendor_pk_hash_slot(slot) {
+        if !self.vendor_pk_hash_slot_is_valid(slot)? {
             // Error when the slot was already marked as invalid
             return Err(ErrorCode::Invalid);
         }
@@ -226,9 +227,9 @@ impl<S: Syscalls> Otp<S> {
             Err(ErrorCode::Invalid)?
         }
 
-        if !self.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+        if !self.vendor_pk_hash_slot_is_valid(vendor_pk_hash_slot)? {
             // Return early if the slot is already marked invalid
-            Ok(())?;
+            return Ok(());
         }
 
         // Check if the slot is provisioned to not burn an empty slot
@@ -351,4 +352,59 @@ pub mod reg {
     pub const FUSE_READ: u32 = 30;
     pub const FUSE_WRITE: u32 = 31;
     pub const FUSE_LOCK_PARTITION: u32 = 32;
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use caliptra_mcu_libtock_platform::CommandReturn;
+    use caliptra_mcu_libtock_unittest::{command_return, fake, DriverInfo};
+    use std::rc::Rc;
+
+    struct OtpDriver {
+        valid_mask: Result<u32, ErrorCode>,
+    }
+
+    impl fake::SyscallDriver for OtpDriver {
+        fn info(&self) -> DriverInfo {
+            DriverInfo::new(OTP_DRIVER_NUM)
+        }
+
+        fn command(&self, command_id: u32, reg_offset: u32, _index: u32) -> CommandReturn {
+            match command_id {
+                cmd::OTP_SET_REGISTER => command_return::success(),
+                cmd::OTP_READ if reg_offset == reg::VENDOR_PK_HASH_VALID => match self.valid_mask {
+                    Ok(mask) => command_return::success_u32(mask),
+                    Err(error) => command_return::failure(error),
+                },
+                _ => command_return::failure(ErrorCode::NoSupport),
+            }
+        }
+    }
+
+    fn otp_with_valid_mask(
+        valid_mask: Result<u32, ErrorCode>,
+    ) -> (fake::Kernel, Otp<fake::Syscalls>) {
+        let kernel = fake::Kernel::new();
+        kernel.add_driver(&Rc::new(OtpDriver { valid_mask }));
+        (kernel, Otp::new())
+    }
+
+    #[test]
+    fn validity_read_failure_is_not_reported_as_revoked() {
+        let (_kernel, otp) = otp_with_valid_mask(Err(ErrorCode::Fail));
+
+        assert_eq!(otp.vendor_pk_hash_slot_is_valid(1), Err(ErrorCode::Fail));
+        assert_eq!(otp.revoke_vendor_pk_hash(1), Err(ErrorCode::Fail));
+    }
+
+    #[test]
+    fn revoking_an_already_revoked_slot_is_idempotent() {
+        let (_kernel, otp) = otp_with_valid_mask(Ok(1 << 1));
+
+        assert_eq!(otp.vendor_pk_hash_slot_is_valid(1), Ok(false));
+        assert_eq!(otp.revoke_vendor_pk_hash(1), Ok(()));
+    }
 }

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -3,12 +3,18 @@
 //! Integration test for Caliptra VDM commands over SPDM vendor-defined messages.
 //!
 //! This test spawns the `caliptra-spdm-validator` binary (from caliptra-spdm-vdm-client) which
-//! runs all Caliptra VDM commands against the MCU's SPDM responder.
+//! runs all Caliptra VDM commands against the MCU's SPDM responder. The checked-in
+//! config includes authorized-fuse success, authorization rejection, and fuse-policy
+//! rejection flows against inactive slot 1 in this disposable emulator model.
 
 #[cfg(test)]
 mod test {
-    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use crate::test::{
+        compile_runtime, finish_runtime_hw_model, start_runtime_hw_model, CustomCaliptraFw,
+        TestParams, TEST_LOCK,
+    };
     use caliptra_api::SocManager;
+    use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
     use caliptra_mcu_debug_unlock_signer::DebugUnlockKeys;
     use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
@@ -23,12 +29,42 @@ mod test {
     use random_port::PortPicker;
     use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::process::{exit, Command, Stdio};
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
     use zerocopy::IntoBytes;
 
     const TEST_NAME: &str = "SPDM-VDM";
+    const TEST_FEATURE: &str = "test-caliptra-util-host-spdm-vdm-validator";
+
+    fn caliptra_fw_svn7() -> CustomCaliptraFw {
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            return CustomCaliptraFw {
+                fw_bytes: binaries.caliptra_fw_svn7.clone(),
+                vendor_pk_hash: binaries.vendor_pk_hash().unwrap(),
+                soc_manifest: binaries.test_soc_manifest(TEST_FEATURE).unwrap().clone(),
+            };
+        }
+
+        let runtime = compile_runtime(Some(TEST_FEATURE), false);
+        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+            svn: Some(7),
+            mcu_firmware: Some(runtime),
+            ..Default::default()
+        });
+        let fw_bytes = std::fs::read(builder.get_caliptra_fw().unwrap()).unwrap();
+        let vendor_pk_hash: [u8; 48] = hex::decode(builder.get_vendor_pk_hash().unwrap())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let soc_manifest = std::fs::read(builder.get_soc_manifest(None).unwrap()).unwrap();
+        CustomCaliptraFw {
+            fw_bytes,
+            vendor_pk_hash,
+            soc_manifest,
+        }
+    }
 
     /// Reusable test harness for running the caliptra-spdm-validator binary against
     /// the MCU HW model's SPDM responder.
@@ -43,21 +79,27 @@ mod test {
         target_addr: DynamicI3cAddress,
         test_timeout: Duration,
         validator_args: &[&str],
-    ) {
+    ) -> Arc<AtomicBool> {
+        SERVER_LISTENING.store(false, Ordering::Relaxed);
         let bridge_port = PortPicker::new().pick().unwrap();
         let addr = SocketAddr::from(([127, 0, 0, 1], i3c_port));
         let stream = TcpStream::connect(addr).unwrap();
         let transport = MctpTransport::new(BufferedStream::new(stream), target_addr.into(), 1);
 
-        // Timeout watchdog
+        // Timeout watchdog. The completion flag prevents a finished suite's
+        // watchdog from terminating a later isolated emulator instance.
+        let completed = Arc::new(AtomicBool::new(false));
+        let watchdog_completed = completed.clone();
         thread::spawn(move || {
             thread::sleep(test_timeout);
-            println!(
-                "[{}] TIMED OUT AFTER {:?} SECONDS",
-                TEST_NAME,
-                test_timeout.as_secs()
-            );
-            exit(-1);
+            if !watchdog_completed.load(Ordering::Relaxed) {
+                println!(
+                    "[{}] TIMED OUT AFTER {:?} SECONDS",
+                    TEST_NAME,
+                    test_timeout.as_secs()
+                );
+                exit(-1);
+            }
         });
 
         let validator_args: Vec<String> = validator_args.iter().map(|s| s.to_string()).collect();
@@ -108,6 +150,7 @@ mod test {
 
             execute_spdm_validator(bridge_port, &validator_args);
         });
+        completed
     }
 
     /// Spawn the caliptra-spdm-validator binary as a subprocess.
@@ -196,9 +239,7 @@ mod test {
             .to_string()
     }
 
-    #[ignore]
-    #[test]
-    fn test_caliptra_util_host_spdm_vdm_validator() {
+    fn run_isolated_fuse_suite(suite: &str) {
         use caliptra_image_fake_keys::{
             VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
             VENDOR_MLDSA_KEY_0_PUBLIC,
@@ -256,7 +297,8 @@ mod test {
 
         // --- Start hw_model with keys provisioned in fuses ---
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some("test-caliptra-util-host-spdm-vdm-validator"),
+            feature: Some(TEST_FEATURE),
+            custom_caliptra_fw: Some(caliptra_fw_svn7()),
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
             debug_intent: true,
@@ -275,10 +317,10 @@ mod test {
             .write(|w| w.prod_dbg_unlock_req(true));
 
         let config_path = test_config_path();
-        run_spdm_vdm_test(
+        let completed = run_spdm_vdm_test(
             hw.i3c_port().unwrap(),
             hw.i3c_address().unwrap().into(),
-            Duration::from_secs(120),
+            Duration::from_secs(600),
             &[
                 "--config",
                 &config_path,
@@ -290,12 +332,46 @@ mod test {
                 &keys_path,
                 "--unlock-level",
                 &unlock_level.to_string(),
+                "--fuse-suite",
+                suite,
             ],
         );
 
         let test = finish_runtime_hw_model(&mut hw);
+        completed.store(true, Ordering::Relaxed);
         assert_eq!(0, test);
 
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
+
+    macro_rules! isolated_fuse_suite_test {
+        ($name:ident, $suite:literal) => {
+            #[ignore]
+            #[test]
+            fn $name() {
+                run_isolated_fuse_suite($suite);
+            }
+        };
+    }
+
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_authorization,
+        "authorization"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_provision_vendor_pk_hash,
+        "provision-vendor-pk-hash"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_increase_min_svn,
+        "increase-min-svn"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_revoke_vendor_pub_key,
+        "revoke-vendor-pub-key"
+    );
+    isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_revoke_vendor_pk_hash,
+        "revoke-vendor-pk-hash"
+    );
 }

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -359,6 +359,10 @@ mod test {
         "authorization"
     );
     isolated_fuse_suite_test!(
+        test_caliptra_util_host_spdm_vdm_validator_fe_prog,
+        "fe-prog"
+    );
+    isolated_fuse_suite_test!(
         test_caliptra_util_host_spdm_vdm_validator_provision_vendor_pk_hash,
         "provision-vendor-pk-hash"
     );


### PR DESCRIPTION
## Summary

Stacks on #1911. Host tooling and end-to-end validation for the authorized fuse VDM commands.

- Typed host requests, explicit little-endian SPDM VDM encoders, and client APIs for vendor PK-hash provisioning, minimum-SVN increase, vendor-key revocation, and PK-hash-slot revocation.
- Preserve device completion codes through the transport, session, and command layers so validator policy tests distinguish responder rejection from transport/session/signing failures.
- Enable bounded generic large-request reassembly for the emulator SPDM app so the 4.7 KiB hybrid signatures reach `AuthorizedCommand` dispatch.
- Extend the SPDM validator with raw malformed-request coverage, exact completion-code assertions, full fuse-policy checks, and isolated emulator suites for each destructive (irreversible) operation.
- Document the exact wire payloads and isolated validation workflow.

### Memory delta (`measure-memory.sh`, devel profile, vs `main`)

| Section | `main` | This stack | Delta |
|---|---:|---:|---:|
| Kernel `.text`/`.data`/`.bss` | 150,392 / 36 / 24,536 | 150,392 / 36 / 24,536 | 0 |
| User-app FLASH | 260,384 | 267,252 | **+6,868 B** |
| User-app RAM | 78,136 | 78,776 | **+640 B** |
| SPDM task FLASH | 104,142 | 111,598 | **+7,456 B** |
| SPDM task RAM | 29,853 | 30,501 | **+648 B** |
| Runtime bundle | 412,160 | 419,072 | **+6,912 B** |
