### PR TITLE
SPDM 1.4 support for (negotiate_)algorithms

### DIFF
--- a/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
@@ -130,6 +130,15 @@ def_flag_set_le! {
     }
 }
 
+def_flag_set_le! {
+  /// KEMAlg.AlgSupported.
+    pub struct KemAlgos(U16: u16) {
+        ML_KEM512 = 1 << 0,
+        ML_KEM768 = 1 << 1,
+        ML_KEM1024 = 1 << 2,
+    }
+}
+
 // ---- AlgType discriminants -------------------------------------------------
 
 /// `AlgType` byte values for AlgStruct entries.

--- a/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
@@ -230,9 +230,10 @@ const _: () =
 pub struct AlgStructEntry {
     /// One of [`alg_type`] constants.
     pub alg_type: u8,
-    /// `FixedAlgCount[3:0] | ExtAlgCount[7:4]`. We always emit
+    /// `ExtAlgCount[3:0] | FixedAlgCount[7:4]`. We always emit
     /// `FixedAlgCount = 2` (one 16-bit AlgSupported bitmap, no
     /// external algs).
+    /// `FixedAlgCount` + 2 shall be a multiple of 4.
     pub alg_count_etc: u8,
     pub alg_supported: U16,
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
@@ -67,6 +67,27 @@ def_flag_set_le! {
 }
 
 def_flag_set_le! {
+  /// PqcAsymAlgo / PqcAsymSel.
+    pub struct PqcAsymAlgos(U32: u32) {
+        MLDSA_44 = 1 << 0,
+        MLDSA_65 = 1 << 1,
+        MLDSA_87 = 1 << 2,
+        SLHDSA_SHA2_128S = 1 << 3,
+        SLHDSA_SHAKE_128S = 1 << 4,
+        SLHDSA_SHA2_128F = 1 << 5,
+        SLHDSA_SHAKE_128F = 1 << 6,
+        SLHDSA_SHA2_192S = 1 << 7,
+        SLHDSA_SHAKE_192S = 1 << 8,
+        SLHDSA_SHA2_192F = 1 << 9,
+        SLHDSA_SHAKE_192F = 1 << 10,
+        SLHDSA_SHA2_256S = 1 << 11,
+        SLHDSA_SHAKE_256S = 1 << 12,
+        SLHDSA_SHA2_256F = 1 << 13,
+        SLHDSA_SHAKE_256F = 1 << 14,
+    }
+}
+
+def_flag_set_le! {
   /// BaseHashAlgo / BaseHashSel.
     pub struct HashAlgos(U32: u32) {
         SHA_256 = 1 << 0,
@@ -117,6 +138,8 @@ pub mod alg_type {
     pub const AEAD: u8 = 0x03;
     pub const REQ_BASE_ASYM: u8 = 0x04;
     pub const KEY_SCHEDULE: u8 = 0x05;
+    pub const REQ_PQC_ASYM: u8 = 0x06;
+    pub const KEM: u8 = 0x07;
 }
 
 // ---- NEGOTIATE_ALGORITHMS request wire types -------------------------------
@@ -138,7 +161,10 @@ pub struct NegotiateAlgorithmsReqBodyFixed {
     pub other_param_support: OtherParamSupport,
     pub base_asym_algo: AsymAlgos,
     pub base_hash_algo: HashAlgos,
-    pub reserved1: [u8; 12],
+    /// Requester supported PQC asymmetric key signature algorithms.
+    /// Since V1.4, reserved in V1.3 and prior.
+    pub pqc_asym_algo: PqcAsymAlgos,
+    pub reserved1: [u8; 8],
     pub ext_asym_count: u8,
     pub ext_hash_count: u8,
     /// Byte 28: Reserved.
@@ -173,7 +199,10 @@ pub struct AlgorithmsRspBodyFixed {
     pub meas_hash_algo: MeasHashAlgos,
     pub base_asym_sel: AsymAlgos,
     pub base_hash_sel: HashAlgos,
-    pub reserved3: [u8; 12],
+    /// Selected PQC asymmetric key signature algorithm.
+    /// Since V1.4, reserved in V1.3 and prior.
+    pub pqc_asym_sel: PqcAsymAlgos,
+    pub reserved3: [u8; 8],
     pub ext_asym_sel_count: u8,
     pub ext_hash_sel_count: u8,
     pub reserved4: [u8; 2],
@@ -242,6 +271,7 @@ pub struct AlgorithmsRsp {
     pub meas_hash_algo: MeasHashAlgos,
     pub base_asym_sel: AsymAlgos,
     pub base_hash_sel: HashAlgos,
+    pub pqc_asym_sel: PqcAsymAlgos,
     /// AlgStruct entries to advertise; `None` slots are skipped.
     pub alg_structs: [Option<AlgStructEntry>; MAX_ALG_STRUCT_ENTRIES],
 }
@@ -271,7 +301,8 @@ impl ResponseBody for AlgorithmsRsp {
             meas_hash_algo: self.meas_hash_algo,
             base_asym_sel: self.base_asym_sel,
             base_hash_sel: self.base_hash_sel,
-            reserved3: [0; 12],
+            pqc_asym_sel: self.pqc_asym_sel,
+            reserved3: [0; 8],
             ext_asym_sel_count: 0,
             ext_hash_sel_count: 0,
             reserved4: [0; 2],

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -29,7 +29,7 @@ mod wire;
 pub use algorithms::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, AlgorithmsRspBodyFixed, AsymAlgos,
     DheAlgos, HashAlgos, KeyScheduleAlgos, MeasHashAlgos, MeasSpec,
-    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, MAX_ALG_STRUCT_ENTRIES,
+    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
 pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp};

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -28,7 +28,7 @@ mod wire;
 
 pub use algorithms::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, AlgorithmsRspBodyFixed, AsymAlgos,
-    DheAlgos, HashAlgos, KeyScheduleAlgos, MeasHashAlgos, MeasSpec,
+    DheAlgos, HashAlgos, KemAlgos, KeyScheduleAlgos, MeasHashAlgos, MeasSpec,
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -24,8 +24,7 @@
 
 use caliptra_mcu_spdm_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, CapFlags, DheAlgos, KeyScheduleAlgos,
-    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, ResponseBody, SpdmMsgHdrPdu,
-    SpdmVersion,
+    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -92,6 +91,7 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
     state.other_param_sel = rsp_body.other_param_support;
     state.negotiated_base_asym_sel = rsp_body.base_asym_sel;
     state.negotiated_base_hash_sel = rsp_body.base_hash_sel;
+    state.negotiated_pqc_asym_sel = rsp_body.pqc_asym_sel;
 
     let resp = build_response(pal, io, state.version, &rsp_body)?;
 
@@ -271,7 +271,7 @@ fn build_response_body<S, L>(
         meas_hash_algo: state.meas_hash_algo,
         base_asym_sel: state.base_asym_sel & fixed.base_asym_algo,
         base_hash_sel: state.base_hash_sel & fixed.base_hash_algo,
-        pqc_asym_sel: PqcAsymAlgos::EMPTY, // TODO
+        pqc_asym_sel: state.pqc_asym_sel & fixed.pqc_asym_algo,
         alg_structs: [
             (!dhe.is_empty()).then(|| AlgStructEntry::dhe(dhe)),
             (!aead.is_empty()).then(|| AlgStructEntry::aead(aead)),

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -24,7 +24,8 @@
 
 use caliptra_mcu_spdm_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, CapFlags, DheAlgos, KeyScheduleAlgos,
-    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -131,7 +132,7 @@ fn locate_alg_structs<'a>(
     fixed: &NegotiateAlgorithmsReqBodyFixed,
     body: &'a [u8],
 ) -> SpdmResult<&'a [u8]> {
-    if fixed.param2 != 0 || fixed.reserved1 != [0; 12] || fixed.reserved2 != 0 {
+    if fixed.param2 != 0 || fixed.reserved1 != [0; 8] || fixed.reserved2 != 0 {
         return Err(SPDM_INVALID_REQUEST);
     }
 
@@ -270,6 +271,7 @@ fn build_response_body<S, L>(
         meas_hash_algo: state.meas_hash_algo,
         base_asym_sel: state.base_asym_sel & fixed.base_asym_algo,
         base_hash_sel: state.base_hash_sel & fixed.base_hash_algo,
+        pqc_asym_sel: PqcAsymAlgos::EMPTY, // TODO
         alg_structs: [
             (!dhe.is_empty()).then(|| AlgStructEntry::dhe(dhe)),
             (!aead.is_empty()).then(|| AlgStructEntry::aead(aead)),
@@ -291,7 +293,7 @@ mod tests {
     use crate::stack::ConnectionState;
     use caliptra_mcu_spdm_codec::{
         alg_type, AlgorithmsRspBodyFixed, AsymAlgos, HashAlgos, MeasHashAlgos, MeasSpec,
-        ReqRespCode,
+        PqcAsymAlgos, ReqRespCode,
     };
     use caliptra_mcu_spdm_traits::SpdmPalHash;
     use futures::executor::block_on;
@@ -327,7 +329,8 @@ mod tests {
             other_param_support: OtherParamSupport::OPAQUE_DATA_FMT1,
             base_asym_algo,
             base_hash_algo: HashAlgos::SHA_384,
-            reserved1: [0; 12],
+            pqc_asym_algo: PqcAsymAlgos::MLDSA_87,
+            reserved1: [0; 8],
             ext_asym_count: 0,
             ext_hash_count: 0,
             reserved2: 0,
@@ -396,7 +399,7 @@ mod tests {
             fixed.base_hash_sel.into_bits(),
             HashAlgos::SHA_384.into_bits()
         );
-        assert_eq!(fixed.reserved3, [0; 12]);
+        assert_eq!(fixed.reserved3, [0; 8]);
         assert_eq!(fixed.ext_asym_sel_count, 0);
         assert_eq!(fixed.ext_hash_sel_count, 0);
         assert_eq!(fixed.reserved4, [0; 2]);

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -15,9 +15,9 @@
 //! itself is unaware of the phase.
 
 use caliptra_mcu_spdm_codec::{
-    encode_aad, AeadAlgos, AsymAlgos, CapFlags, DheAlgos, HashAlgos, KeyScheduleAlgos,
-    MeasHashAlgos, MeasSpec, OtherParamSupport, ReqRespCode, SecuredMessageHeader, SpdmMsgHdrPdu,
-    SpdmVersion, AES_256_GCM_TAG_SIZE, SECURED_MSG_HDR_SIZE,
+    encode_aad, AeadAlgos, AsymAlgos, CapFlags, DheAlgos, HashAlgos, KemAlgos, KeyScheduleAlgos,
+    MeasHashAlgos, MeasSpec, OtherParamSupport, PqcAsymAlgos, ReqRespCode, SecuredMessageHeader,
+    SpdmMsgHdrPdu, SpdmVersion, AES_256_GCM_TAG_SIZE, SECURED_MSG_HDR_SIZE,
 };
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use caliptra_mcu_spdm_traits::*;
@@ -111,6 +111,10 @@ pub struct ConnectionState<S, L> {
     pub aead: AeadAlgos,
     /// Key-schedule bitmap (always `SPDM` for this responder).
     pub key_schedule: KeyScheduleAlgos,
+    /// PQC asymmetric algorithms advertised
+    pub pqc_asym_sel: PqcAsymAlgos,
+    /// Advertised KEMs (Key Encapsulation Mechanisms)
+    pub kem: KemAlgos,
 
     // ---- Connection-scoped negotiation -----------------------------------
     /// Current connection phase.
@@ -138,6 +142,8 @@ pub struct ConnectionState<S, L> {
     pub transcript: crate::transcript::Transcript<S>,
     /// Consolidated context managing large-payload request reassembly and response chunking.
     pub(crate) large_msg_ctx: chunk::LargeMessageCtx<L>,
+    /// Negotiated PQC asymmetric algorithms
+    pub negotiated_pqc_asym_sel: PqcAsymAlgos,
 }
 
 impl<S, L> ConnectionState<S, L> {
@@ -180,9 +186,11 @@ impl<S, L> ConnectionState<S, L> {
             meas_hash_algo: MeasHashAlgos::SHA_384,
             base_asym_sel: AsymAlgos::ECDSA_ECC_NIST_P384,
             base_hash_sel: HashAlgos::SHA_384,
+            pqc_asym_sel: PqcAsymAlgos::EMPTY, // TODO
             dhe: DheAlgos::SECP_384_R1,
             aead: AeadAlgos::AES_256_GCM,
             key_schedule: KeyScheduleAlgos::SPDM,
+            kem: KemAlgos::EMPTY, // TODO
 
             phase: Phase::Start,
             version: SpdmVersion::V12,
@@ -195,6 +203,7 @@ impl<S, L> ConnectionState<S, L> {
             negotiated_base_hash_sel: HashAlgos::EMPTY,
             transcript: crate::transcript::Transcript::new(),
             large_msg_ctx: chunk::LargeMessageCtx::new(),
+            negotiated_pqc_asym_sel: PqcAsymAlgos::EMPTY,
         }
     }
 


### PR DESCRIPTION
- Add ReqPqcAsymAlg and KEMAlg to AlgType
- Add PqcAsymAlgos bitfield
- Add pqc_asym_algo field to NEGOTIATE_ALGORITHMS request
- Add pqc_asym_sel field to ALGORITHMS response
- Add bitmap for KEMAlg structure
- Add policy and negotiated fields for PQC and KEM to ConnectionState

Staging copy of #1867 .