### PR TITLE
ci(size-history): pick up the worktree-reset fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "caliptra-size-history"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-infra.git?rev=64e75e17e1a2eb07ff8dd6698932af82182da85e#64e75e17e1a2eb07ff8dd6698932af82182da85e"
+source = "git+https://github.com/chipsalliance/caliptra-infra.git?rev=c7497382a9d338430bcbe79f4e54c94ff7c297c3#c7497382a9d338430bcbe79f4e54c94ff7c297c3"
 dependencies = [
  "ghac",
  "prost 0.13.2",
@@ -3118,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.109",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,7 +358,7 @@ dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869
 crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 
-size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", package = "caliptra-size-history", rev = "64e75e17e1a2eb07ff8dd6698932af82182da85e" }
+size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", package = "caliptra-size-history", rev = "c7497382a9d338430bcbe79f4e54c94ff7c297c3" }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }


### PR DESCRIPTION
## What

Bumps the pinned `size-history` rev from `64e75e17` to `c7497382`.

`c7497382` is the squash-merge of **chipsalliance/caliptra-infra PR 76** ("fix(size-history): reset the worktree before each checkout"), merged 2026-08-10 and now that repo's `main` tip. This repo pins the crate by rev, so merging PR 76 alone changed nothing here — this bump is what actually delivers the fix to CI.

## Why

The `analyze` job aborts partway through its history walk whenever the Actions cache misses:

```
error: Your local changes to the following files would be overwritten by checkout:
	Cargo.lock
Aborting
```

`worktree.checkout()` in the size-history crate is fatal while build errors are only printed. So a commit whose committed `Cargo.lock` disagrees with its own `Cargo.toml` kills the entire run — cargo regenerates the lockfile during that commit's build, and the next bare checkout refuses to move.

main's commit `4ea26b146` is exactly that case: its lockfile lists `sha2` under `caliptra-mcu-builder`, but `sha2` was only added to that manifest by the child commit `15b7ac207`. `cargo metadata --locked` exits 101 there.

Runs that hit cache `break` after 1–3 commits and never reach it. Runs that miss walk deep and fail — 17 `analyze` failures across 8 branches over 6–7 Aug, including two pushes to `main` (PRs 1873, 1910, 1911, 1912, 1862, 1905, 1933).

## Verification

Reproduced the abort and the fix directly at the offending commit:

```
cargo metadata --locked @ 4ea26b146          -> exit 101
cargo build -p caliptra-mcu-builder          -> M Cargo.lock
before:  git checkout 5796651816f4           -> aborts
after:   reset --hard, then checkout          -> succeeds (lands on 579665181)
```

`579665181` is the commit the failing runs die on. `cargo build -p xtask` compiles against the new rev.

## Scope

Two files: the pin in `Cargo.toml` and the regenerated `Cargo.lock` entry. The unrelated second `caliptra-infra` pin (`e061f229`, a different package) is untouched.
