### PR TITLE
ci: raise the build-firmware timeout to 90 minutes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
 
   build-firmware:
     runs-on: [e2-standard-16-big-disk]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     env:
       CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Problem

`build-firmware` runs against its 60-minute cap and is cancelled roughly a third of the time.

Over the last 29 runs of `build-test.yml`: **6 timeouts, each on a different branch** — `ci/bump-size-history-fix`, `parvathib/fix-util-host-precheckin-f`, `feat/populate-mldsa-idevid-cert`, `mlvisaya/issue-1908-incorrect-compon`, `mlvisaya/image-header-filename`, `util-host-fuse-vdm`. No branch repeats, so this is not caused by any particular change.

The 12 successes in that window ran **46.5–58.7 minutes**:

```
min 46.5m   median 51.1m   max 58.7m      cap 60.0m
```

The slowest passing run cleared the cap by 78 seconds. Whether a run survives depends on runner speed and sccache warmth, not on the diff.

## It is slow, not stuck

Checked before proposing a timeout raise, since a hang would not be fixed by more time:

- Longest gap between log lines in a cancelled run: **5.4 minutes** (a link step).
- Output was still being emitted **every second** when the cancellation landed.
- Step 8, "Build ROM and runtime binaries", took **56.2 of the 60 minutes** by itself. Steps 9–11 were skipped as a result, which is what makes `test_emulator` and `print_test_results` fail downstream.

## Fix

Raise the cap to 90, matching `test_emulator` in this same file.

## What this does not fix

The underlying cost. `--separate-runtimes` gives each feature its own target directory — 56 of them in a single job — so common dependencies are rebuilt per feature:

```
21,668 "Compiling" lines / 486 distinct crates  =  ~45x redundancy
syn compiled 335 times, mcu-caliptra-api-lite 249, caliptra-mcu-romtime 245
```

Sharding step 8 across a matrix, or letting the per-feature builds share a build cache, would attack that directly. Worth noting that `RUSTC_WRAPPER`/sccache is configured but the logs carry no cache hit/miss summary, so the actual hit rate across those 56 target directories is unmeasured — if it is poor, fixing it would be higher leverage than sharding. Left for a follow-up.
