### PR TITLE
ci(spdm): gate feature/spdm-1_4 pull requests on the SPDM suites

### DIFF
--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -6,6 +6,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   workflow_call:
+  # SPDM 1.4 is developed on this branch, so the SPDM suites gate its pull
+  # requests instead of only running in the nightly job. Other branches are
+  # deliberately excluded: these tests build spdm-emu from source and run four
+  # emulator suites, which is too slow to put in front of every pull request.
+  pull_request:
+    # TODO: Remove this filter after feature/spdm-1_4 merges to main.
+    branches: [ feature/spdm-1_4 ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # Pin the Caliptra core ROM to a release tag; image/update crates continue
@@ -83,7 +94,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-emu
-          ref: caliptra-main
+          ref: caliptra-main-14
           path: spdm-emu
           submodules: recursive
 
@@ -146,6 +157,19 @@ jobs:
         run: |
           cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
+
+      - name: Upload attestation logs and traces for MCTP transport
+        if: always()
+        uses: actions/upload-artifact@v7
+        env:
+          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+        with:
+          name: spdm-mctp-attestation-results
+          if-no-files-found: warn
+          path: |
+            ${{ env.SPDM_VALIDATOR_DIR }}/spdm_requester_emu_output.txt
+            ${{ env.SPDM_VALIDATOR_DIR }}/caliptra-evidence.pcap
+            ${{ env.SPDM_VALIDATOR_DIR }}/measurement_block_*.bin
 
       - name: Run SPDM validator tests on DOE transport
         env:

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes};
 
 const RECEIVER_BUFFER_SIZE: usize = 4160;
+const ATTESTATION_REQUESTER_CAPABILITIES: &str = "CERT,CHAL,CHUNK,LARGE_RESP";
 pub const SOCKET_SPDM_COMMAND_NORMAL: u32 = 0x0001;
 pub const SOCKET_SPDM_COMMAND_STOP: u32 = 0xFFFE;
 pub const SOCKET_SPDM_COMMAND_TEST: u32 = 0xDEAD;
@@ -280,10 +281,13 @@ pub fn execute_spdm_tee_io_validator(transport: &'static str) {
 }
 
 pub fn execute_spdm_attestation(transport: &'static str) {
-    execute_spdm_attestation_with_port(transport, None);
+    let _ = execute_spdm_attestation_with_port(transport, None);
 }
 
-pub fn execute_spdm_attestation_with_port(transport: &'static str, port: Option<u16>) {
+pub fn execute_spdm_attestation_with_port(
+    transport: &'static str,
+    port: Option<u16>,
+) -> std::thread::JoinHandle<bool> {
     crate::spawn_with_emulator_state(move || {
         println!("Starting spdm_requester_emu process. Waiting for SPDM listener to start...");
         while !SERVER_LISTENING.load(Ordering::Relaxed) {
@@ -296,23 +300,25 @@ pub fn execute_spdm_attestation_with_port(transport: &'static str, port: Option<
                     match child.try_wait() {
                         Ok(Some(status)) => {
                             println!("spdm_requester_emu exited with status: {:?}", status);
-                            break;
+                            return status.success();
                         }
                         Ok(None) => {}
                         Err(e) => {
                             println!("Error: {:?}", e);
-                            std::process::exit(1);
+                            return false;
                         }
                     }
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
                 let _ = child.kill();
+                false
             }
             Err(e) => {
                 println!("Error: {:?} Failed to spawn spdm_requester_emu!!", e);
+                false
             }
         }
-    });
+    })
 }
 
 pub fn execute_spdm_responder_validator(transport: &'static str) {
@@ -380,20 +386,25 @@ fn start_spdm_attestation_with_port(
     spawn_validator_binary(
         "spdm_requester_emu",
         "spdm_requester_emu_output.txt",
-        |cmd| {
-            println!(
-                "Starting spdm_requester_emu process with transport: {}",
-                transport
-            );
-            cmd.arg("--trans")
-                .arg(transport)
-                .arg("--pcap")
-                .arg("caliptra-evidence.pcap");
-            if let Some(port) = port {
-                cmd.arg("--port").arg(port.to_string());
-            }
-        },
+        |cmd| configure_spdm_attestation_command(cmd, transport, port),
     )
+}
+
+fn configure_spdm_attestation_command(cmd: &mut Command, transport: &str, port: Option<u16>) {
+    println!(
+        "Starting spdm_requester_emu process with transport: {}",
+        transport
+    );
+    cmd.arg("--trans")
+        .arg(transport)
+        // Endpoint information is not part of this attestation flow.
+        .arg("--cap")
+        .arg(ATTESTATION_REQUESTER_CAPABILITIES)
+        .arg("--pcap")
+        .arg("caliptra-evidence.pcap");
+    if let Some(port) = port {
+        cmd.arg("--port").arg(port.to_string());
+    }
 }
 
 pub fn start_spdm_tee_io_validator(
@@ -468,4 +479,33 @@ where
         .stderr(Stdio::from(output_file_clone))
         .current_dir(&dir_path)
         .spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attestation_requester_excludes_endpoint_info() {
+        let mut command = Command::new("spdm_requester_emu");
+        configure_spdm_attestation_command(&mut command, "MCTP", Some(1025));
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            [
+                "--trans",
+                "MCTP",
+                "--cap",
+                "CERT,CHAL,CHUNK,LARGE_RESP",
+                "--pcap",
+                "caliptra-evidence.pcap",
+                "--port",
+                "1025",
+            ]
+        );
+    }
 }

--- a/tests/integration/src/test_mctp_spdm_attestation.rs
+++ b/tests/integration/src/test_mctp_spdm_attestation.rs
@@ -168,6 +168,8 @@ pub(crate) mod test {
             );
             SERVER_LISTENING.store(true, Ordering::Relaxed);
 
+            let requester = execute_spdm_attestation_with_port("MCTP", Some(spdm_port));
+
             if let Some(spdm_stream) = listener.incoming().next() {
                 let mut spdm_stream = spdm_stream.expect("Failed to accept connection");
 
@@ -177,6 +179,17 @@ pub(crate) mod test {
                     println!("[{}]: Spdm Attestation Test Failed", test_name);
                     exit(-1);
                 } else {
+                    match requester.join() {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            println!("[{}]: spdm_requester_emu failed", test_name);
+                            exit(-1);
+                        }
+                        Err(_) => {
+                            println!("[{}]: spdm_requester_emu panicked", test_name);
+                            exit(-1);
+                        }
+                    }
                     if let Err(err) = validate_spdm_attestation_artifacts() {
                         println!(
                             "[{}]: Spdm Attestation Artifact Check Failed: {err}",
@@ -188,10 +201,6 @@ pub(crate) mod test {
                     exit(0);
                 }
             }
-        });
-
-        caliptra_mcu_testing_common::spawn_with_emulator_state(move || {
-            execute_spdm_attestation_with_port("MCTP", Some(spdm_port));
         });
     }
 }


### PR DESCRIPTION
## Summary

- Gate `feature/spdm-1_4` PRs with MCTP conformance, MCTP PCR quote, DOE conformance, and DOE TDISP/IDE; keep nightly coverage unchanged and cancel superseded runs.
- Use the `caliptra-main-14` SPDM 1.4 stack, including its `CHALLENGE_AUTH` fix.
- Make PCR-quote CI use compatible requester capabilities and report requester failures directly.
- New Validator cases still require a future spdm-emu submodule bump.
