### PR TITLE
ci: add FPGA workflow gate

### DIFF
--- a/.github/workflows/caliptra-sw-smoke-test.yml
+++ b/.github/workflows/caliptra-sw-smoke-test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   caliptra-sw-mcu-rom-smoke-test:
+    if: ${{ vars.RUN_FPGA_CI != 'false' }}
     uses: chipsalliance/caliptra-sw/.github/workflows/fpga-subsystem.yml@caliptra-2.0
     with:
       mcu-commit: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/fpga-spdm.yml
+++ b/.github/workflows/fpga-spdm.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build_test_binaries:
+    if: ${{ vars.RUN_FPGA_CI != 'false' }}
     runs-on: [ e2-standard-8-big-disk ]
     # Cross-compilation plus spdm-emu can consume almost the full hour on cache misses.
     timeout-minutes: 90
@@ -220,6 +221,7 @@ jobs:
           retention-days: 1
 
   test_spdm:
+    if: ${{ vars.RUN_FPGA_CI != 'false' }}
     runs-on: vck190-subsystem
     needs: build_test_binaries
     timeout-minutes: 120

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build_test_binaries:
+    if: ${{ vars.RUN_FPGA_CI != 'false' }}
     runs-on: [e2-standard-8-big-disk]
     # Cross-compilation can consume almost the full hour on cache misses; leave
     # enough headroom for packaging and artifact uploads so the downstream FPGA
@@ -201,6 +202,7 @@ jobs:
           retention-days: 1
 
   test_artifacts:
+    if: ${{ vars.RUN_FPGA_CI != 'false' }}
     runs-on: vck190-subsystem
     needs: build_test_binaries
     timeout-minutes: 120


### PR DESCRIPTION
Add a default-on repository-variable gate to pause FPGA CI without removing required check names.

Set `RUN_FPGA_CI=false` to skip FPGA build, hardware, SPDM, and Caliptra smoke-test jobs. Set it to `true` to resume them.

Validation:
- VS Code workflow diagnostics: clean
- `git diff --check`: clean