### PR TITLE
ci(size-history): pick up the worktree-reset fix (cherry-pick of 1943)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "caliptra-size-history"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-infra.git?rev=64e75e17e1a2eb07ff8dd6698932af82182da85e#64e75e17e1a2eb07ff8dd6698932af82182da85e"
+source = "git+https://github.com/chipsalliance/caliptra-infra.git?rev=c7497382a9d338430bcbe79f4e54c94ff7c297c3#c7497382a9d338430bcbe79f4e54c94ff7c297c3"
 dependencies = [
  "ghac",
  "prost 0.13.2",
@@ -3717,7 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.109",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,7 +395,7 @@ dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151
 # caliptra-infra dependencies; keep git revs in sync
 caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-infra", rev = "e061f229d5d284ce39387eb104f3022053c6c772" }
 
-size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", package = "caliptra-size-history", rev = "64e75e17e1a2eb07ff8dd6698932af82182da85e" }
+size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", package = "caliptra-size-history", rev = "c7497382a9d338430bcbe79f4e54c94ff7c297c3" }
 
 # local caliptra dependency; useful when developing
 # caliptra-sw deps:


### PR DESCRIPTION
Cherry-pick of #1943 onto `main-2.1`.

Bumps the pinned `size-history` rev from `64e75e17` to `c7497382` — the squash-merge of chipsalliance/caliptra-infra PR 76 ("fix(size-history): reset the worktree before each checkout"). Keeps the two branches' `caliptra-infra` revs in sync, as the comment above the pin asks.

Preventive here rather than a fix for an observed failure: `main-2.1` does not contain `main`'s offending commit `4ea26b146`, and the `Size History 2.1` workflow has no runs yet. It is still worth landing because `main-2.1` receives cherry-picks from `main`, so the same lockfile-ordering pattern can arrive later.

Two files: the pin in `Cargo.toml` and the regenerated `Cargo.lock` entry. `cargo build -p caliptra-mcu-xtask` compiles against the new rev.
