### PR TITLE
[ci] fix smoke-test workflow: drop continue-on-error on reusable-workflow job

### DIFF
--- a/.github/workflows/caliptra-sw-smoke-test.yml
+++ b/.github/workflows/caliptra-sw-smoke-test.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   caliptra-sw-mcu-rom-smoke-test:
     name: Smoke Test (Optional)
-    continue-on-error: true
     uses: chipsalliance/caliptra-sw/.github/workflows/fpga-subsystem.yml@main
     with:
       mcu-commit: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Problem

The `Caliptra SW Smoke Test (Optional)` workflow fails to parse, so it errors on every PR against `main-2.1`:

```
Invalid workflow file: .github/workflows/caliptra-sw-smoke-test.yml#L1
(Line: 13, Col: 5): Unexpected value 'uses'
(Line: 14, Col: 5): Unexpected value 'with'
(Line: 11, Col: 5): Required property is missing: runs-on
```

## Cause

Commit 64649d15 ("[ci]: Signal that the smoke test is optional", #1784) added `continue-on-error: true` to the `caliptra-sw-mcu-rom-smoke-test` job. That job calls a reusable workflow via `uses:`, and `continue-on-error` is not an allowed key on a reusable-workflow-call job (only `name`, `uses`, `with`, `secrets`, `needs`, `if`, `strategy`, `permissions`, `concurrency` are). The parser hits the illegal key, stops treating it as a `uses:` job, and falls back to normal-job validation, hence the "unexpected `uses`/`with`" and "missing `runs-on`" errors.

## Fix

Remove the `continue-on-error: true` line. The "optional / non-blocking" intent from #1784 is expressed by not marking this check required in branch protection; there is no valid job-level equivalent for a reusable-workflow call.

Fixes #1915