### PR TITLE
pldm-lib: discover update agent EID

### DIFF
--- a/common/testing/src/mctp_transport.rs
+++ b/common/testing/src/mctp_transport.rs
@@ -44,6 +44,7 @@ struct MctpPldmSocketData {
 impl PldmSocket for MctpPldmSocket {
     fn send(&self, payload: &[u8]) -> Result<(), PldmTransportError> {
         let mut mctp_util = MctpUtil::new();
+        mctp_util.set_src_eid(self.source.0);
         let mut mctp_common_header = MctpCommonHeader(0);
         mctp_common_header.set_ic(0);
         mctp_common_header.set_msg_type(MCTP_PLDM_MSG_TYPE);

--- a/common/testing/src/mctp_util/common.rs
+++ b/common/testing/src/mctp_util/common.rs
@@ -59,7 +59,6 @@ impl MctpUtil {
 
     pub fn new_req(&mut self, msg_tag: u8) {
         self.dest_eid = 0;
-        self.src_eid = LOCAL_TEST_ENDPOINT_EID;
         self.msg_tag = msg_tag;
         self.tag_owner = 1;
     }
@@ -572,6 +571,19 @@ impl MctpUtil {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_request_preserves_configured_source_eid() {
+        let mut mctp = MctpUtil::new();
+        mctp.set_src_eid(11);
+        mctp.new_req(0);
+
+        let packets = mctp.packetize(&[0]);
+        let header: MCTPHdr<[u8; MCTP_HDR_SIZE]> =
+            MCTPHdr::read_from_bytes(&packets[0][..MCTP_HDR_SIZE]).unwrap();
+
+        assert_eq!(header.src_eid(), 11);
+    }
 
     #[test]
     fn test_mctp_packetize_assembly() {

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -61,6 +61,8 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use tests::pldm_request_response_test::PldmRequestResponseTest;
 
+const STREAMING_BOOT_UA_EID: u8 = 11;
+
 // Type aliases for external shim callbacks
 pub type ExternalReadCallback =
     Box<dyn Fn(caliptra_emu_types::RvSize, caliptra_emu_types::RvAddr, &mut u32) -> bool>;
@@ -1052,8 +1054,13 @@ impl Emulator {
             // Start the PLDM Daemon
             i3c_controller_join_handle = Some(i3c_controller.start());
             let pldm_transport = MctpTransport::new(cli.i3c_port.unwrap(), i3c_dynamic_address);
+            let ua_eid = if test_feature == "test-pldm-streaming-boot" {
+                STREAMING_BOOT_UA_EID
+            } else {
+                LOCAL_TEST_ENDPOINT_EID
+            };
             let pldm_socket = pldm_transport
-                .create_socket(EndpointId(LOCAL_TEST_ENDPOINT_EID), EndpointId(0))
+                .create_socket(EndpointId(ua_eid), EndpointId(0))
                 .unwrap();
             if test_feature == "test-pldm-streaming-boot" {
                 // If we are running the PLDM daemon from an integration test,

--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -64,19 +64,23 @@ impl<'a> CmdInterface<'a> {
         msg_buf: &mut [u8],
     ) -> McuResult<ResponderAction> {
         // Receive msg from mctp transport
-        transport
+        let requester_eid = transport
             .receive_request(msg_buf)
             .await
             .map_err(|_| errors::TRANSPORT_ERROR)?;
 
         // Process the request
-        let (resp_len, action) = self.process_request(msg_buf).await?;
+        let (resp_len, action, bind_ua_eid) = self.process_request(msg_buf).await?;
 
         // Send the response
         transport
             .send_response(&msg_buf[..resp_len])
             .await
             .map_err(|_| errors::TRANSPORT_ERROR)?;
+
+        if bind_ua_eid {
+            transport.bind_ua_eid(requester_eid);
+        }
 
         Ok(action)
     }
@@ -167,7 +171,10 @@ impl<'a> CmdInterface<'a> {
         self.fd_ctx.ops()
     }
 
-    async fn process_request(&self, msg_buf: &mut [u8]) -> McuResult<(usize, ResponderAction)> {
+    async fn process_request(
+        &self,
+        msg_buf: &mut [u8],
+    ) -> McuResult<(usize, ResponderAction, bool)> {
         // Check if the handler is busy processing a request
         if self.busy.load(Ordering::SeqCst) {
             return Err(errors::NOT_READY);
@@ -184,14 +191,14 @@ impl<'a> CmdInterface<'a> {
             Err(e) => {
                 self.busy.store(false, Ordering::SeqCst);
                 let len = reserved_len + generate_failure_response(payload, e)?;
-                return Ok((len, ResponderAction::Continue));
+                return Ok((len, ResponderAction::Continue, false));
             }
         };
 
         let result = match pldm_type {
             PldmSupportedType::Base => self
                 .process_control_cmd(cmd_opcode, payload)
-                .map(|len| (len, ResponderAction::Continue)),
+                .map(|len| (len, ResponderAction::Continue, false)),
             PldmSupportedType::FwUpdate => self.process_fw_update_cmd(cmd_opcode, payload).await,
             _ => {
                 unreachable!()
@@ -200,8 +207,8 @@ impl<'a> CmdInterface<'a> {
 
         self.busy.store(false, Ordering::SeqCst);
 
-        let (resp_len, action) = result?;
-        Ok((reserved_len + resp_len, action))
+        let (resp_len, action, bind_ua_eid) = result?;
+        Ok((reserved_len + resp_len, action, bind_ua_eid))
     }
 
     fn process_control_cmd(&self, cmd_opcode: u8, payload: &mut [u8]) -> McuResult<usize> {
@@ -223,64 +230,64 @@ impl<'a> CmdInterface<'a> {
         &self,
         cmd_opcode: u8,
         payload: &mut [u8],
-    ) -> McuResult<(usize, ResponderAction)> {
+    ) -> McuResult<(usize, ResponderAction, bool)> {
         match FwUpdateCmd::try_from(cmd_opcode) {
             Ok(cmd) => match cmd {
                 FwUpdateCmd::QueryDeviceIdentifiers => self
                     .fd_ctx
                     .query_devid_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Continue, false)),
                 FwUpdateCmd::GetFirmwareParameters => self
                     .fd_ctx
                     .get_firmware_parameters_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Continue, false)),
                 FwUpdateCmd::RequestUpdate => self
                     .fd_ctx
                     .request_update_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|(len, accepted)| (len, ResponderAction::Continue, accepted)),
                 FwUpdateCmd::PassComponentTable => self
                     .fd_ctx
                     .pass_component_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Continue, false)),
                 FwUpdateCmd::UpdateComponent => self
                     .fd_ctx
                     .update_component_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Continue, false)),
 
                 FwUpdateCmd::ActivateFirmware => self
                     .fd_ctx
                     .activate_firmware_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Complete)),
+                    .map(|len| (len, ResponderAction::Complete, false)),
                 FwUpdateCmd::CancelUpdateComponent => self
                     .fd_ctx
                     .cancel_update_component_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Complete)),
+                    .map(|len| (len, ResponderAction::Complete, false)),
                 FwUpdateCmd::CancelUpdate => self
                     .fd_ctx
                     .cancel_update_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Complete)),
+                    .map(|len| (len, ResponderAction::Complete, false)),
                 FwUpdateCmd::GetStatus => self
                     .fd_ctx
                     .get_status_rsp(payload)
                     .await
-                    .map(|len| (len, ResponderAction::Continue)),
+                    .map(|len| (len, ResponderAction::Continue, false)),
                 _ => generate_failure_response(
                     payload,
                     PldmBaseCompletionCode::UnsupportedPldmCmd as u8,
                 )
-                .map(|len| (len, ResponderAction::Continue)),
+                .map(|len| (len, ResponderAction::Continue, false)),
             },
             Err(_) => {
                 generate_failure_response(payload, PldmBaseCompletionCode::UnsupportedPldmCmd as u8)
-                    .map(|len| (len, ResponderAction::Continue))
+                    .map(|len| (len, ResponderAction::Continue, false))
             }
         }
     }

