### PR TITLE
Optimize validator firmware builds

### DIFF
--- a/.github/workflows/caliptra-util-host-validator.yml
+++ b/.github/workflows/caliptra-util-host-validator.yml
@@ -184,23 +184,35 @@ jobs:
           cargo xtask test
           popd
 
-      - name: Run Caliptra Util Host validator tests
+      - name: Build validator test firmware bundle
         run: |
-          cargo xtask all-build
+          cargo xtask all-build --separate-runtimes \
+            --runtime-features test-caliptra-util-host-validator,test-caliptra-util-host-mctp-vdm-validator,test-caliptra-util-host-spdm-vdm-validator,test-mctp-spdm-set-certificate
+
+      - name: Run Caliptra Util Host validator tests
+        env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
+        run: |
           cargo test --package caliptra-mcu-tests-integration --lib -- test::test_caliptra_util_host_validator --nocapture --include-ignored
           sccache --show-stats
 
       - name: Run Caliptra Util Host MCTP VDM validator tests
+        env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
         run: |
           cargo test --package caliptra-mcu-tests-integration --lib -- test_mctp_vdm_validator::test::test_caliptra_util_host_mctp_vdm_validator --nocapture --include-ignored
           sccache --show-stats
 
       - name: Run Caliptra Util Host SPDM VDM validator tests (production mode)
+        env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
         run: |
           cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator --exact --nocapture --include-ignored
           sccache --show-stats
 
       - name: Run Caliptra Util Host SPDM VDM validator tests (manufacturing mode)
+        env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
         run: |
           cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator_mfg_mode --exact --nocapture --include-ignored
           sccache --show-stats
@@ -209,7 +221,6 @@ jobs:
         env:
           CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
         run: |
-          cargo xtask all-build --separate-runtimes --runtime-features test-mctp-spdm-set-certificate
           cargo test --package caliptra-mcu-tests-integration --lib -- test_ocp_dev_identity_provision_tool::test::test_mctp_spdm_set_certificate_with_ocp_provision_tool --exact --nocapture --include-ignored
           sccache --show-stats
 

--- a/.github/workflows/fpga-spdm.yml
+++ b/.github/workflows/fpga-spdm.yml
@@ -150,11 +150,13 @@ jobs:
 
           # Build ROM and runtime binaries
           echo "Cross compiling FPGA binaries"
-          cargo xtask-fpga fpga build \
-            --configuration subsystem \
+          cargo xtask all-build \
+            --output all-fw.zip \
+            --platform fpga \
             --rom-features "core_test" \
             --mcu_cfg mcu,0x0,0xB00C0000,2,2,2,test-fpga-flash-ctrl \
-            --separate-runtimes
+            --separate-runtimes \
+            --runtime-features test-mctp-spdm-attestation-pcr-quote,test-mctp-spdm-responder-conformance
           sccache --show-stats
 
           mkdir -p /tmp/caliptra-binaries

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -103,13 +103,18 @@ jobs:
         run: |
           echo "SPDM_NONCE=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+      - name: Build SPDM validator firmware bundle
+        run: |
+          cargo xtask all-build --separate-runtimes \
+            --runtime-features test-mctp-spdm-responder-conformance,test-mctp-spdm-attestation-pcr-quote,test-doe-spdm-responder-conformance,test-doe-spdm-tdisp-ide-validator
+
       - name: Run SPDM validator tests on MCTP transport
         env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
-          cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
 
@@ -142,16 +147,16 @@ jobs:
 
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
         env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
-          cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
 
       - name: Run SPDM validator tests on DOE transport
         env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
-          cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
 
@@ -206,9 +211,9 @@ jobs:
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
         env:
+          CPTRA_FIRMWARE_BUNDLE: ${{ github.workspace }}/target/all-fw.zip
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
-          cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_tdisp_ide_validator --nocapture --include-ignored
           sccache --show-stats
 

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -42,11 +42,11 @@ use caliptra_mcu_core_util_host_command_types::debug_unlock::{
 use caliptra_mcu_core_util_host_command_types::fuse::{
     FeProgResponse, GetAuthCmdChallengeResponse,
 };
-use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
     SpdmVdmDriver, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
+use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
 use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_csr;
 use caliptra_util_host_commands::api::debug_unlock::{
     caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,


### PR DESCRIPTION
The validator workflows generated broad all-build bundles containing many test runtime features that the selected tests never use. They also did not set CPTRA_FIRMWARE_BUNDLE for most test invocations, so the test harness ignored the prebuilt images and compiled firmware again at runtime.

Build one feature-filtered bundle per workflow and pass it to each test through CPTRA_FIRMWARE_BUNDLE. This removes unused firmware variants and avoids duplicate builds that unnecessarily prolong CI execution.