### PR TITLE
Zeroize stable_owner_key_cmk and effective_key after use

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -52,6 +52,8 @@ use core::ops::Deref;
 
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
+#[cfg(feature = "stable-owner-key")]
+use zeroize::Zeroize;
 
 // TODO: Remove these local CM_AES_GCM_DECRYPT_DMA definitions once caliptra-sw
 // includes the DMA decrypt command and the caliptra-sw git pointer is updated.
@@ -1574,7 +1576,7 @@ impl BootFlow for ColdBoot {
         {
             // Derive stable owner key using the OTP personalization seed.
             crate::call_hook(params.hooks, |h| h.pre_stable_owner_key_derivation());
-            let stable_owner_key = crate::stable_owner_key::derive_stable_owner_key(env)
+            let mut stable_owner_key = crate::stable_owner_key::derive_stable_owner_key(env)
                 .unwrap_or_else(|err| {
                     caliptra_mcu_romtime::println!(
                         "[mcu-rom] Stable owner key derivation failed: {}",
@@ -1582,9 +1584,11 @@ impl BootFlow for ColdBoot {
                     );
                     fatal_error(err);
                 });
-            let stable_owner_key_cmk: [u8; STABLE_OWNER_KEY_CMK_SIZE] =
+            let mut stable_owner_key_cmk: [u8; STABLE_OWNER_KEY_CMK_SIZE] =
                 transmute!(stable_owner_key.0);
             HandoffData::write_stable_owner_key(&stable_owner_key_cmk);
+            stable_owner_key.zeroize();
+            stable_owner_key_cmk.zeroize();
             crate::call_hook(params.hooks, |h| h.post_stable_owner_key_derivation());
         }
 

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -27,6 +27,7 @@ use caliptra_mcu_error::{McuError, McuResult};
 use caliptra_mcu_romtime::otp::Otp;
 use caliptra_mcu_romtime::{HexWord, McuRomBootStatus};
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
+use zeroize::Zeroize;
 
 const DOT_LABEL: &[u8; 23] = b"Caliptra DOT stable key";
 pub const DOT_BLOB_SIZE: usize = core::mem::size_of::<DotBlob>();
@@ -176,12 +177,13 @@ pub(crate) fn install_owner_pk_hash(
 }
 
 /// Caliptra Cryptographic Mailbox Key (CMK) handle.
-#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Zeroize)]
 pub struct Cmk(pub [u32; 32]);
 
 /// DOT Effective Key derived from DOT_ROOT_KEY and DOT_FUSE_ARRAY state.
 ///
 /// This key is used to authenticate DOT blobs via HMAC.
+#[derive(Zeroize)]
 pub struct DotEffectiveKey(pub Cmk);
 
 /// The DOT blob data structure containing ownership credentials and locking keys.
@@ -287,9 +289,11 @@ pub fn dot_flow(
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DeviceOwnershipTransferStarted.into());
 
-    let dot_effective_key = derive_stable_key_flow(env, dot_fuses, stable_key_type)?;
+    let mut dot_effective_key = derive_stable_key_flow(env, dot_fuses, stable_key_type)?;
 
-    verify_dot_blob(&mut env.soc_manager, blob, &dot_effective_key)?;
+    let verify_result = verify_dot_blob(&mut env.soc_manager, blob, &dot_effective_key);
+    dot_effective_key.zeroize();
+    verify_result?;
 
     burn_dot_fuses(env, dot_fuses, blob)?;
 


### PR DESCRIPTION
Clear the stable owner key material (stable_owner_key and its CMK transmute) in cold_boot after it's written to handoff, and clear the DOT effective key in dot_flow after blob verification.