--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -86,8 +86,7 @@ impl<'a> CmdInterface<'a> {
         transport: &mut MctpTransport,
         msg_buf: &mut [u8],
     ) -> McuResult<()> {
-        // Retrieve the UA EID from the configuration
-        let ua_eid: u8 = crate::config::UA_EID;
+        let ua_eid = transport.ua_eid();
 
         // Prepare the request payload
         let payload = construct_mctp_pldm_msg(msg_buf).map_err(|_| errors::UTIL_ERROR)?;

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -282,7 +282,7 @@ async fn run_optimized_download(
     msg_buffer: &mut [u8],
     session: &mut TransferSession,
 ) -> McuResult<bool> {
-    let ua_eid: u8 = crate::config::UA_EID;
+    let ua_eid = transport.ua_eid();
     let ops = cmd_interface.ops();
 
     // Check for cancellation (atomic, no mutex)

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/fd_context.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/fd_context.rs
@@ -148,13 +148,14 @@ impl<'a> FirmwareDeviceContext<'a> {
         }
     }
 
-    pub async fn request_update_rsp(&self, payload: &mut [u8]) -> McuResult<usize> {
+    pub async fn request_update_rsp(&self, payload: &mut [u8]) -> McuResult<(usize, bool)> {
         // Check if FD is in idle state. Otherwise returns 'ALREADY_IN_UPDATE_MODE' completion code
         if self.internal.is_update_mode() {
-            return generate_failure_response(
+            let len = generate_failure_response(
                 payload,
                 FwUpdateCompletionCode::AlreadyInUpdateMode as u8,
-            );
+            )?;
+            return Ok((len, false));
         }
 
         // Set timestamp for FD T1 timeout
@@ -164,10 +165,11 @@ impl<'a> FirmwareDeviceContext<'a> {
         let req = RequestUpdateRequest::decode(payload).map_err(|_| errors::CODEC_ERROR)?;
         let ua_transfer_size = req.fixed.max_transfer_size as usize;
         if ua_transfer_size < PLDM_FWUP_BASELINE_TRANSFER_SIZE {
-            return generate_failure_response(
+            let len = generate_failure_response(
                 payload,
                 FwUpdateCompletionCode::InvalidTransferLength as u8,
-            );
+            )?;
+            return Ok((len, false));
         }
 
         // Get the transfer size for the firmware update operation
@@ -194,10 +196,11 @@ impl<'a> FirmwareDeviceContext<'a> {
                 // Move FD state to 'LearnComponents'
                 self.internal
                     .set_fd_state(FirmwareDeviceState::LearnComponents);
-                Ok(bytes)
+                Ok((bytes, true))
             }
             Err(_) => {
                 generate_failure_response(payload, PldmBaseCompletionCode::InvalidLength as u8)
+                    .map(|len| (len, false))
             }
         }
     }
@@ -1108,6 +1111,7 @@ mod test {
         ActivateFirmwareRequest, ActivateFirmwareResponse, SelfContainedActivationRequest,
     };
     use caliptra_mcu_pldm_common::message::firmware_update::apply_complete::ApplyResult;
+    use caliptra_mcu_pldm_common::message::firmware_update::request_update::RequestUpdateRequest;
     use caliptra_mcu_pldm_common::message::firmware_update::update_component::{
         UpdateComponentRequest, UpdateComponentResponse,
     };
@@ -1238,6 +1242,54 @@ mod test {
             &ver_str,
         );
         req.encode(payload).unwrap()
+    }
+
+    fn encode_request_update(payload: &mut [u8], max_transfer_size: u32) -> usize {
+        let ver_str = PldmFirmwareString::new("UTF-8", "fw-v2.0").unwrap();
+        let req = RequestUpdateRequest::new(
+            1,
+            PldmMsgType::Request,
+            max_transfer_size,
+            1,
+            1,
+            0,
+            &ver_str,
+        );
+        req.encode(payload).unwrap()
+    }
+
+    #[test]
+    fn test_request_update_acceptance() {
+        let mock_ops = MockFdOps;
+        let fd_ctx = FirmwareDeviceContext::new(&mock_ops);
+        let mut payload = [0u8; 256];
+
+        encode_request_update(&mut payload, PLDM_FWUP_BASELINE_TRANSFER_SIZE as u32);
+        let (_, accepted) = block_on(fd_ctx.request_update_rsp(&mut payload)).unwrap();
+
+        assert!(accepted);
+        assert_eq!(
+            fd_ctx.internal.get_fd_state(),
+            FirmwareDeviceState::LearnComponents
+        );
+
+        encode_request_update(&mut payload, PLDM_FWUP_BASELINE_TRANSFER_SIZE as u32);
+        let (_, accepted) = block_on(fd_ctx.request_update_rsp(&mut payload)).unwrap();
+        assert!(!accepted);
+    }
+
+    #[test]
+    fn test_invalid_request_update_is_not_accepted() {
+        let mock_ops = MockFdOps;
+        let fd_ctx = FirmwareDeviceContext::new(&mock_ops);
+        let mut payload = [0u8; 256];
+
+        encode_request_update(&mut payload, (PLDM_FWUP_BASELINE_TRANSFER_SIZE - 1) as u32);
+        let (_, accepted) = block_on(fd_ctx.request_update_rsp(&mut payload)).unwrap();
+        assert!(!accepted);
+
+        let mut malformed_payload = [0u8; 2];
+        assert!(block_on(fd_ctx.request_update_rsp(&mut malformed_payload)).is_err());
     }
 
     // =========================================================================

--- a/runtime/userspace/api/pldm-lib/src/transport.rs
+++ b/runtime/userspace/api/pldm-lib/src/transport.rs
@@ -36,6 +36,12 @@ impl MctpTransport {
         }
     }
 
