### PR TITLE
fix(fpga): mctp test after hitless update reset

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -94,6 +94,7 @@ const FEATURES_REQUIRING_SOC_IMAGES: &[&str] = &[
     "test-mctp-spdm-attestation-mixed",
     "test-mctp-spdm-attestation-pcr-quote",
     "test-firmware-v2",
+    "test-mctp-capsule-loopback",
 ];
 
 /// Features that require flash-based boot (partition table at offset 0)

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -86,7 +86,7 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    #[cfg_attr(not(feature = "fpga_realtime"), ignore)]
+    #[cfg(feature = "fpga_realtime")]
     #[test]
     fn test_mctp_capsule_loopback_after_hitless_update_reset() {
         use crate::test_fpga_flash_ctrl::test::run_imaginary_flash_controller_service_with_init;

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod test {
     use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
-    use caliptra_mcu_hw_model::{McuHwModel, McuManager};
+    use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_romtime::McuBootMilestones;
     use caliptra_mcu_testing_common::i3c_socket::{
         self, BufferedStream, MctpTestState, MctpTransportTest,
@@ -89,22 +89,30 @@ mod test {
     #[cfg_attr(not(feature = "fpga_realtime"), ignore)]
     #[test]
     fn test_mctp_capsule_loopback_after_hitless_update_reset() {
-        let feature = "test-mctp-capsule-loopback";
+        use crate::test_fpga_flash_ctrl::test::run_imaginary_flash_controller_service_with_init;
+
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+        let binaries = caliptra_mcu_builder::FirmwareBinaries::from_env()
+            .expect("CPTRA_FIRMWARE_BUNDLE not set");
+        let update_flash_image = binaries
+            .test_flash_image("test-mctp-capsule-loopback")
+            .expect("Prebuilt capsule loopback flash image not found");
+
         let mut hw = start_runtime_hw_model(TestParams {
-            feature: Some(feature),
-            rom_feature: Some("test-force-hitless-update"),
+            feature: Some("test-firmware-activate"),
             i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 
-        let reset_reason = hw.mcu_manager().with_mci(|mci| mci.reset_reason().read());
-        assert!(
-            reset_reason.fw_hitless_upd_reset(),
-            "MCU did not boot through the hitless update flow"
-        );
+        hw.start_i3c_controller();
+
+        let mci_ptr = hw.base.mmio.mci().unwrap().ptr as u64;
+        run_imaginary_flash_controller_service_with_init(mci_ptr, Some(update_flash_image));
+        hw.output()
+            .set_search_term("Executing test-mctp-capsule-loopback");
+        hw.step_until(|model| model.output().search_matched());
 
         hw.start_i3c_controller();
 
@@ -119,6 +127,7 @@ mod test {
         let test = finish_runtime_hw_model(&mut hw);
 
         assert_eq!(0, test);
+        caliptra_mcu_testing_common::stop_emulator();
 
         // force the compiler to keep the lock
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
The integration test to exercise MCTP communication after a hitless update reset is flaky. Currently, it uses the ROM to perform directly hitless update reset, however, this is causing sometimes i3c to not initialize properly after reset.

Use the actual hitless update reset path in Runtime using the activation path in firmware update. This will cause MCU Runtime to follow the proper reset sequence to boot to the new image before doing the MCTP loopback test.