### PR TITLE
ci(size-history): pick up the worktree-reset fix [blocked on caliptra-infra#76]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-size-history"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-infra.git?rev=64e75e17e1a2eb07ff8dd6698932af82182da85e#64e75e17e1a2eb07ff8dd6698932af82182da85e"
+source = "git+https://github.com/RaunakGu/caliptra-infra.git?rev=20aeb2e6441c#20aeb2e6441cfbb17acfe2d67c8fd035346b21e0"
 dependencies = [
  "ghac",
  "prost 0.13.2",
@@ -3098,7 +3098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.109",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,10 @@ dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869
 crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 
-size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", package = "caliptra-size-history", rev = "64e75e17e1a2eb07ff8dd6698932af82182da85e" }
+# TODO: repoint at chipsalliance/caliptra-infra once PR #76 merges, and replace
+# this rev with the resulting upstream commit. Pinned to the fork meanwhile so
+# CI picks up the size-history worktree-reset fix; see PR body.
+size-history = { git = "https://github.com/RaunakGu/caliptra-infra.git", package = "caliptra-size-history", rev = "20aeb2e6441c" }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }


### PR DESCRIPTION
## ⛔ Depends on chipsalliance/caliptra-infra 76 — do not merge before that lands

Blocked by: **chipsalliance/caliptra-infra 76**

This PR currently pins the `size-history` crate to a **fork** rev so CI can exercise the fix. Before merge, the rev must be repointed at `chipsalliance/caliptra-infra` using the commit that 76 produces. There is a `TODO` on the pin in `Cargo.toml` saying so.

## Why

The `analyze` job dies partway through its history walk whenever the GitHub-Actions cache misses.

`worktree.checkout()` in the size-history crate is fatal (`?`) while `compute_sizes` errors are only printed. A commit whose committed `Cargo.lock` disagrees with its own `Cargo.toml` makes cargo regenerate the lockfile mid-walk, so the next bare checkout aborts:

```
error: Your local changes to the following files would be overwritten by checkout:
	Cargo.lock
Aborting
```

main's commit `4ea26b146` is exactly that case — its lockfile lists `sha2` under `caliptra-mcu-builder`, but `sha2` was only added to that manifest by the **child** commit `15b7ac207`. The lockfile was committed out of order, so `cargo metadata --locked` exits 101 there.

PRs that hit the cache `break` after 1–3 commits and never reach it. PRs that miss walk deep enough to fail.

## Verification

Reproduced on plain `main` with no other changes:

```
cargo metadata --locked @ 4ea26b146    -> EXIT 101   (self-inconsistent)
cargo build -p caliptra-mcu-builder    -> M Cargo.lock

before:  git checkout 5796651816f4                  -> aborts
after:   git reset --hard && git checkout 5796651816f4 -> succeeds (lands on 579665181)
```

`579665181` is the exact commit the failing runs die on. `cargo build -p xtask` compiles against the new rev.

## Scope

Two files: the pin in `Cargo.toml` and the regenerated `Cargo.lock` entry. The unrelated second `caliptra-infra` pin (`e061f229`, a different package) is untouched.