+    pub fn bind_ua_eid(&self, eid: u8) {
+        if eid != 0 {
+            DISCOVERED_UA_EID.store(eid, Ordering::Relaxed);
+        }
+    }
+
     pub async fn send_request(&mut self, dest_eid: u8, req: &[u8]) -> McuResult<()> {
         let mctp_hdr = MctpCommonHeader(req[MCTP_COMMON_HEADER_OFFSET]);
         if mctp_hdr.ic() != 0 || mctp_hdr.msg_type() != MCTP_PLDM_MSG_TYPE {
@@ -79,7 +85,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn receive_request(&mut self, req: &mut [u8]) -> McuResult<()> {
+    pub async fn receive_request(&mut self, req: &mut [u8]) -> McuResult<u8> {
         // Reset msg buffer
         req.fill(0);
         let (req_len, msg_info) = self
@@ -98,12 +104,10 @@ impl MctpTransport {
             Err(errors::UNEXPECTED_MESSAGE_TYPE)?;
         }
 
-        if msg_info.eid != 0 {
-            DISCOVERED_UA_EID.store(msg_info.eid, Ordering::Relaxed);
-        }
+        let requester_eid = msg_info.eid;
         self.cur_resp_ctx = Some(msg_info);
 
-        Ok(())
+        Ok(requester_eid)
     }
 
     pub async fn send_response(&mut self, resp: &[u8]) -> McuResult<()> {
@@ -139,7 +143,7 @@ mod tests {
 
         assert_eq!(initiator.ua_eid(), crate::config::UA_EID);
 
-        DISCOVERED_UA_EID.store(11, Ordering::Relaxed);
+        responder.bind_ua_eid(11);
         assert_eq!(responder.ua_eid(), 11);
         assert_eq!(initiator.ua_eid(), 11);
 

--- a/runtime/userspace/api/pldm-lib/src/transport.rs
+++ b/runtime/userspace/api/pldm-lib/src/transport.rs
@@ -5,7 +5,10 @@ use caliptra_mcu_libsyscall_caliptra::mctp::{Mctp, MessageInfo};
 use caliptra_mcu_pldm_common::util::mctp_transport::{
     MctpCommonHeader, MCTP_COMMON_HEADER_OFFSET, MCTP_PLDM_MSG_TYPE,
 };
+use core::sync::atomic::{AtomicU8, Ordering};
 use mcu_error::McuResult;
+
+static DISCOVERED_UA_EID: AtomicU8 = AtomicU8::new(0);
 
 pub enum PldmTransportType {
     Mctp,
@@ -23,6 +26,13 @@ impl MctpTransport {
             mctp: Mctp::new(drv_num),
             cur_resp_ctx: None,
             cur_req_ctx: None,
+        }
+    }
+
+    pub fn ua_eid(&self) -> u8 {
+        match DISCOVERED_UA_EID.load(Ordering::Relaxed) {
+            0 => crate::config::UA_EID,
+            eid => eid,
         }
     }
 
@@ -88,6 +98,9 @@ impl MctpTransport {
             Err(errors::UNEXPECTED_MESSAGE_TYPE)?;
         }
 
+        if msg_info.eid != 0 {
+            DISCOVERED_UA_EID.store(msg_info.eid, Ordering::Relaxed);
+        }
         self.cur_resp_ctx = Some(msg_info);
 
         Ok(())
@@ -111,5 +124,25 @@ impl MctpTransport {
         self.cur_resp_ctx = None;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ua_eid_is_shared_across_transport_instances() {
+        DISCOVERED_UA_EID.store(0, Ordering::Relaxed);
+        let responder = MctpTransport::new(1);
+        let initiator = MctpTransport::new(1);
+
+        assert_eq!(initiator.ua_eid(), crate::config::UA_EID);
+
+        DISCOVERED_UA_EID.store(11, Ordering::Relaxed);
+        assert_eq!(responder.ua_eid(), 11);
+        assert_eq!(initiator.ua_eid(), 11);
+
+        DISCOVERED_UA_EID.store(0, Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
Learn the PLDM Update Agent EID from incoming MCTP requests and use it for initiator traffic. Exercise the behavior in streaming boot with UA EID 11.

Fixes [1909](https://github.com/chipsalliance/caliptra-mcu-sw/issues/1909)