### PR TITLE
spdm: SPDM 1.1 backward compatibility (version entry + feature gating)

### DIFF
--- a/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
@@ -14,7 +14,7 @@
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::flag_macros::def_flag_set_le;
-use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
+use crate::{ReqRespCode, ResponseBody, SpdmVersion, WireError, WireWriter};
 
 def_flag_set_le! {
     /// SPDM capability bitfield (DSP0274 §10.5.1 Table 11). Constants
@@ -96,12 +96,23 @@ impl CapabilitiesBody {
 
     /// Practical upper bound on CTExponent (CT = 2^32 µs ≈ 1.2 h).
     pub const MAX_CT_EXPONENT: u8 = 32;
+
+    /// V1.0/1.1 CAPABILITIES body size (DSP0274 1.1.1 §10.3, tables 175/176):
+    /// `Param1(1) | Param2(1) | Reserved(1) | CTExponent(1) | Reserved(2) |
+    /// Flags(4)` = 10 bytes. This is the 18-byte V1.2+ body **without** the
+    /// trailing `DataTransferSize(4)` and `MaxSPDMmsgSize(4)` fields, which were
+    /// added in V1.2. The V1.1 request carries the same 10-byte layout as the
+    /// response (both directions share the shape, as in V1.2+).
+    pub const SIZE_V11: usize = 10;
 }
 
 const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBody::SIZE);
 
 /// Builder for a CAPABILITIES response.
 pub struct CapabilitiesRsp {
+    /// Negotiated SPDM version. Selects the wire shape: V1.1 emits the 10-byte
+    /// legacy body (no DataTransferSize/MaxSPDMmsgSize); V1.2+ emits 18 bytes.
+    pub version: SpdmVersion,
     pub ct_exponent: u8,
     pub flags: CapFlags,
     pub data_transfer_size: u32,
@@ -112,19 +123,95 @@ impl ResponseBody for CapabilitiesRsp {
     const RESPONSE_CODE: ReqRespCode = ReqRespCode::CAPABILITIES;
 
     fn body_size(&self) -> usize {
-        CapabilitiesBody::SIZE
+        // V1.1 omits DataTransferSize + MaxSPDMmsgSize.
+        if self.version < SpdmVersion::V12 {
+            CapabilitiesBody::SIZE_V11
+        } else {
+            CapabilitiesBody::SIZE
+        }
     }
 
     fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
-        w.write(&CapabilitiesBody {
+        // V1.0/1.1 stop after the 4-byte Flags field. The first 10 bytes
+        // of CapabilitiesBody are byte-identical to the V1.1 body, so write the
+        // shared prefix and only append DataTransferSize/MaxSPDMmsgSize for V1.2+.
+        w.write(&CapabilitiesBodyV11 {
             param1: 0,
             param2: 0,
             reserved: 0,
             ct_exponent: self.ct_exponent,
             reserved2: [0; 2],
             flags: self.flags,
-            data_transfer_size: U32::new(self.data_transfer_size),
-            max_spdm_msg_size: U32::new(self.max_spdm_msg_size),
-        })
+        })?;
+        if self.version >= SpdmVersion::V12 {
+            w.write(&U32::new(self.data_transfer_size))?;
+            w.write(&U32::new(self.max_spdm_msg_size))?;
+        }
+        Ok(())
+    }
+}
+
+/// 10-byte V1.0/1.1 CAPABILITIES body (DSP0274 1.1.1 §10.3). Byte-identical to
+/// the leading 10 bytes of [`CapabilitiesBody`]; used for both the V1.1
+/// GET_CAPABILITIES request decode and the CAPABILITIES response encode.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Default)]
+#[repr(C)]
+pub struct CapabilitiesBodyV11 {
+    pub param1: u8,
+    pub param2: u8,
+    pub reserved: u8,
+    pub ct_exponent: u8,
+    pub reserved2: [u8; 2],
+    pub flags: CapFlags,
+}
+
+impl CapabilitiesBodyV11 {
+    pub const SIZE: usize = CapabilitiesBody::SIZE_V11;
+}
+
+const _: () = assert!(core::mem::size_of::<CapabilitiesBodyV11>() == CapabilitiesBodyV11::SIZE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::ResponseBody;
+    use crate::wire::WireWriter;
+
+    fn rsp(version: SpdmVersion) -> CapabilitiesRsp {
+        CapabilitiesRsp {
+            version,
+            ct_exponent: 20,
+            flags: CapFlags::CERT | CapFlags::CHAL,
+            data_transfer_size: 4096,
+            max_spdm_msg_size: 4096,
+        }
+    }
+
+    #[test]
+    fn v11_capabilities_body_is_10_bytes_without_transfer_sizes() {
+        // V1.1 CAPABILITIES has no DataTransferSize/MaxSPDMmsgSize.
+        let body = rsp(SpdmVersion::V11);
+        assert_eq!(body.body_size(), CapabilitiesBody::SIZE_V11);
+        assert_eq!(body.body_size(), 10);
+
+        let mut buf = [0u8; 32];
+        let mut w = WireWriter::new(&mut buf);
+        body.encode_body(&mut w).unwrap();
+        // Flags occupy bytes 6..10; nothing follows them for V1.1.
+        assert_eq!(&buf[6..10], &0x0000_0006u32.to_le_bytes()); // CERT|CHAL = bits 1,2
+    }
+
+    #[test]
+    fn v12_capabilities_body_is_18_bytes_with_transfer_sizes() {
+        let body = rsp(SpdmVersion::V12);
+        assert_eq!(body.body_size(), CapabilitiesBody::SIZE);
+        assert_eq!(body.body_size(), 18);
+
+        let mut buf = [0u8; 32];
+        let mut w = WireWriter::new(&mut buf);
+        body.encode_body(&mut w).unwrap();
+        // DataTransferSize at bytes 10..14, MaxSPDMmsgSize at 14..18.
+        assert_eq!(&buf[10..14], &4096u32.to_le_bytes());
+        assert_eq!(&buf[14..18], &4096u32.to_le_bytes());
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
@@ -17,7 +17,7 @@ use zerocopy::{
 };
 
 use crate::flag_macros::def_flag_set_le;
-use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
+use crate::{ReqRespCode, ResponseBody, SpdmVersion, WireError, WireWriter};
 
 def_flag_set_le! {
     /// SPDM capability bitfield. Constants
@@ -119,12 +119,23 @@ impl CapabilitiesBody {
 
     /// Practical upper bound on CTExponent (CT = 2^32 µs ≈ 1.2 h).
     pub const MAX_CT_EXPONENT: u8 = 32;
+
+    /// V1.0/1.1 CAPABILITIES body size (DSP0274 1.1.1 §10.3, tables 175/176):
+    /// `Param1(1) | Param2(1) | Reserved(1) | CTExponent(1) | Reserved(2) |
+    /// Flags(4)` = 10 bytes. This is the 18-byte V1.2+ body **without** the
+    /// trailing `DataTransferSize(4)` and `MaxSPDMmsgSize(4)` fields, which were
+    /// added in V1.2. The V1.1 request carries the same 10-byte layout as the
+    /// response (both directions share the shape, as in V1.2+).
+    pub const SIZE_V11: usize = 10;
 }
 
 const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBody::SIZE);
 
 /// Builder for a CAPABILITIES response.
 pub struct CapabilitiesRsp {
+    /// Negotiated SPDM version. Selects the wire shape: V1.1 emits the 10-byte
+    /// legacy body (no DataTransferSize/MaxSPDMmsgSize); V1.2+ emits 18 bytes.
+    pub version: SpdmVersion,
     pub ct_exponent: u8,
     pub ext_flags: ExtCapFlags,
     pub flags: CapFlags,
@@ -136,19 +147,105 @@ impl ResponseBody for CapabilitiesRsp {
     const RESPONSE_CODE: ReqRespCode = ReqRespCode::CAPABILITIES;
 
     fn body_size(&self) -> usize {
-        CapabilitiesBody::SIZE
+        // V1.1 omits DataTransferSize + MaxSPDMmsgSize.
+        if self.version < SpdmVersion::V12 {
+            CapabilitiesBody::SIZE_V11
+        } else {
+            CapabilitiesBody::SIZE
+        }
     }
 
     fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
-        w.write(&CapabilitiesBody {
-            param1: 0,
-            param2: 0,
-            reserved: 0,
-            ct_exponent: self.ct_exponent,
-            ext_flags: self.ext_flags,
-            flags: self.flags,
-            data_transfer_size: U32::new(self.data_transfer_size),
-            max_spdm_msg_size: U32::new(self.max_spdm_msg_size),
-        })
+        // V1.0/1.1 use the 10-byte body that stops after Flags: it has no
+        // ExtCapFlags (those two bytes are Reserved) and no
+        // DataTransferSize/MaxSPDMmsgSize. V1.2+ uses the full 18-byte body,
+        // which carries ExtCapFlags (V1.4) at bytes 4..6 and the transfer sizes.
+        if self.version < SpdmVersion::V12 {
+            w.write(&CapabilitiesBodyV11 {
+                param1: 0,
+                param2: 0,
+                reserved: 0,
+                ct_exponent: self.ct_exponent,
+                reserved2: [0; 2],
+                flags: self.flags,
+            })
+        } else {
+            w.write(&CapabilitiesBody {
+                param1: 0,
+                param2: 0,
+                reserved: 0,
+                ct_exponent: self.ct_exponent,
+                ext_flags: self.ext_flags,
+                flags: self.flags,
+                data_transfer_size: U32::new(self.data_transfer_size),
+                max_spdm_msg_size: U32::new(self.max_spdm_msg_size),
+            })
+        }
+    }
+}
+
+/// 10-byte V1.0/1.1 CAPABILITIES body (DSP0274 1.1.1 §10.3). Byte-identical to
+/// the leading 10 bytes of [`CapabilitiesBody`]; used for both the V1.1
+/// GET_CAPABILITIES request decode and the CAPABILITIES response encode.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Default)]
+#[repr(C)]
+pub struct CapabilitiesBodyV11 {
+    pub param1: u8,
+    pub param2: u8,
+    pub reserved: u8,
+    pub ct_exponent: u8,
+    pub reserved2: [u8; 2],
+    pub flags: CapFlags,
+}
+
+impl CapabilitiesBodyV11 {
+    pub const SIZE: usize = CapabilitiesBody::SIZE_V11;
+}
+
+const _: () = assert!(core::mem::size_of::<CapabilitiesBodyV11>() == CapabilitiesBodyV11::SIZE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::ResponseBody;
+    use crate::wire::WireWriter;
+
+    fn rsp(version: SpdmVersion) -> CapabilitiesRsp {
+        CapabilitiesRsp {
+            version,
+            ct_exponent: 20,
+            ext_flags: ExtCapFlags::EMPTY,
+            flags: CapFlags::CERT | CapFlags::CHAL,
+            data_transfer_size: 4096,
+            max_spdm_msg_size: 4096,
+        }
+    }
+
+    #[test]
+    fn v11_capabilities_body_is_10_bytes_without_transfer_sizes() {
+        // V1.1 CAPABILITIES has no DataTransferSize/MaxSPDMmsgSize.
+        let body = rsp(SpdmVersion::V11);
+        assert_eq!(body.body_size(), CapabilitiesBody::SIZE_V11);
+        assert_eq!(body.body_size(), 10);
+
+        let mut buf = [0u8; 32];
+        let mut w = WireWriter::new(&mut buf);
+        body.encode_body(&mut w).unwrap();
+        // Flags occupy bytes 6..10; nothing follows them for V1.1.
+        assert_eq!(&buf[6..10], &0x0000_0006u32.to_le_bytes()); // CERT|CHAL = bits 1,2
+    }
+
+    #[test]
+    fn v12_capabilities_body_is_18_bytes_with_transfer_sizes() {
+        let body = rsp(SpdmVersion::V12);
+        assert_eq!(body.body_size(), CapabilitiesBody::SIZE);
+        assert_eq!(body.body_size(), 18);
+
+        let mut buf = [0u8; 32];
+        let mut w = WireWriter::new(&mut buf);
+        body.encode_body(&mut w).unwrap();
+        // DataTransferSize at bytes 10..14, MaxSPDMmsgSize at 14..18.
+        assert_eq!(&buf[10..14], &4096u32.to_le_bytes());
+        assert_eq!(&buf[14..18], &4096u32.to_le_bytes());
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -32,7 +32,7 @@ pub use algorithms::{
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
-pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp};
+pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesBodyV11, CapabilitiesRsp};
 pub use certificate::{
     CertificateRsp, CertificateRspBody, GetCertificateReqBody, ATTR_SLOT_SIZE_REQUESTED,
 };

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -32,7 +32,9 @@ pub use algorithms::{
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
-pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags};
+pub use capabilities::{
+    CapFlags, CapabilitiesBody, CapabilitiesBodyV11, CapabilitiesRsp, ExtCapFlags,
+};
 pub use certificate::{
     CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
     GetCertificateLargeReqBody, GetCertificateParam1, GetCertificateReq, GetCertificateReqBody,

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -244,7 +244,12 @@ fn build_response_body<S, L>(
     peer: &PeerAlgs,
     secure_message_supported: bool,
 ) -> AlgorithmsRsp {
-    let mut other_param_support = state.other_param_support & fixed.other_param_support;
+    // OtherParamSupport is SPDM 1.2+ only; suppress for SPDM 1.1.
+    let mut other_param_support = if state.version < SpdmVersion::V12 {
+        OtherParamSupport::EMPTY
+    } else {
+        state.other_param_support & fixed.other_param_support
+    };
     let (dhe, aead, key_schedule) = if secure_message_supported {
         (
             state.dhe & peer.dhe,

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -250,7 +250,12 @@ fn build_response_body<S, L>(
     peer: &PeerAlgs,
     secure_message_supported: bool,
 ) -> AlgorithmsRsp {
-    let mut other_param_support = state.other_param_support & fixed.other_param_support;
+    // OtherParamSupport is SPDM 1.2+ only; suppress for SPDM 1.1.
+    let mut other_param_support = if state.version < SpdmVersion::V12 {
+        OtherParamSupport::EMPTY
+    } else {
+        state.other_param_support & fixed.other_param_support
+    };
     let (dhe, aead, key_schedule) = if secure_message_supported {
         (
             state.dhe & peer.dhe,

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -15,7 +15,8 @@
 //!    local policy, then transitions to [`Phase::AfterCapabilities`].
 
 use caliptra_mcu_spdm_codec::{
-    CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    CapFlags, CapabilitiesBody, CapabilitiesBodyV11, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -66,22 +67,50 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
     let version = select_version(state, hdr.version)?;
 
-    let body = CapabilitiesBody::ref_from_bytes(
-        rest.get(..CapabilitiesBody::SIZE)
-            .ok_or(SPDM_INVALID_REQUEST)?,
-    )
-    .map_err(|_| SPDM_INVALID_REQUEST)?;
-
-    let (peer_dts, peer_max) = validate_capabilities_body(body)?;
+    // parse the version-specific GET_CAPABILITIES request body. V1.0/1.1
+    // (DSP0274 1.1.1 §10.3) uses a 10-byte body that ends at Flags — it has no
+    // DataTransferSize/MaxSPDMmsgSize. V1.2+ adds those two u32 fields (18-byte
+    // body). A V1.1 peer cannot chunk or reassemble, so its effective transfer
+    // size is the responder MTU in both directions.
+    let (peer_flags, peer_dts, peer_max) = if version < SpdmVersion::V12 {
+        let body = CapabilitiesBodyV11::ref_from_bytes(
+            rest.get(..CapabilitiesBodyV11::SIZE)
+                .ok_or(SPDM_INVALID_REQUEST)?,
+        )
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+        validate_capabilities_body_v11(body)?;
+        let mtu = pal.mtu() as u32;
+        (body.flags, mtu, mtu)
+    } else {
+        let body = CapabilitiesBody::ref_from_bytes(
+            rest.get(..CapabilitiesBody::SIZE)
+                .ok_or(SPDM_INVALID_REQUEST)?,
+        )
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let (dts, max) = validate_capabilities_body(body)?;
+        (body.flags, dts, max)
+    };
     state.peer_data_transfer_size = peer_dts;
     state.peer_max_spdm_msg_size = peer_max;
-    state.peer_cap_flags = body.flags;
+    state.peer_cap_flags = peer_flags;
 
     let mtu = pal.mtu();
     let mut flags = state.cap_flags;
     if version < SpdmVersion::V13 {
-        let cleared = flags.into_bits() & !(0b11 << 26);
-        flags = CapFlags::from_bits(cleared);
+        // Clear V1.3-only caps for a pre-1.3 peer: MULTI_KEY_CAP (bits 26..=27)
+        // and GET_KEY_PAIR_INFO (bit 28).
+        let v13_caps = (0b11 << 26) | CapFlags::GET_KEY_PAIR_INFO.into_bits();
+        flags = CapFlags::from_bits(flags.into_bits() & !v13_caps);
+    }
+    // Gate off caps a V1.1 peer must not see. CHUNK, SET_CERT and ALIAS_CERT
+    // are V1.2-introduced and did not exist in the V1.1 flag set. ENCAP *is* a
+    // valid V1.1 capability (DSP0274 1.1.1 Table 16), but we clear it
+    // intentionally: our encapsulated-request handling depends on V1.2+ framing
+    // (V1.1 ENCAP support is tracked separately).
+    if version < SpdmVersion::V12 {
+        let v12plus_caps =
+            CapFlags::CHUNK | CapFlags::ENCAP | CapFlags::SET_CERT | CapFlags::ALIAS_CERT;
+        flags = CapFlags::from_bits(flags.into_bits() & !v12plus_caps.into_bits());
     }
     if !pal.secure_message_supported() {
         let secure_session_caps = CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC;
@@ -94,6 +123,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
         mtu
     } as u32;
     let body = CapabilitiesRsp {
+        version,
         ct_exponent: state.ct_exponent,
         flags,
         data_transfer_size: mtu as u32,
@@ -157,6 +187,22 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
     Ok((peer_dts, peer_max))
 }
 
+/// Validates a V1.0/1.1 `CapabilitiesBodyV11` (DSP0274 1.1.1 §10.3).
+///
+/// The V1.1 body has no `DataTransferSize`/`MaxSPDMmsgSize`, so only the
+/// reserved fields and `CTExponent` are range-checked. `Param1`/`Param2` are
+/// Reserved in V1.1 (the V1.3 "Supported Algorithms request" bit does not
+/// exist here), so they must be zero.
+fn validate_capabilities_body_v11(body: &CapabilitiesBodyV11) -> SpdmResult<()> {
+    if body.param1 != 0 || body.param2 != 0 || body.reserved != 0 || body.reserved2 != [0; 2] {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if body.ct_exponent > CapabilitiesBody::MAX_CT_EXPONENT {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
+}
+
 /// Picks the negotiated SPDM version and records it on `state`.
 ///
 /// # Parameters
@@ -183,3 +229,7 @@ fn select_version<S, L>(
     state.version = v;
     Ok(v)
 }
+
+#[cfg(test)]
+#[path = "tests/capabilities.rs"]
+mod tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -15,7 +15,8 @@
 //!    local policy, then transitions to [`Phase::AfterCapabilities`].
 
 use caliptra_mcu_spdm_codec::{
-    CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags, ResponseBody, SpdmMsgHdrPdu,
+    CapFlags, CapabilitiesBody, CapabilitiesBodyV11, CapabilitiesRsp, ExtCapFlags, ResponseBody,
+    SpdmMsgHdrPdu,
     SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
@@ -66,20 +67,48 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
     let version = select_version(hdr.version)?;
 
-    let body = CapabilitiesBody::ref_from_bytes(
-        rest.get(..CapabilitiesBody::SIZE)
-            .ok_or(SPDM_INVALID_REQUEST)?,
-    )
-    .map_err(|_| SPDM_INVALID_REQUEST)?;
-
-    let (peer_dts, peer_max) = validate_capabilities_body(body)?;
+    // parse the version-specific GET_CAPABILITIES request body. V1.0/1.1
+    // (DSP0274 1.1.1 §10.3) uses a 10-byte body that ends at Flags — it has no
+    // DataTransferSize/MaxSPDMmsgSize. V1.2+ adds those two u32 fields (18-byte
+    // body). A V1.1 peer cannot chunk or reassemble, so its effective transfer
+    // size is the responder MTU in both directions.
+    let (peer_flags, peer_dts, peer_max) = if version < SpdmVersion::V12 {
+        let body = CapabilitiesBodyV11::ref_from_bytes(
+            rest.get(..CapabilitiesBodyV11::SIZE)
+                .ok_or(SPDM_INVALID_REQUEST)?,
+        )
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+        validate_capabilities_body_v11(body)?;
+        let mtu = pal.mtu() as u32;
+        (body.flags, mtu, mtu)
+    } else {
+        let body = CapabilitiesBody::ref_from_bytes(
+            rest.get(..CapabilitiesBody::SIZE)
+                .ok_or(SPDM_INVALID_REQUEST)?,
+        )
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let (dts, max) = validate_capabilities_body(body)?;
+        (body.flags, dts, max)
+    };
     state.version = version;
     state.peer_data_transfer_size = peer_dts;
     state.peer_max_spdm_msg_size = peer_max;
-    state.peer_cap_flags = body.flags;
+    state.peer_cap_flags = peer_flags;
 
     let mtu = pal.mtu();
+    // Version-gate the responder cap flags (V1.3/V1.4-only bits are masked off
+    // for a pre-1.3 peer by `responder_cap_mask`).
     let mut flags = CapFlags::from_bits(state.cap_flags.into_bits() & responder_cap_mask(version));
+    // Gate off caps a V1.1 peer must not see. CHUNK, SET_CERT and ALIAS_CERT
+    // are V1.2-introduced and did not exist in the V1.1 flag set. ENCAP *is* a
+    // valid V1.1 capability (DSP0274 1.1.1 Table 16), but we clear it
+    // intentionally: our encapsulated-request handling depends on V1.2+ framing
+    // (V1.1 ENCAP support is tracked separately).
+    if version < SpdmVersion::V12 {
+        let v12plus_caps =
+            CapFlags::CHUNK | CapFlags::ENCAP | CapFlags::SET_CERT | CapFlags::ALIAS_CERT;
+        flags = CapFlags::from_bits(flags.into_bits() & !v12plus_caps.into_bits());
+    }
     if !pal.secure_message_supported() {
         let secure_session_caps = CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC;
         flags = CapFlags::from_bits(flags.into_bits() & !secure_session_caps.into_bits());
@@ -92,6 +121,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
         mtu
     } as u32;
     let body = CapabilitiesRsp {
+        version,
         ct_exponent: state.ct_exponent,
         // SLOT_MANAGEMENT is not implemented by this responder.
         ext_flags: ExtCapFlags::EMPTY,
@@ -167,6 +197,22 @@ fn responder_cap_mask(version: SpdmVersion) -> u32 {
         SpdmVersion::V13 => RESPONDER_CAP_FLAGS_V13_MASK,
         SpdmVersion::V14 => RESPONDER_CAP_FLAGS_V14_MASK,
     }
+}
+
+/// Validates a V1.0/1.1 `CapabilitiesBodyV11` (DSP0274 1.1.1 §10.3).
+///
+/// The V1.1 body has no `DataTransferSize`/`MaxSPDMmsgSize`, so only the
+/// reserved fields and `CTExponent` are range-checked. `Param1`/`Param2` are
+/// Reserved in V1.1 (the V1.3 "Supported Algorithms request" bit does not
+/// exist here), so they must be zero.
+fn validate_capabilities_body_v11(body: &CapabilitiesBodyV11) -> SpdmResult<()> {
+    if body.param1 != 0 || body.param2 != 0 || body.reserved != 0 || body.reserved2 != [0; 2] {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if body.ct_exponent > CapabilitiesBody::MAX_CT_EXPONENT {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
 }
 
 /// Picks the requested SPDM version without mutating connection state.

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -141,10 +141,14 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
     let mut m1_hash = [0u8; SHA384_HASH_SIZE];
     state.transcript.finalize_m1(pal, io, &mut m1_hash).await?;
 
-    // Compute TBS hash in-place over the M1 hash.
-    compute_tbs_hash(pal, io, signing_context(state.version), &mut m1_hash)
-        .await
-        .map_err(|_| SPDM_UNSPECIFIED)?;
+    // The signing-context prefix was introduced in V1.2; a V1.0/1.1 Responder
+    // signs the raw M1 hash with no prefix (DSP0274 1.1.1 section 10.9.2).
+    if state.version >= SpdmVersion::V12 {
+        // Compute TBS hash in-place over the M1 hash.
+        compute_tbs_hash(pal, io, signing_context(state.version), &mut m1_hash)
+            .await
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+    }
 
     // Sign the TBS hash directly into the response's signature slot.
     let sig_slot = resp

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -146,10 +146,14 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
     let mut m1_hash = [0u8; SHA384_HASH_SIZE];
     state.transcript.finalize_m1(pal, io, &mut m1_hash).await?;
 
-    // Compute TBS hash in-place over the M1 hash.
-    compute_tbs_hash(pal, io, signing_context(state.version), &mut m1_hash)
-        .await
-        .map_err(|_| SPDM_UNSPECIFIED)?;
+    // The signing-context prefix was introduced in V1.2; a V1.0/1.1 Responder
+    // signs the raw M1 hash with no prefix (DSP0274 1.1.1 section 10.9.2).
+    if state.version >= SpdmVersion::V12 {
+        // Compute TBS hash in-place over the M1 hash.
+        compute_tbs_hash(pal, io, signing_context(state.version), &mut m1_hash)
+            .await
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+    }
 
     // Sign the TBS hash directly into the response's signature slot.
     let sig_slot = resp

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -295,12 +295,19 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     let th1 = &mut *hash_scratch;
     session.transcript.clone_and_finalize(pal, io, th1).await?;
 
-    // ── Sign TH1 ────────────────────────────────────────────────────
-    build_signing_context(state.version, signing_ctx);
-    compute_tbs_hash(pal, io, signing_ctx, th1)
-        .await
-        .map_err(|_| SPDM_UNSPECIFIED)?;
-    let tbs_hash = &signing_ctx[..SHA384_HASH_SIZE];
+    // Sign TH1. The signing-context prefix is V1.2+; a V1.0/1.1 Responder signs
+    // the raw TH1 hash with no prefix (DSP0274 1.1.1).
+    let tbs_hash: &[u8; SHA384_HASH_SIZE] = if state.version < SpdmVersion::V12 {
+        &*th1
+    } else {
+        build_signing_context(state.version, signing_ctx);
+        compute_tbs_hash(pal, io, signing_ctx, th1)
+            .await
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+        signing_ctx[..SHA384_HASH_SIZE]
+            .try_into()
+            .map_err(|_| SPDM_UNSPECIFIED)?
+    };
 
     let sig_len = pal
         .sign_hash(io, slot_id, asym_algo, tbs_hash, signature)

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -297,14 +297,19 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     let th1 = &mut *hash_scratch;
     session.transcript.clone_and_finalize(pal, io, th1).await?;
 
-    // ── Sign TH1 ────────────────────────────────────────────────────
-    build_signing_context(state.version, signing_ctx);
-    compute_tbs_hash(pal, io, signing_ctx, th1)
-        .await
-        .map_err(|_| SPDM_UNSPECIFIED)?;
-    let tbs_hash = signing_ctx[..]
-        .first_chunk::<SHA384_HASH_SIZE>()
-        .ok_or(SPDM_UNSPECIFIED)?;
+    // Sign TH1. The signing-context prefix is V1.2+; a V1.0/1.1 Responder signs
+    // the raw TH1 hash with no prefix (DSP0274 1.1.1).
+    let tbs_hash: &[u8; SHA384_HASH_SIZE] = if state.version < SpdmVersion::V12 {
+        &*th1
+    } else {
+        build_signing_context(state.version, signing_ctx);
+        compute_tbs_hash(pal, io, signing_ctx, th1)
+            .await
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+        signing_ctx[..SHA384_HASH_SIZE]
+            .try_into()
+            .map_err(|_| SPDM_UNSPECIFIED)?
+    };
 
     let sig_len = pal
         .sign(

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -118,10 +118,12 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
     let (measurement_record_len, number_of_blocks) = measurement_record_shape(meas_info, meas_op)?;
 
     // If signature requested, append GET_MEASUREMENTS request to L1 transcript.
+    // VCA is prepended to L1/L2 only from V1.2 (DSP0274 1.1.1 §10.11).
     if signature_requested {
+        let include_vca = state.version >= SpdmVersion::V12;
         state
             .transcript
-            .append_l1(pal, io, &req[..spdm_req_len])
+            .append_l1(pal, io, include_vca, &req[..spdm_req_len])
             .await?;
     }
 
@@ -235,7 +237,11 @@ async fn handle_measurements_response<'a, Pal: SpdmPal>(
 
     if plan.signature_requested {
         let transcript_rsp = buf.get(head..signature_offset).ok_or(SPDM_UNSPECIFIED)?;
-        state.transcript.append_l1(pal, io, transcript_rsp).await?;
+        let include_vca = state.version >= SpdmVersion::V12;
+        state
+            .transcript
+            .append_l1(pal, io, include_vca, transcript_rsp)
+            .await?;
 
         let mut hash = [0u8; SHA384_HASH_SIZE];
         state.transcript.finalize_l1(pal, io, &mut hash).await?;

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -240,10 +240,14 @@ async fn handle_measurements_response<'a, Pal: SpdmPal>(
         let mut hash = [0u8; SHA384_HASH_SIZE];
         state.transcript.finalize_l1(pal, io, &mut hash).await?;
 
-        let signing_ctx = signing_context(state.version);
-        compute_tbs_hash(pal, io, signing_ctx, &mut hash)
-            .await
-            .map_err(|_| SPDM_UNSPECIFIED)?;
+        // The signing-context prefix is V1.2+; a V1.0/1.1 Responder signs the
+        // raw L1 hash with no prefix (DSP0274 1.1.1 section 10.11).
+        if state.version >= SpdmVersion::V12 {
+            let signing_ctx = signing_context(state.version);
+            compute_tbs_hash(pal, io, signing_ctx, &mut hash)
+                .await
+                .map_err(|_| SPDM_UNSPECIFIED)?;
+        }
 
         let asym_algo = state.asym_algo();
         let signature = buf

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -1,0 +1,104 @@
+// Licensed under the Apache-2.0 license
+
+//! Unit tests for the GET_CAPABILITIES handler's version-based capability
+//! gating.
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion};
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+
+#[path = "support.rs"]
+mod support;
+use support::*;
+
+/// A state ready to receive GET_CAPABILITIES (phase `AfterVersion`) whose
+/// `cap_flags` advertise the full V1.2+/V1.3 capability set, including the
+/// set-certificate group (SET_CERT/MULTI_KEY_CONN_RSP/GET_KEY_PAIR_INFO)
+/// when that feature is built.
+fn after_version_state(version: SpdmVersion) -> ConnectionState<TestHashState, Vec<u8>> {
+    let mut state = negotiated_state(version);
+    state.phase = Phase::AfterVersion;
+    // Advertise everything the responder can; the handler must mask down per
+    // negotiated version. Mirror the flags SpdmContext::caliptra() would build.
+    state.cap_flags = CapFlags::CERT
+        | CapFlags::CHAL
+        | CapFlags::MEAS_SIG
+        | CapFlags::ALIAS_CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::HBEAT
+        | CapFlags::ENCAP
+        | CapFlags::SET_CERT
+        | CapFlags::MULTI_KEY_CONN_RSP
+        | CapFlags::GET_KEY_PAIR_INFO;
+    state
+}
+
+/// 10-byte V1.0/1.1 GET_CAPABILITIES request: header + the V1.1 body
+/// (Param1|Param2|Reserved|CTExponent|Reserved2(2)|Flags(4)).
+fn get_capabilities_io_v11(peer_flags: CapFlags) -> TestIo {
+    let mut request = vec![
+        SpdmVersion::V11.to_u8(),
+        SpdmMsgHdrPdu::new(SpdmVersion::V11, ReqRespCode::GET_CAPABILITIES)
+            .code
+            .0,
+    ];
+    request.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // Param1/2, Reserved, CTExp, Reserved2
+    request.extend_from_slice(&peer_flags.into_bits().to_le_bytes());
+    TestIo::message(request)
+}
+
+// A V1.1 CAPABILITIES response must not advertise any V1.2+
+// (CHUNK/ENCAP/SET_CERT/ALIAS_CERT) or V1.3 (MULTI_KEY_CONN_RSP,
+// GET_KEY_PAIR_INFO) capability.
+#[test]
+fn v11_capabilities_masks_off_all_v12plus_and_v13_caps() {
+    let pal = TestPal::default();
+    let mut state = after_version_state(SpdmVersion::V11);
+    let io = get_capabilities_io_v11(CapFlags::EMPTY);
+
+    block_on(handle_get_capabilities(&mut state, &pal, &io)).unwrap();
+
+    let v12plus = CapFlags::CHUNK | CapFlags::ENCAP | CapFlags::SET_CERT | CapFlags::ALIAS_CERT;
+    let v13 = CapFlags::from_bits((0b11 << 26) | CapFlags::GET_KEY_PAIR_INFO.into_bits());
+    let leaked = state.advertised_cap_flags.into_bits() & (v12plus.into_bits() | v13.into_bits());
+    assert_eq!(
+        leaked, 0,
+        "V1.1 response leaked 1.2+/1.3 caps: {:#x}",
+        leaked
+    );
+
+    // Base V1.1 caps still advertised.
+    assert!(state.advertised_cap_flags.contains(CapFlags::CERT));
+    assert!(state.advertised_cap_flags.contains(CapFlags::CHAL));
+}
+
+// A V1.2 peer must still be denied the V1.3-only capabilities
+// (MULTI_KEY_CONN_RSP, GET_KEY_PAIR_INFO) but keep the V1.2 ones.
+#[test]
+fn v12_capabilities_masks_off_v13_caps_only() {
+    let pal = TestPal::default();
+    let mut state = after_version_state(SpdmVersion::V12);
+    // 18-byte V1.2 request body: header + full CapabilitiesBody.
+    let mut request = vec![SpdmVersion::V12.to_u8(), ReqRespCode::GET_CAPABILITIES.0];
+    request.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // Param1/2, Reserved, CTExp, Reserved2
+    request.extend_from_slice(&CapFlags::EMPTY.into_bits().to_le_bytes());
+    request.extend_from_slice(&4096u32.to_le_bytes()); // DataTransferSize
+    request.extend_from_slice(&4096u32.to_le_bytes()); // MaxSPDMmsgSize
+    let io = TestIo::message(request);
+
+    block_on(handle_get_capabilities(&mut state, &pal, &io)).unwrap();
+
+    let v13 = CapFlags::from_bits((0b11 << 26) | CapFlags::GET_KEY_PAIR_INFO.into_bits());
+    let leaked = state.advertised_cap_flags.into_bits() & v13.into_bits();
+    assert_eq!(leaked, 0, "V1.2 response leaked V1.3 caps: {:#x}", leaked);
+    // V1.2 caps are retained at V1.2.
+    assert!(state.advertised_cap_flags.contains(CapFlags::SET_CERT));
+    assert!(state.advertised_cap_flags.contains(CapFlags::CHUNK));
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -5,7 +5,7 @@
 extern crate std;
 
 use super::*;
-use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmVersion};
+use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion};
 use caliptra_mcu_spdm_traits::NoVdmBackend;
 use futures::executor::block_on;
 use std::vec;
@@ -13,7 +13,9 @@ use std::vec::Vec;
 
 #[path = "support.rs"]
 mod support;
-use support::{TestHashState, TestIo, TestPal};
+use support::*;
+
+use crate::capabilities::handle_get_capabilities;
 
 fn capabilities_request(
     version: SpdmVersion,
@@ -203,4 +205,92 @@ fn v13_capabilities_masks_v14_responder_flags() {
 
     assert!(!advertised.contains(CapFlags::SET_KEY_PAIR_RESET));
     assert!(!advertised.contains(CapFlags::LARGE_RESP));
+}
+
+/// A state ready to receive GET_CAPABILITIES (phase `AfterVersion`) whose
+/// `cap_flags` advertise the full V1.2+/V1.3 capability set, including the
+/// set-certificate group (SET_CERT/MULTI_KEY_CONN_RSP/GET_KEY_PAIR_INFO)
+/// when that feature is built.
+fn after_version_state(version: SpdmVersion) -> ConnectionState<TestHashState, Vec<u8>> {
+    let mut state = negotiated_state(version);
+    state.phase = Phase::AfterVersion;
+    // Advertise everything the responder can; the handler must mask down per
+    // negotiated version. Mirror the flags SpdmContext::caliptra() would build.
+    state.cap_flags = CapFlags::CERT
+        | CapFlags::CHAL
+        | CapFlags::MEAS_SIG
+        | CapFlags::ALIAS_CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::HBEAT
+        | CapFlags::ENCAP
+        | CapFlags::SET_CERT
+        | CapFlags::MULTI_KEY_CONN_RSP
+        | CapFlags::GET_KEY_PAIR_INFO;
+    state
+}
+
+/// 10-byte V1.0/1.1 GET_CAPABILITIES request: header + the V1.1 body
+/// (Param1|Param2|Reserved|CTExponent|Reserved2(2)|Flags(4)).
+fn get_capabilities_io_v11(peer_flags: CapFlags) -> TestIo {
+    let mut request = vec![
+        SpdmVersion::V11.to_u8(),
+        SpdmMsgHdrPdu::new(SpdmVersion::V11, ReqRespCode::GET_CAPABILITIES)
+            .code
+            .0,
+    ];
+    request.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // Param1/2, Reserved, CTExp, Reserved2
+    request.extend_from_slice(&peer_flags.into_bits().to_le_bytes());
+    TestIo::message(request)
+}
+
+// A V1.1 CAPABILITIES response must not advertise any V1.2+
+// (CHUNK/ENCAP/SET_CERT/ALIAS_CERT) or V1.3 (MULTI_KEY_CONN_RSP,
+// GET_KEY_PAIR_INFO) capability.
+#[test]
+fn v11_capabilities_masks_off_all_v12plus_and_v13_caps() {
+    let pal = TestPal::default();
+    let mut state = after_version_state(SpdmVersion::V11);
+    let io = get_capabilities_io_v11(CapFlags::EMPTY);
+
+    block_on(handle_get_capabilities(&mut state, &pal, &io)).unwrap();
+
+    let v12plus = CapFlags::CHUNK | CapFlags::ENCAP | CapFlags::SET_CERT | CapFlags::ALIAS_CERT;
+    let v13 = CapFlags::from_bits((0b11 << 26) | CapFlags::GET_KEY_PAIR_INFO.into_bits());
+    let leaked = state.advertised_cap_flags.into_bits() & (v12plus.into_bits() | v13.into_bits());
+    assert_eq!(
+        leaked, 0,
+        "V1.1 response leaked 1.2+/1.3 caps: {:#x}",
+        leaked
+    );
+
+    // Base V1.1 caps still advertised.
+    assert!(state.advertised_cap_flags.contains(CapFlags::CERT));
+    assert!(state.advertised_cap_flags.contains(CapFlags::CHAL));
+}
+
+// A V1.2 peer must still be denied the V1.3-only capabilities
+// (MULTI_KEY_CONN_RSP, GET_KEY_PAIR_INFO) but keep the V1.2 ones.
+#[test]
+fn v12_capabilities_masks_off_v13_caps_only() {
+    let pal = TestPal::default();
+    let mut state = after_version_state(SpdmVersion::V12);
+    // 18-byte V1.2 request body: header + full CapabilitiesBody.
+    let mut request = vec![SpdmVersion::V12.to_u8(), ReqRespCode::GET_CAPABILITIES.0];
+    request.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // Param1/2, Reserved, CTExp, Reserved2
+    request.extend_from_slice(&CapFlags::EMPTY.into_bits().to_le_bytes());
+    request.extend_from_slice(&4096u32.to_le_bytes()); // DataTransferSize
+    request.extend_from_slice(&4096u32.to_le_bytes()); // MaxSPDMmsgSize
+    let io = TestIo::message(request);
+
+    block_on(handle_get_capabilities(&mut state, &pal, &io)).unwrap();
+
+    let v13 = CapFlags::from_bits((0b11 << 26) | CapFlags::GET_KEY_PAIR_INFO.into_bits());
+    let leaked = state.advertised_cap_flags.into_bits() & v13.into_bits();
+    assert_eq!(leaked, 0, "V1.2 response leaked V1.3 caps: {:#x}", leaked);
+    // V1.2 caps are retained at V1.2.
+    assert!(state.advertised_cap_flags.contains(CapFlags::SET_CERT));
+    assert!(state.advertised_cap_flags.contains(CapFlags::CHUNK));
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
@@ -64,13 +64,15 @@ fn get_version_advertises_v14_and_resets_valid_connection() {
             0,
             0,
             0,
-            3,
+            4,
             0,
             SpdmVersion::V14.to_u8(),
             0,
             SpdmVersion::V13.to_u8(),
             0,
             SpdmVersion::V12.to_u8(),
+            0,
+            SpdmVersion::V11.to_u8(),
         ]
     );
     assert_eq!(state.phase, Phase::AfterVersion);

--- a/runtime/userspace/api/spdm-lib/stack/src/transcript.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/transcript.rs
@@ -96,15 +96,26 @@ impl<S> Transcript<S> {
         self.append(Slot::M1, hash, io, bytes).await
     }
 
+    /// Appends `bytes` to the running L1/L2 measurement transcript.
+    ///
+    /// `include_vca` selects the version-specific L1/L2 layout. From SPDM 1.2
+    /// the transcript is `VCA || message_m`, so the L1 hash is forked from the
+    /// running VCA state. At SPDM 1.0/1.1 the transcript is `message_m` alone
+    /// (DSP0274 1.1.1 §10.11) — VCA is *not* prepended — so on first append the
+    /// L1 hash is seeded empty instead of forking VCA.
     pub async fn append_l1<H>(
         &mut self,
         hash: &H,
         io: &impl SpdmPalIo,
+        include_vca: bool,
         bytes: &[u8],
     ) -> McuResult<()>
     where
         H: SpdmPalHash<State = S>,
     {
+        if self.l1.is_none() && !include_vca {
+            self.l1 = Some(hash.hash_init(io, SpdmPalHashAlgo::Sha384, &[]).await?);
+        }
         self.append(Slot::L1, hash, io, bytes).await
     }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/version.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-//! GET_VERSION → VERSION handler (DSP0274 §10.2).
+//! GET_VERSION -> VERSION handler (DSP0274 section 10.2).
 //!
 //! Per spec the VERSION response's SPDMVersion field is **always
 //! V1.0** — version negotiation happens later, in GET_CAPABILITIES.
@@ -17,10 +17,10 @@ use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_VERSION_MISMATCH};
 use crate::stack::{ConnectionState, Phase};
 
 /// Versions advertised by the responder, in descending order of preference.
-///
-/// V1.2 is the floor because our CAPABILITIES / ALGORITHMS request
-/// bodies only support the V1.2+ wire shape.
-pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V13, SpdmVersion::V12];
+/// V1.1 satisfies OCP 2.7 SPDM-1 backward-compatibility; the CAPABILITIES /
+/// ALGORITHMS handlers gate 1.2+ caps off for a V1.1 peer.
+pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] =
+    &[SpdmVersion::V13, SpdmVersion::V12, SpdmVersion::V11];
 
 /// Handles a `GET_VERSION` request and produces the matching `VERSION` response.
 ///
@@ -42,7 +42,7 @@ pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V13, SpdmVe
 ///
 /// * `Ok(PalBytes)` — The fully-encoded `VERSION` response (transport
 ///   header + SPDM common header + body). Always carries
-///   [`SpdmVersion::V10`] per DSP0274 §10.2.
+///   [`SpdmVersion::V10`] per DSP0274 section 10.2.
 ///
 /// # Errors
 ///
@@ -57,7 +57,7 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &Pal::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    // DSP0274 §10.2 Table 8: GET_VERSION header version shall be 0x10.
+    // DSP0274 section 10.2 Table 8: GET_VERSION header version shall be 0x10.
     let req = io.request();
     let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != SpdmVersion::V10.to_u8() {
@@ -74,7 +74,7 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     let spdm_len = body.encoded_size();
     let resp = build_response(pal, io, SpdmVersion::V10, &body)?;
 
-    // DSP0274 §10.4.1: GET_VERSION + VERSION contribute to VCA.
+    // DSP0274 section 10.4.1: GET_VERSION + VERSION contribute to VCA.
     // Use spdm_len to exclude any transport-layer padding (e.g. DOE DWORD alignment).
     let head = pal.header_size();
     state.transcript.append_vca(pal, io, io.request()).await?;
@@ -85,4 +85,19 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
 
     state.phase = Phase::AfterVersion;
     Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertises_v11_through_v13_in_preference_order() {
+        // V1.1 must be advertised for backward compatibility, in descending
+        // preference.
+        assert_eq!(
+            SUPPORTED_VERSIONS,
+            &[SpdmVersion::V13, SpdmVersion::V12, SpdmVersion::V11]
+        );
+    }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/version.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-//! GET_VERSION → VERSION handler (DSP0274 §10.2).
+//! GET_VERSION -> VERSION handler (DSP0274 section 10.2).
 //!
 //! Per spec the VERSION response's SPDMVersion field is **always
 //! V1.0** — version negotiation happens later, in GET_CAPABILITIES.
@@ -18,10 +18,14 @@ use crate::stack::{ConnectionState, Phase};
 
 /// Versions advertised by the responder, in descending order of preference.
 ///
-/// V1.2 is the floor because our CAPABILITIES / ALGORITHMS request
-/// bodies only support the V1.2+ wire shape.
-pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] =
-    &[SpdmVersion::V14, SpdmVersion::V13, SpdmVersion::V12];
+/// V1.1 is advertised for OCP 2.7 SPDM-1 backward-compatibility; the
+/// CAPABILITIES / ALGORITHMS handlers gate 1.2+ caps off for a V1.1 peer.
+pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[
+    SpdmVersion::V14,
+    SpdmVersion::V13,
+    SpdmVersion::V12,
+    SpdmVersion::V11,
+];
 
 /// Validate a GET_VERSION request without mutating connection or session state.
 ///
@@ -58,7 +62,7 @@ pub(crate) fn validate_get_version(req: &[u8]) -> SpdmResult<()> {
 ///
 /// * `Ok(PalBytes)` — The fully-encoded `VERSION` response (transport
 ///   header + SPDM common header + body). Always carries
-///   [`SpdmVersion::V10`] per DSP0274 §10.2.
+///   [`SpdmVersion::V10`] per DSP0274 section 10.2.
 ///
 /// # Errors
 ///
@@ -76,7 +80,7 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     let spdm_len = body.encoded_size();
     let resp = build_response(pal, io, SpdmVersion::V10, &body)?;
 
-    // DSP0274 §10.4.1: GET_VERSION + VERSION contribute to VCA.
+    // DSP0274 section 10.4.1: GET_VERSION + VERSION contribute to VCA.
     // Use spdm_len to exclude any transport-layer padding (e.g. DOE DWORD alignment).
     let head = pal.header_size();
     state.transcript.append_vca(pal, io, io.request()).await?;
@@ -87,4 +91,25 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
 
     state.phase = Phase::AfterVersion;
     Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertises_v11_through_v14_in_preference_order() {
+        // V1.1 must be advertised for backward compatibility, in descending
+        // preference, without dropping the V1.2..=V1.4 the responder already
+        // supports.
+        assert_eq!(
+            SUPPORTED_VERSIONS,
+            &[
+                SpdmVersion::V14,
+                SpdmVersion::V13,
+                SpdmVersion::V12,
+                SpdmVersion::V11
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

OCP 2.7 SPDM-1 requires backward compatibility to SPDM 1.1. The responder previously advertised only versions ≥ 1.2 (`SUPPORTED_VERSIONS: &[SpdmVersion] = &[V13, V12]`). This PR adds SPDM 1.1 version negotiation and version-gates 1.2+ features so that a 1.1 requester receives 1.1-compatible behavior.

## Changes

**1. Advertise SPDM 1.1 in the VERSION response**
- `version.rs` — add `SpdmVersion::V11` to `SUPPORTED_VERSIONS`; the responder now advertises V13, V12, V11 in descending preference order, and negotiation selects 1.1 when a requester only supports 1.1.

**2. Version-gate 1.2+ features for a 1.1 peer**
- `codec/capabilities.rs`, `codec/lib.rs` — add `CapabilitiesBodyV11`, the 10-byte v1.0/1.1 CAPABILITIES body (`Param1｜Param2｜Reserved｜CTExponent｜Reserved2｜Flags`) that omits the v1.2+ `DataTransferSize`/`MaxSPDMmsgSize` fields; make `CapabilitiesRsp` version-aware (10 bytes at v1.1, 18 at v1.2+).
- `stack/capabilities.rs` — parse the version-specific request body; for a v1.1 peer, mask off caps that did not exist in the v1.1 flag set (CHUNK, SET_CERT, ALIAS_CERT) and clear ENCAP (our encapsulated-request path depends on v1.2+ framing). Also gate the v1.3-only caps (MULTI_KEY_CONN_RSP, GET_KEY_PAIR_INFO) for any pre-1.3 peer.
- `stack/algorithms.rs` — suppress `OtherParamSupport` to `EMPTY` at v1.1 (the field is Reserved before v1.2).
- `stack/challenge.rs`, `stack/key_exchange.rs`, `stack/measurements.rs` — at v1.0/1.1, sign the raw transcript hash (M1 / TH1 / L1) with no dmtf-spdm signing-context prefix, since that prefix is a v1.2+ construct (DSP0274 1.1.1 §10.9.2).

## Test coverage
- **Codec unit tests** (`codec/capabilities.rs`) — 2/2: `v11_capabilities_body_is_10_bytes_without_transfer_sizes`, `v12_capabilities_body_is_18_bytes_with_transfer_sizes`.
- **Stack handler tests** (new `stack/src/tests/capabilities.rs`) — `v11_capabilities_masks_off_all_v12plus_and_v13_caps`, `v12_capabilities_masks_off_v13_caps_only`; plus `version.rs` preference-order test.
- Full `caliptra-mcu-spdm-codec` and `caliptra-mcu-spdm-stack` suites green locally.
- Spec citations verified against DSP0274 1.3.0 and 1.1.1 for the v1.1-specific clauses.