### PR TITLE
Zeroize sensitive key material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,10 +1021,10 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-mcu-mbox-common",
  "fips204",
- "hmac",
  "p384",
  "sha2",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/common/command-auth-challenge-signer/Cargo.toml
+++ b/common/command-auth-challenge-signer/Cargo.toml
@@ -4,15 +4,15 @@
 name = "caliptra-mcu-command-auth-challenge-signer"
 version.workspace = true
 edition.workspace = true
-description = "Command authorization trait and HMAC implementation for Caliptra MCU"
+description = "Command authorization trait and asymmetric signer for Caliptra MCU"
 
 [dependencies]
 anyhow.workspace = true
 caliptra-image-types.workspace = true
 caliptra-mcu-mbox-common.workspace = true
-hmac.workspace = true
 sha2.workspace = true
 p384 = { workspace = true, features = ["ecdsa", "std"] }
 fips204 = { workspace = true, features = ["default-rng", "ml-dsa-87"] }
 base64.workspace = true
 zerocopy.workspace = true
+zeroize = { workspace = true, features = ["alloc"] }

--- a/common/command-auth-challenge-signer/src/lib.rs
+++ b/common/command-auth-challenge-signer/src/lib.rs
@@ -15,6 +15,7 @@ use fips204::ml_dsa_87;
 use fips204::traits::{KeyGen, SerDes, Signer as MldsaSigner};
 use p384::ecdsa::{signature::Signer, Signature, SigningKey};
 use sha2::{Digest, Sha384, Sha512};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 /// Width of the authorization challenge nonce in bytes. Re-exported from
 /// `caliptra-mcu-mbox-common`, the single source of truth for this size.
@@ -61,17 +62,28 @@ pub struct AsymmetricCommandAuthorizer {
     mldsa_pub: [u8; MLDSA87_PUB_KEY_BYTE_SIZE],
 }
 
+impl Drop for AsymmetricCommandAuthorizer {
+    fn drop(&mut self) {
+        self.mldsa_pub.zeroize();
+    }
+}
+
+// The ECC and ML-DSA private-key fields zeroize themselves on drop; the
+// implementation above covers the remaining cached key material.
+impl ZeroizeOnDrop for AsymmetricCommandAuthorizer {}
+
 impl AsymmetricCommandAuthorizer {
     /// Create a new authorizer using the provided ECC private key and ML-DSA seed.
     pub fn new(ecc_key: &[u8], mldsa_seed: &[u8]) -> Result<Self> {
         let ecc_key = SigningKey::from_slice(ecc_key)
             .map_err(|e| anyhow::anyhow!("Failed to load ECC private key: {}", e))?;
 
-        let seed: &[u8; 32] = mldsa_seed
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("ML-DSA seed must be 32 bytes"))?;
+        let seed = Zeroizing::new(
+            <[u8; 32]>::try_from(mldsa_seed)
+                .map_err(|_| anyhow::anyhow!("ML-DSA seed must be 32 bytes"))?,
+        );
 
-        let (pk, mldsa_key) = ml_dsa_87::KG::keygen_from_seed(seed);
+        let (pk, mldsa_key) = ml_dsa_87::KG::keygen_from_seed(&seed);
 
         Ok(Self {
             ecc_key,
@@ -107,7 +119,8 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
         // inner-hashed transcript. The nonce TRAVELS on the wire (prod-debug-unlock
         // idiom): the device compares the wire nonce to its stored one-time challenge,
         // then rebuilds this identical pre-image from the wire copy before verifying.
-        let mut pre_image = Vec::with_capacity(4 + payload.len() + AUTH_CMD_NONCE_LEN);
+        let mut pre_image =
+            Zeroizing::new(Vec::with_capacity(4 + payload.len() + AUTH_CMD_NONCE_LEN));
         pre_image.extend_from_slice(&cmd_id.to_be_bytes());
         pre_image.extend_from_slice(payload);
         pre_image.extend_from_slice(challenge);
@@ -121,10 +134,10 @@ impl CommandAuthChallengeSigner for AsymmetricCommandAuthorizer {
         // 2. ML-DSA-87 over SHA-512(pre-image): sign the 64-byte SHA-512 digest as the
         //    message (external pre-hash), matching the device's verify over the same
         //    digest.
-        let mldsa_msg: [u8; 64] = Sha512::digest(&pre_image).into();
+        let mldsa_msg = Zeroizing::new(<[u8; 64]>::from(Sha512::digest(&pre_image)));
         let mldsa_sig = self
             .mldsa_key
-            .try_sign(&mldsa_msg, &[])
+            .try_sign(&mldsa_msg[..], &[])
             .map_err(|e| anyhow::anyhow!("ML-DSA signing failed: {:?}", e))?; // returns [u8; 4627]
 
         let mut padded_mldsa_sig = mldsa_sig.to_vec();
@@ -181,6 +194,15 @@ mod tests {
         164, 61, 183, 99, 202, 159, 47, 112, 54,
     ];
     const TEST_MLDSA_SEED: [u8; 32] = *b"caliptra-mcu-testing-mldsa-seed-";
+
+    #[test]
+    fn private_key_owners_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<SigningKey>();
+        assert_zeroize_on_drop::<ml_dsa_87::PrivateKey>();
+        assert_zeroize_on_drop::<AsymmetricCommandAuthorizer>();
+    }
 
     /// Recreate the ML-DSA-87 public key from the test seed for verification.
     fn mldsa_pubkey() -> ml_dsa_87::PublicKey {

--- a/common/testing/src/doe_util/protocol.rs
+++ b/common/testing/src/doe_util/protocol.rs
@@ -9,6 +9,17 @@ const PCISIG_DOE_VENDOR_ID: u16 = 0x0001;
 const LENGTH_FIELD_BITS: u32 = 18;
 const LENGTH_MASK: u32 = (1 << LENGTH_FIELD_BITS) - 1;
 
+/// Vendor ID reported in a DOE Discovery Response when there is no Data Object
+/// Protocol associated with the requested index.
+pub const UNSUPPORTED_VENDOR_ID: u16 = 0xFFFF;
+
+/// DOE Discovery Version used when the DOE Extended Capability Version is 01h.
+pub const DOE_DISCOVERY_VERSION_LEGACY: u8 = 0x00;
+
+/// DOE Discovery Version required when the DOE Extended Capability Version is
+/// 02h or greater.
+pub const DOE_DISCOVERY_VERSION_2: u8 = 0x02;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
 pub enum DataObjectType {
@@ -64,7 +75,8 @@ bitfield! {
     pub struct DoeDiscoveryRequest([u8]);
     impl Debug;
     pub u8, index, set_index: 7, 0;
-    u32, reserved_1, _: 31, 8;
+    pub u8, version, set_version: 15, 8;
+    u16, reserved_1, _: 31, 16;
 }
 
 impl Default for DoeDiscoveryRequest<[u8; DOE_DISCOVERY_REQ_RESP_LEN]> {
@@ -75,8 +87,13 @@ impl Default for DoeDiscoveryRequest<[u8; DOE_DISCOVERY_REQ_RESP_LEN]> {
 
 impl DoeDiscoveryRequest<[u8; DOE_DISCOVERY_REQ_RESP_LEN]> {
     pub fn new(index: u8) -> Self {
+        Self::new_with_version(index, DOE_DISCOVERY_VERSION_LEGACY)
+    }
+
+    pub fn new_with_version(index: u8, version: u8) -> Self {
         let mut req = Self::default();
         req.set_index(index);
+        req.set_version(version);
         req
     }
 }
@@ -103,6 +120,14 @@ impl DoeDiscoveryResponse<[u8; DOE_DISCOVERY_REQ_RESP_LEN]> {
         response.set_vendor_id(PCISIG_DOE_VENDOR_ID);
         response.set_data_object_protocol(data_object_protocol);
         response.set_next_index(next_index);
+        response
+    }
+
+    /// Response expected when the requested index is out of range or the DOE
+    /// Discovery Version is not supported.
+    pub fn unsupported() -> Self {
+        let mut response = Self::default();
+        response.set_vendor_id(UNSUPPORTED_VENDOR_ID);
         response
     }
 }

--- a/docs/src/doe.md
+++ b/docs/src/doe.md
@@ -48,6 +48,19 @@ The DOE capsule implements the system calls for the user space applications to s
 
 During board initialization, a `DoeDriver` instance is created and registered with a unique driver number. This instance manages the handling of DOE Discovery (Data Object Type 0), SPDM (Data Object Type 1), and Secure-SPDM (Data Object Type 2) data objects.
 
+### DOE Discovery handling
+Every well-formed DOE Discovery Request is answered with a DOE Discovery Response; the capsule never silently discards one. The response contents depend on the request:
+
+| Request | Discovery Response |
+| --- | --- |
+| Index 0, 1 or 2 with a supported Discovery Version | Vendor ID `0001h` (PCI-SIG), the matching Data Object Protocol, and the next index (wrapping to `0` after the last protocol) |
+| Index greater than 2 | Vendor ID `FFFFh`, Data Object Protocol `0`, Next Index `0` |
+| Unsupported DOE Discovery Version | Vendor ID `FFFFh`, Data Object Protocol `0`, Next Index `0` |
+
+A Vendor ID of `FFFFh` tells the requester there is no Data Object Protocol at the requested index, which is how discovery enumeration terminates. Responding rather than dropping the request also keeps the DOE transport from stalling a requester that is waiting on `Data Object Ready`.
+
+The DOE Discovery Version occupies bits 15:8 of the request payload. Version `00h` (used when the DOE Extended Capability Version is `01h`, where the field is reserved) and version `02h` (required when the Capability Version is `02h` or greater) are accepted; any other value is rejected with the `FFFFh` response above.
+
 
 ```Rust
 

--- a/emulator/app/src/tests/doe_discovery.rs
+++ b/emulator/app/src/tests/doe_discovery.rs
@@ -14,6 +14,10 @@ pub enum DoeDiscoveryTest {
     DoeDiscovery,
     Spdm,
     SecureSpdm,
+    OutOfRangeIndex,
+    MaxIndex,
+    SupportedVersion,
+    UnsupportedVersion,
 }
 
 impl std::fmt::Display for DoeDiscoveryTest {
@@ -22,6 +26,10 @@ impl std::fmt::Display for DoeDiscoveryTest {
             DoeDiscoveryTest::DoeDiscovery => write!(f, "DoeDiscovery"),
             DoeDiscoveryTest::Spdm => write!(f, "DoeSpdm"),
             DoeDiscoveryTest::SecureSpdm => write!(f, "DoeSecureSpdm"),
+            DoeDiscoveryTest::OutOfRangeIndex => write!(f, "DoeOutOfRangeIndex"),
+            DoeDiscoveryTest::MaxIndex => write!(f, "DoeMaxIndex"),
+            DoeDiscoveryTest::SupportedVersion => write!(f, "DoeSupportedDiscoveryVersion"),
+            DoeDiscoveryTest::UnsupportedVersion => write!(f, "DoeUnsupportedDiscoveryVersion"),
         }
     }
 }
@@ -39,24 +47,46 @@ impl DoeDiscoveryTest {
     }
 
     fn request_message(&self) -> Vec<u8> {
-        let index = match self {
-            DoeDiscoveryTest::DoeDiscovery => DataObjectType::DoeDiscovery as u8,
-            DoeDiscoveryTest::Spdm => DataObjectType::DoeSpdm as u8,
-            DoeDiscoveryTest::SecureSpdm => DataObjectType::DoeSecureSpdm as u8,
+        let (index, version) = match self {
+            DoeDiscoveryTest::DoeDiscovery => (
+                DataObjectType::DoeDiscovery as u8,
+                DOE_DISCOVERY_VERSION_LEGACY,
+            ),
+            DoeDiscoveryTest::Spdm => (DataObjectType::DoeSpdm as u8, DOE_DISCOVERY_VERSION_LEGACY),
+            DoeDiscoveryTest::SecureSpdm => (
+                DataObjectType::DoeSecureSpdm as u8,
+                DOE_DISCOVERY_VERSION_LEGACY,
+            ),
+            DoeDiscoveryTest::OutOfRangeIndex => (
+                DataObjectType::DoeSecureSpdm as u8 + 1,
+                DOE_DISCOVERY_VERSION_LEGACY,
+            ),
+            DoeDiscoveryTest::MaxIndex => (u8::MAX, DOE_DISCOVERY_VERSION_LEGACY),
+            DoeDiscoveryTest::SupportedVersion => {
+                (DataObjectType::DoeDiscovery as u8, DOE_DISCOVERY_VERSION_2)
+            }
+            DoeDiscoveryTest::UnsupportedVersion => (DataObjectType::DoeDiscovery as u8, 0x01),
         };
-        DoeDiscoveryRequest::new(index).as_bytes().to_vec()
+        DoeDiscoveryRequest::new_with_version(index, version)
+            .as_bytes()
+            .to_vec()
     }
 
     fn response_message(&self) -> Vec<u8> {
         match self {
-            DoeDiscoveryTest::DoeDiscovery => Self::build_response(
-                DataObjectType::DoeDiscovery,
-                DataObjectType::DoeDiscovery as u8 + 1,
-            ),
+            DoeDiscoveryTest::DoeDiscovery | DoeDiscoveryTest::SupportedVersion => {
+                Self::build_response(
+                    DataObjectType::DoeDiscovery,
+                    DataObjectType::DoeDiscovery as u8 + 1,
+                )
+            }
             DoeDiscoveryTest::Spdm => {
                 Self::build_response(DataObjectType::DoeSpdm, DataObjectType::DoeSpdm as u8 + 1)
             }
             DoeDiscoveryTest::SecureSpdm => Self::build_response(DataObjectType::DoeSecureSpdm, 0),
+            DoeDiscoveryTest::OutOfRangeIndex
+            | DoeDiscoveryTest::MaxIndex
+            | DoeDiscoveryTest::UnsupportedVersion => Self::build_unsupported_response(),
         }
     }
 
@@ -65,13 +95,25 @@ impl DoeDiscoveryTest {
             .as_bytes()
             .to_vec()
     }
+
+    /// Expected response for an out-of-range index or an unsupported DOE
+    /// Discovery Version: Vendor ID FFFFh with a zero protocol and next index.
+    fn build_unsupported_response() -> Vec<u8> {
+        DoeDiscoveryResponse::unsupported().as_bytes().to_vec()
+    }
 }
+
+/// Number of polling attempts before a test case is declared failed for not
+/// receiving a response. Bounding this keeps a non-responsive firmware from
+/// hanging the whole test binary until the global timeout fires.
+const MAX_RECEIVE_ATTEMPTS: u32 = 60;
 
 struct Test {
     name: String,
     req_msg: Vec<u8>,
     resp_msg: Vec<u8>,
     test_state: DoeTestState,
+    recv_attempts: u32,
     passed: bool,
 }
 
@@ -82,6 +124,7 @@ impl Test {
             req_msg,
             resp_msg,
             test_state: DoeTestState::Start,
+            recv_attempts: 0,
             passed: false,
         }
     }
@@ -97,6 +140,7 @@ impl DoeTransportTest for Test {
         println!("DOE_DISCOVERY_TEST: Running test: {}", self.name);
 
         self.test_state = DoeTestState::Start;
+        self.recv_attempts = 0;
 
         while caliptra_mcu_testing_common::is_emulator_running() {
             match self.test_state {
@@ -136,8 +180,18 @@ impl DoeTransportTest for Test {
                         self.test_state = DoeTestState::Finish;
                     }
                     Ok(_) => {
-                        // Stay in ReceiveData state and yield for a bit
-                        sleep_emulator_ticks(100_000);
+                        self.recv_attempts += 1;
+                        if self.recv_attempts >= MAX_RECEIVE_ATTEMPTS {
+                            println!(
+                                "DOE_DISCOVERY_TEST: No response received for {}, expected: {:?}",
+                                self.name, self.resp_msg
+                            );
+                            self.passed = false;
+                            self.test_state = DoeTestState::Finish;
+                        } else {
+                            // Stay in ReceiveData state and yield for a bit
+                            sleep_emulator_ticks(100_000);
+                        }
                     }
                     Err(e) => {
                         println!("DOE_DISCOVERY_TEST: Failed to receive response: {:?}", e);

--- a/ocp-eat-verifier/Cargo.toml
+++ b/ocp-eat-verifier/Cargo.toml
@@ -22,3 +22,4 @@ clap = { version = "4", features = ["derive"] }
 corim-rs = { git = "https://github.com/chipsalliance/caliptra-corim-rs.git", branch = "caliptra-main" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ciborium = "0.2"
+zeroize = { version = "1.6", default-features = false }

--- a/ocp-eat-verifier/ocptoken-lib/Cargo.toml
+++ b/ocp-eat-verifier/ocptoken-lib/Cargo.toml
@@ -20,6 +20,7 @@ hex.workspace = true
 thiserror.workspace = true
 openssl = { workspace = true, optional = true }
 corim-rs.workspace = true
+zeroize = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
 openssl.workspace = true

--- a/ocp-eat-verifier/ocptoken-lib/src/ta_store/stores/fs.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/ta_store/stores/fs.rs
@@ -7,6 +7,9 @@ use openssl::x509::{X509StoreContext, X509};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use zeroize::{Zeroize, Zeroizing};
+
+type CertificateDer = Zeroizing<Vec<u8>>;
 
 /// Filesystem-backed Trust Anchor Store.
 ///
@@ -25,12 +28,10 @@ use std::path::Path;
 /// are indexed by their Subject Key Identifier (SKI) X.509 extension,
 /// which is used as the `kid` for lookup.
 pub struct FsTrustAnchorStore {
-    /// Trusted root CA certificates.
-    roots: Vec<X509>,
-    /// Pre-built OpenSSL X509 store from the root CAs (for chain validation).
-    store: X509Store,
-    /// Endorsement certificates indexed by kid (Subject Key Identifier).
-    endorsement_certs: HashMap<Vec<u8>, X509>,
+    /// Trusted root CA certificates in canonical DER form.
+    roots: Vec<CertificateDer>,
+    /// Endorsement certificate DER indexed by kid (Subject Key Identifier).
+    endorsement_certs: HashMap<Vec<u8>, CertificateDer>,
 }
 
 impl FsTrustAnchorStore {
@@ -55,9 +56,6 @@ impl FsTrustAnchorStore {
             ));
         }
 
-        // Build the X509 store from roots
-        let store = build_x509_store(&roots)?;
-
         // Load endorsement certs and index by kid (SKI)
         let endorsement_certs = if signing_dir.is_dir() {
             load_and_index_endorsement_certs(&signing_dir)?
@@ -67,7 +65,6 @@ impl FsTrustAnchorStore {
 
         Ok(Self {
             roots,
-            store,
             endorsement_certs,
         })
     }
@@ -76,8 +73,9 @@ impl FsTrustAnchorStore {
     /// the Subject Key Identifier, falling back to DER comparison.
     fn is_trusted_root(&self, cert: &X509) -> Result<bool, TrustAnchorError> {
         let candidate_ski = subject_key_identifier(cert)?;
-        for root in &self.roots {
-            let root_ski = subject_key_identifier(root)?;
+        for root_der in &self.roots {
+            let root = X509::from_der(root_der)?;
+            let root_ski = subject_key_identifier(&root)?;
             if let (Some(c), Some(r)) = (&candidate_ski, &root_ski) {
                 if c == r {
                     return Ok(true);
@@ -86,9 +84,9 @@ impl FsTrustAnchorStore {
         }
 
         // Fallback: compare DER-encoded forms directly
-        let candidate_der = cert.to_der()?;
-        for root in &self.roots {
-            if root.to_der()? == candidate_der {
+        let candidate_der = Zeroizing::new(cert.to_der()?);
+        for root_der in &self.roots {
+            if root_der.as_slice() == candidate_der.as_slice() {
                 return Ok(true);
             }
         }
@@ -97,17 +95,31 @@ impl FsTrustAnchorStore {
     }
 }
 
+impl Drop for FsTrustAnchorStore {
+    fn drop(&mut self) {
+        for root in &mut self.roots {
+            root.zeroize();
+        }
+        for (mut kid, mut cert) in self.endorsement_certs.drain() {
+            kid.zeroize();
+            cert.zeroize();
+        }
+    }
+}
+
 impl TrustAnchorStore for FsTrustAnchorStore {
     fn authenticate_by_kid(&self, kid: &[u8]) -> Result<Vec<u8>, TrustAnchorError> {
-        let cert = self
+        let cert_der = self
             .endorsement_certs
             .get(kid)
             .ok_or_else(|| TrustAnchorError::UnknownKid(hex::encode(kid)))?;
+        let cert = X509::from_der(cert_der)?;
+        let store = build_x509_store(&self.roots)?;
 
         // Validate the endorsement cert against the trusted roots
         let empty_chain = Stack::new()?;
         let mut ctx = X509StoreContext::new()?;
-        let valid = ctx.init(&self.store, cert, &empty_chain, |ctx| ctx.verify_cert())?;
+        let valid = ctx.init(&store, &cert, &empty_chain, |ctx| ctx.verify_cert())?;
 
         if !valid {
             return Err(TrustAnchorError::ChainValidation(format!(
@@ -116,7 +128,7 @@ impl TrustAnchorStore for FsTrustAnchorStore {
             )));
         }
 
-        Ok(cert.to_der()?)
+        Ok(cert_der.to_vec())
     }
 
     fn authenticate_chain(&self, chain: &[Vec<u8>]) -> Result<Vec<u8>, TrustAnchorError> {
@@ -131,6 +143,7 @@ impl TrustAnchorStore for FsTrustAnchorStore {
             .collect::<Result<Vec<_>, _>>()?;
 
         let leaf = &parsed[0];
+        let store = build_x509_store(&self.roots)?;
 
         // Check that the root of the provided chain is in our trusted roots
         let chain_root = &parsed[parsed.len() - 1];
@@ -146,7 +159,7 @@ impl TrustAnchorStore for FsTrustAnchorStore {
 
         // Validate: leaf → intermediates → trusted root
         let mut ctx = X509StoreContext::new()?;
-        let valid = ctx.init(&self.store, leaf, &untrusted, |ctx| ctx.verify_cert())?;
+        let valid = ctx.init(&store, leaf, &untrusted, |ctx| ctx.verify_cert())?;
 
         if !valid {
             return Err(TrustAnchorError::ChainValidation(
@@ -159,16 +172,16 @@ impl TrustAnchorStore for FsTrustAnchorStore {
 }
 
 /// Build an OpenSSL `X509Store` from a list of trusted root certificates.
-fn build_x509_store(roots: &[X509]) -> Result<X509Store, TrustAnchorError> {
+fn build_x509_store(roots: &[CertificateDer]) -> Result<X509Store, TrustAnchorError> {
     let mut builder = X509StoreBuilder::new()?;
-    for root in roots {
-        builder.add_cert(root.clone())?;
+    for root_der in roots {
+        builder.add_cert(X509::from_der(root_der)?)?;
     }
     Ok(builder.build())
 }
 
 /// Load all PEM and DER certificate files from a directory (non-recursive).
-fn load_certs_from_dir(dir: &Path) -> Result<Vec<X509>, TrustAnchorError> {
+fn load_certs_from_dir(dir: &Path) -> Result<Vec<CertificateDer>, TrustAnchorError> {
     let mut certs = Vec::new();
 
     let mut entries: Vec<_> = fs::read_dir(dir)?
@@ -179,7 +192,7 @@ fn load_certs_from_dir(dir: &Path) -> Result<Vec<X509>, TrustAnchorError> {
 
     for entry in entries {
         let path = entry.path();
-        let data = fs::read(&path)?;
+        let data = Zeroizing::new(fs::read(&path)?);
 
         let cert = if looks_like_pem(&data) {
             X509::from_pem(&data)
@@ -188,7 +201,7 @@ fn load_certs_from_dir(dir: &Path) -> Result<Vec<X509>, TrustAnchorError> {
         };
 
         match cert {
-            Ok(c) => certs.push(c),
+            Ok(c) => certs.push(Zeroizing::new(c.to_der()?)),
             Err(e) => {
                 return Err(TrustAnchorError::Load(format!(
                     "Failed to parse certificate '{}': {}",
@@ -204,18 +217,21 @@ fn load_certs_from_dir(dir: &Path) -> Result<Vec<X509>, TrustAnchorError> {
 
 /// Load endorsement certificates from a directory and index them by their
 /// Subject Key Identifier (SKI).
-fn load_and_index_endorsement_certs(dir: &Path) -> Result<HashMap<Vec<u8>, X509>, TrustAnchorError> {
+fn load_and_index_endorsement_certs(
+    dir: &Path,
+) -> Result<HashMap<Vec<u8>, CertificateDer>, TrustAnchorError> {
     let certs = load_certs_from_dir(dir)?;
     let mut map = HashMap::new();
 
-    for cert in certs {
+    for cert_der in certs {
+        let cert = X509::from_der(&cert_der)?;
         let ski = subject_key_identifier(&cert)?.ok_or_else(|| {
             TrustAnchorError::Load(format!(
                 "Endorsement certificate has no Subject Key Identifier extension: {:?}",
                 cert.subject_name()
             ))
         })?;
-        map.insert(ski, cert);
+        map.insert(ski, cert_der);
     }
 
     Ok(map)
@@ -233,4 +249,26 @@ fn subject_key_identifier(cert: &X509) -> Result<Option<Vec<u8>>, TrustAnchorErr
 /// Heuristic check: does the data look like PEM-encoded content?
 fn looks_like_pem(data: &[u8]) -> bool {
     data.starts_with(b"-----BEGIN ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_roots_into_zeroizing_der_storage() {
+        let store_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../ocptoken/test-data/ta-store");
+        let store = FsTrustAnchorStore::load(&store_path).unwrap();
+
+        assert_eq!(store.roots.len(), 1);
+        let root = X509::from_der(&store.roots[0]).unwrap();
+        assert!(store.is_trusted_root(&root).unwrap());
+
+        let root_der = store.roots[0].to_vec();
+        assert_eq!(
+            store.authenticate_chain(&[root_der.clone()]).unwrap(),
+            root_der
+        );
+    }
 }

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -445,10 +445,8 @@ fn enter_i3c_services(
     }
 
     let reassembly_buf = unsafe {
-        core::slice::from_raw_parts_mut(
-            mci.registers.mcu_mbox0_csr_mbox_sram.as_ptr() as *mut u32,
-            crate::i3c_mailbox::MAX_REASSEMBLY_WORDS,
-        )
+        &mut *(mci.registers.mcu_mbox0_csr_mbox_sram.as_ptr()
+            as *mut [u32; crate::i3c_mailbox::MAX_REASSEMBLY_WORDS])
     };
 
     let mut handler =

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -24,6 +24,7 @@ use caliptra_mcu_error::{McuError, McuResult};
 use caliptra_mcu_romtime::Otp;
 use caliptra_mcu_romtime::{HexWord, McuRomBootStatus};
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
+use zeroize::{Zeroize, Zeroizing};
 
 const DOT_LABEL: &[u8; 23] = b"Caliptra DOT stable key";
 pub const DOT_BLOB_SIZE: usize = core::mem::size_of::<DotBlob>();
@@ -173,13 +174,19 @@ pub(crate) fn install_owner_pk_hash(
 }
 
 /// Caliptra Cryptographic Mailbox Key (CMK) handle.
-#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Zeroize)]
 pub struct Cmk(pub [u32; 32]);
 
 /// DOT Effective Key derived from DOT_ROOT_KEY and DOT_FUSE_ARRAY state.
 ///
 /// This key is used to authenticate DOT blobs via HMAC.
 pub struct DotEffectiveKey(pub Cmk);
+
+impl Drop for DotEffectiveKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
 
 /// The DOT blob data structure containing ownership credentials and locking keys.
 ///
@@ -352,7 +359,7 @@ pub(crate) fn cm_derive_stable_key_impl(
     info[LABEL_LEN] = fuse_slice[0];
     info[LABEL_LEN + 1] = fuse_slice[1];
 
-    let mut resp = [0u32; core::mem::size_of::<CmDeriveStableKeyResp>() / 4];
+    let mut resp = Zeroizing::new([0u32; core::mem::size_of::<CmDeriveStableKeyResp>() / 4]);
     let req = CmDeriveStableKeyReq {
         info,
         key_type: key_type.into(),
@@ -363,14 +370,26 @@ pub(crate) fn cm_derive_stable_key_impl(
     if let Err(err) = soc_manager.exec_mailbox_req_u32(
         CommandId::CM_DERIVE_STABLE_KEY.into(),
         &mut req32,
-        &mut resp,
+        &mut resp[..],
     ) {
         let _ = err;
         caliptra_mcu_romtime::println!("[mcu-rom] DOT key err");
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
-    let resp: CmDeriveStableKeyResp = transmute!(resp);
-    let dot_effective_key = DotEffectiveKey(Cmk(transmute!(resp.cmk)));
+    let resp = CmDeriveStableKeyResp::ref_from_bytes(resp.as_bytes()).map_err(|_| {
+        caliptra_mcu_romtime::println!("[mcu-rom] Invalid DOT key response");
+        McuError::ROM_COLD_BOOT_DOT_ERROR
+    })?;
+    let mut dot_effective_key = DotEffectiveKey(Cmk::default());
+    for (dest, source) in dot_effective_key
+        .0
+         .0
+        .as_mut_bytes()
+        .iter_mut()
+        .zip(resp.cmk.0.iter())
+    {
+        *dest = *source;
+    }
     Ok(dot_effective_key)
 }
 
@@ -385,6 +404,12 @@ pub struct CmHmacDotBlobReq {
     pub data: DotBlobFields,
 }
 
+impl Zeroize for CmHmacDotBlobReq {
+    fn zeroize(&mut self) {
+        self.cmk.zeroize();
+    }
+}
+
 /// Calls Caliptra to compute an HMAC over DotBlobFields.
 pub(crate) fn cm_hmac(
     soc_manager: &mut caliptra_mcu_romtime::CaliptraSoC,
@@ -392,17 +417,23 @@ pub(crate) fn cm_hmac(
     fields: &DotBlobFields,
 ) -> McuResult<[u32; 16]> {
     let mut resp = [0u32; core::mem::size_of::<CmHmacResp>() / 4];
-    let req = CmHmacDotBlobReq {
-        cmk: transmute!(key.0),
+    let mut req = Zeroizing::new(CmHmacDotBlobReq {
+        cmk: Cmk::default(),
         hash_algorithm: CmHashAlgorithm::Sha512.into(),
         data_size: core::mem::size_of::<DotBlobFields>() as u32,
         data: fields.clone(),
         ..Default::default()
+    });
+    req.cmk.0.copy_from_slice(&key.0);
+    let req_words = unsafe {
+        core::slice::from_raw_parts_mut(
+            core::ptr::from_mut(&mut *req).cast::<u32>(),
+            core::mem::size_of::<CmHmacDotBlobReq>() / 4,
+        )
     };
-    let mut req: [u32; core::mem::size_of::<CmHmacDotBlobReq>() / 4] = transmute!(req);
 
     if let Err(err) =
-        soc_manager.exec_mailbox_req_u32(CommandId::CM_HMAC.into(), &mut req, &mut resp)
+        soc_manager.exec_mailbox_req_u32(CommandId::CM_HMAC.into(), req_words, &mut resp)
     {
         let _ = err;
         caliptra_mcu_romtime::println!("[mcu-rom] Error computing HMAC");
@@ -594,7 +625,7 @@ pub(crate) fn burn_dot_lock_fuse(otp: &Otp, dot_fuses: &DotFuses) -> McuResult<(
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Zeroize)]
 pub struct EccP384PublicKey {
     pub x: [u32; 12],
     pub y: [u32; 12],
@@ -609,6 +640,12 @@ pub struct OverrideRequest<'a> {
     pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
 }
 
+impl Drop for OverrideRequest<'_> {
+    fn drop(&mut self) {
+        self.ecc_pub_key.zeroize();
+    }
+}
+
 /// Override challenge response containing vendor public keys and dual signatures over the challenge.
 pub struct OverrideChallengeResponse<'a> {
     pub ecc_pub_key: EccP384PublicKey,
@@ -616,6 +653,14 @@ pub struct OverrideChallengeResponse<'a> {
     pub ecc_signature_s: [u8; 48],
     pub mldsa_signature: &'a [u32; MLDSA87_SIGNATURE_SIZE_DWORDS],
     pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
+}
+
+impl Drop for OverrideChallengeResponse<'_> {
+    fn drop(&mut self) {
+        self.ecc_pub_key.zeroize();
+        self.ecc_signature_r.zeroize();
+        self.ecc_signature_s.zeroize();
+    }
 }
 
 /// Authentication parameters for a DOT override challenge/response.
@@ -655,6 +700,17 @@ pub trait RecoveryTransport {
     /// when the override completed successfully, or `false` if signature
     /// verification or fuse/flash operations failed.
     fn notify_override_result(&self, success: bool);
+
+    /// Clear transport-owned cryptographic material that is no longer needed.
+    fn zeroize_sensitive_data(&self);
+}
+
+struct RecoveryTransportZeroizeGuard<'a>(&'a dyn RecoveryTransport);
+
+impl Drop for RecoveryTransportZeroizeGuard<'_> {
+    fn drop(&mut self) {
+        self.0.zeroize_sensitive_data();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1117,6 +1173,8 @@ pub fn dot_override_challenge_flow(
         }
     };
 
+    let _transport_zeroize_guard = RecoveryTransportZeroizeGuard(transport);
+
     let request = transport.wait_for_override_request().inspect_err(|_e| {
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
@@ -1125,29 +1183,38 @@ pub fn dot_override_challenge_flow(
     // Verify vendor public key hash matches recovery PK hash in OTP fuses
     // using the caliptra-sw owner-PK-hash convention (per-dword-reversed
     // ECC || natural MLDSA).
-    let computed_hash = cm_owner_pk_hash_sha384(
-        &mut env.soc_manager,
-        &request.ecc_pub_key,
-        request.mldsa_pub_key,
-    )
-    .inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
+    let computed_hash = Zeroizing::new(
+        cm_owner_pk_hash_sha384(
+            &mut env.soc_manager,
+            &request.ecc_pub_key,
+            request.mldsa_pub_key,
+        )
+        .inspect_err(|_e| {
+            env.mci
+                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+        })?,
+    );
+
+    drop(request);
+    transport.zeroize_sensitive_data();
 
     let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
-    if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
+    let fuse_hash_bytes = Zeroizing::new(fuse_hash_bytes);
+    if !constant_time_eq::constant_time_eq(&computed_hash[..], &fuse_hash_bytes[..]) {
         caliptra_mcu_romtime::println!("[mcu-rom-dot] Vendor recovery PK hash mismatch");
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
         return Err(McuError::ROM_DOT_OVERRIDE_PK_HASH_MISMATCH);
     }
 
+    drop(computed_hash);
+    drop(fuse_hash_bytes);
+
     // Generate and send challenge
-    let challenge = cm_random_generate(&mut env.soc_manager).inspect_err(|_e| {
+    let challenge = Zeroizing::new(cm_random_generate(&mut env.soc_manager).inspect_err(|_e| {
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
+    })?);
 
     transport.send_challenge(&challenge).inspect_err(|_e| {
         env.mci
@@ -1176,6 +1243,9 @@ pub fn dot_override_challenge_flow(
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
     })?;
+
+    drop(response);
+    transport.zeroize_sensitive_data();
 
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DotOverrideSigVerified.into());

--- a/rom/src/dot_override.rs
+++ b/rom/src/dot_override.rs
@@ -27,6 +27,7 @@ use crate::{
 use caliptra_mcu_registers_generated::mci;
 use caliptra_mcu_romtime::StaticRef;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use zeroize::Zeroize;
 
 pub const CMD_DOT_UNLOCK_CHALLENGE: u32 = 0x444F_5457;
 pub const CMD_DOT_OVERRIDE: u32 = 0x444F_5458;
@@ -119,6 +120,7 @@ impl Mbox0Helpers {
     }
 
     fn send_mbox0_response(&self, data: &[u8]) {
+        self.zeroize_sram();
         let sram = &self.mci.mcu_mbox0_csr_mbox_sram;
         let sram =
             unsafe { core::slice::from_raw_parts_mut(sram.as_ptr() as *mut u32, sram.len()) };
@@ -142,12 +144,14 @@ impl Mbox0Helpers {
     }
 
     fn cmd_failure(&self) {
+        self.zeroize_sram();
         self.mci
             .mcu_mbox0_csr_mbox_cmd_status
             .write(mci::bits::MboxCmdStatus::Status::CmdFailure);
     }
 
     fn cmd_complete(&self) {
+        self.zeroize_sram();
         self.mci
             .mcu_mbox0_csr_mbox_cmd_status
             .write(mci::bits::MboxCmdStatus::Status::CmdComplete);
@@ -155,6 +159,13 @@ impl Mbox0Helpers {
 
     fn dlen(&self) -> usize {
         self.mci.mcu_mbox0_csr_mbox_dlen.get() as usize
+    }
+
+    fn zeroize_sram(&self) {
+        let sram = &self.mci.mcu_mbox0_csr_mbox_sram;
+        let sram =
+            unsafe { core::slice::from_raw_parts_mut(sram.as_ptr() as *mut u32, sram.len()) };
+        sram.zeroize();
     }
 }
 
@@ -279,5 +290,9 @@ impl RecoveryTransport for Mbox0RecoveryTransport {
         } else {
             self.helpers.cmd_failure();
         }
+    }
+
+    fn zeroize_sensitive_data(&self) {
+        self.helpers.zeroize_sram();
     }
 }

--- a/rom/src/i3c_mailbox.rs
+++ b/rom/src/i3c_mailbox.rs
@@ -5,6 +5,7 @@ use caliptra_mcu_registers_generated::i3c;
 use caliptra_mcu_registers_generated::i3c::bits::{InterruptStatus, Status, TtiResetControl};
 use caliptra_mcu_romtime::StaticRef;
 use tock_registers::interfaces::{Readable, Writeable};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 /// I3C Mandatory Data Byte for service IBI notifications.
 const MDB_SERVICES: u8 = 0x1F;
@@ -80,6 +81,7 @@ pub struct DotContext<'a> {
 }
 
 /// Tracks state for the multi-message DOT_OVERRIDE challenge/response flow.
+#[derive(Zeroize, ZeroizeOnDrop)]
 enum OverrideState {
     /// No override in progress.
     Idle,
@@ -102,7 +104,7 @@ pub struct I3cMailboxHandler<'a> {
     dot_ctx: Option<DotContext<'a>>,
     override_state: OverrideState,
     /// Word-aligned reassembly buffer (backed by MCI mailbox SRAM).
-    reassembly_buf: &'a mut [u32],
+    reassembly_buf: &'a mut [u32; MAX_REASSEMBLY_WORDS],
     /// Number of payload bytes accumulated so far.
     reassembly_len: usize,
     reassembly_cmd: u8,
@@ -116,7 +118,7 @@ impl<'a> I3cMailboxHandler<'a> {
         services: crate::I3cServicesModes,
         target_addr: u8,
         dot_ctx: Option<DotContext<'a>>,
-        reassembly_buf: &'a mut [u32],
+        reassembly_buf: &'a mut [u32; MAX_REASSEMBLY_WORDS],
     ) -> Self {
         use caliptra_mcu_registers_generated::i3c::bits::StbyCrDeviceAddr;
         // Prefer the dynamic address assigned by the controller; fall back
@@ -161,7 +163,9 @@ impl<'a> I3cMailboxHandler<'a> {
 
         for _ in 0..MAX_POLL_ITERATIONS {
             if let Some((cmd, payload_len)) = self.try_receive_reassembled_command() {
-                match self.dispatch(cmd, payload_len) {
+                let result = self.dispatch(cmd, payload_len);
+                self.zeroize_reassembly();
+                match result {
                     DispatchResult::Continue => {}
                     DispatchResult::Done => return Ok(()),
                 }
@@ -169,6 +173,9 @@ impl<'a> I3cMailboxHandler<'a> {
         }
 
         caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] I3C services timed out");
+        self.zeroize_reassembly();
+        self.override_state.zeroize();
+        self.reset_data_queues();
         Err(McuError::ROM_COLD_BOOT_DOT_ERROR)
     }
 
@@ -207,7 +214,10 @@ impl<'a> I3cMailboxHandler<'a> {
     /// Handle DOT_STATUS: return current DOT fuse state.
     fn handle_dot_status(&mut self) -> DispatchResult {
         caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] DOT_STATUS received");
-        let ctx = self.dot_ctx.as_ref().unwrap();
+        let Some(ctx) = self.dot_ctx.as_ref() else {
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        };
         // Response: [status, enabled, locked, burned_lo, burned_hi]
         let enabled = ctx.dot_fuses.enabled as u8;
         let locked = ctx.dot_fuses.is_locked() as u8;
@@ -234,18 +244,24 @@ impl<'a> I3cMailboxHandler<'a> {
             return DispatchResult::Continue;
         }
 
-        let mut blob_bytes = [0u8; crate::DOT_BLOB_SIZE];
-        read_bytes_from_words(self.reassembly_buf, 0, &mut blob_bytes);
+        let mut blob_bytes = Zeroizing::new([0u8; crate::DOT_BLOB_SIZE]);
+        read_bytes_from_words(self.reassembly_buf, 0, &mut blob_bytes[..]);
 
-        let result = {
-            let ctx = self.dot_ctx.as_mut().unwrap();
+        let (result, mci) = {
+            let Some(ctx) = self.dot_ctx.as_mut() else {
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            };
             let key_type = ctx.key_type;
-            crate::device_ownership_transfer::verify_and_write_recovery_blob(
-                ctx.soc_manager,
-                ctx.dot_fuses,
-                &blob_bytes,
-                ctx.dot_flash,
-                key_type,
+            (
+                crate::device_ownership_transfer::verify_and_write_recovery_blob(
+                    ctx.soc_manager,
+                    ctx.dot_fuses,
+                    &blob_bytes,
+                    ctx.dot_flash,
+                    key_type,
+                ),
+                ctx.mci,
             )
         };
 
@@ -255,8 +271,7 @@ impl<'a> I3cMailboxHandler<'a> {
                     "[mcu-rom-i3c-svc] DOT_RECOVERY succeeded, triggering reset"
                 );
                 self.send_status(STATUS_SUCCESS);
-                let ctx = self.dot_ctx.as_ref().unwrap();
-                ctx.mci.trigger_warm_reset();
+                mci.trigger_warm_reset();
                 return DispatchResult::Done;
             }
             Err(err) => {
@@ -289,16 +304,21 @@ impl<'a> I3cMailboxHandler<'a> {
         }
 
         // ECC public key (all offsets are word-aligned)
-        let mut ecc_x = [0u32; 12];
-        let mut ecc_y = [0u32; 12];
-        read_words(self.reassembly_buf, 0, &mut ecc_x);
-        read_words(self.reassembly_buf, 12, &mut ecc_y);
+        let mut ecc_key = Zeroizing::new(crate::EccP384PublicKey {
+            x: [0u32; 12],
+            y: [0u32; 12],
+        });
+        read_words(self.reassembly_buf, 0, &mut ecc_key.x);
+        read_words(self.reassembly_buf, 12, &mut ecc_key.y);
 
         // MLDSA public key
-        let mut mldsa_pub_key = [0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS];
-        read_words(self.reassembly_buf, 24, &mut mldsa_pub_key);
+        let mut mldsa_pub_key = Zeroizing::new([0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS]);
+        read_words(self.reassembly_buf, 24, &mut mldsa_pub_key[..]);
 
-        let ctx = self.dot_ctx.as_mut().unwrap();
+        let Some(ctx) = self.dot_ctx.as_mut() else {
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        };
 
         // Verify device is in locked state
         if !ctx.dot_fuses.is_locked() {
@@ -320,36 +340,37 @@ impl<'a> I3cMailboxHandler<'a> {
             }
         };
 
-        let ecc_key = crate::EccP384PublicKey { x: ecc_x, y: ecc_y };
-
-        let computed_hash = match crate::device_ownership_transfer::cm_owner_pk_hash_sha384(
-            ctx.soc_manager,
-            &ecc_key,
-            &mldsa_pub_key,
-        ) {
-            Ok(h) => h,
-            Err(err) => {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom-i3c-svc] PK hash computation failed: {}",
-                    caliptra_mcu_romtime::HexWord(err.into())
-                );
-                self.send_status(STATUS_ERROR);
-                return DispatchResult::Continue;
-            }
-        };
+        let computed_hash = Zeroizing::new(
+            match crate::device_ownership_transfer::cm_owner_pk_hash_sha384(
+                ctx.soc_manager,
+                &ecc_key,
+                &mldsa_pub_key[..],
+            ) {
+                Ok(h) => h,
+                Err(err) => {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom-i3c-svc] PK hash computation failed: {}",
+                        caliptra_mcu_romtime::HexWord(err.into())
+                    );
+                    self.send_status(STATUS_ERROR);
+                    return DispatchResult::Continue;
+                }
+            },
+        );
 
         let fuse_hash_bytes: [u8; 48] = zerocopy::transmute!(recovery_pk_hash.0);
-        if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
+        let fuse_hash_bytes = Zeroizing::new(fuse_hash_bytes);
+        if !constant_time_eq::constant_time_eq(&computed_hash[..], &fuse_hash_bytes[..]) {
             caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] Vendor recovery PK hash mismatch");
             #[cfg(feature = "test-i3c-services")]
             {
                 caliptra_mcu_romtime::println!(
                     "[mcu-rom-i3c-svc] computed: {}",
-                    caliptra_mcu_romtime::HexBytes(&computed_hash)
+                    caliptra_mcu_romtime::HexBytes(&computed_hash[..])
                 );
                 caliptra_mcu_romtime::println!(
                     "[mcu-rom-i3c-svc] fuse:     {}",
-                    caliptra_mcu_romtime::HexBytes(&fuse_hash_bytes)
+                    caliptra_mcu_romtime::HexBytes(&fuse_hash_bytes[..])
                 );
             }
             self.send_status(STATUS_ERROR);
@@ -358,8 +379,9 @@ impl<'a> I3cMailboxHandler<'a> {
         caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] Vendor PK hash verified");
 
         // Generate random challenge
-        let challenge = match crate::device_ownership_transfer::cm_random_generate(ctx.soc_manager)
-        {
+        let challenge = Zeroizing::new(match crate::device_ownership_transfer::cm_random_generate(
+            ctx.soc_manager,
+        ) {
             Ok(c) => c,
             Err(err) => {
                 caliptra_mcu_romtime::println!(
@@ -369,16 +391,17 @@ impl<'a> I3cMailboxHandler<'a> {
                 self.send_status(STATUS_ERROR);
                 return DispatchResult::Continue;
             }
-        };
+        });
 
         // Release mutable borrow before calling self.send_response
 
         // Send challenge as response
-        self.send_response(STATUS_SUCCESS, &challenge);
-        self.override_state = OverrideState::ChallengeSent { challenge };
+        self.send_response(STATUS_SUCCESS, &challenge[..]);
+        self.override_state = OverrideState::ChallengeSent {
+            challenge: *challenge,
+        };
         caliptra_mcu_romtime::println!(
-            "[mcu-rom-i3c-svc] Challenge sent, waiting for DOT_OVERRIDE: {}",
-            caliptra_mcu_romtime::HexBytes(&challenge),
+            "[mcu-rom-i3c-svc] Challenge sent, waiting for DOT_OVERRIDE"
         );
         DispatchResult::Continue
     }
@@ -394,7 +417,7 @@ impl<'a> I3cMailboxHandler<'a> {
         caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] DOT_OVERRIDE received");
 
         // Verify we're in the correct state
-        let challenge = match &self.override_state {
+        let challenge = Zeroizing::new(match &self.override_state {
             OverrideState::ChallengeSent { challenge } => *challenge,
             OverrideState::Idle => {
                 caliptra_mcu_romtime::println!(
@@ -403,7 +426,7 @@ impl<'a> I3cMailboxHandler<'a> {
                 self.send_status(STATUS_ERROR);
                 return DispatchResult::Continue;
             }
-        };
+        });
 
         // Reset override state
         self.override_state = OverrideState::Idle;
@@ -422,35 +445,41 @@ impl<'a> I3cMailboxHandler<'a> {
             return DispatchResult::Continue;
         }
 
-        let payload = &self.reassembly_buf;
+        let payload = &self.reassembly_buf[..];
         let mut woff = 0usize; // word offset
 
         // ECC PK
-        let mut ecc_x = [0u32; 12];
-        let mut ecc_y = [0u32; 12];
-        read_words(payload, woff, &mut ecc_x);
+        let mut ecc_key = Zeroizing::new(crate::EccP384PublicKey {
+            x: [0u32; 12],
+            y: [0u32; 12],
+        });
+        read_words(payload, woff, &mut ecc_key.x);
         woff += 12;
-        read_words(payload, woff, &mut ecc_y);
+        read_words(payload, woff, &mut ecc_key.y);
         woff += 12;
 
         // ECC signature (read as bytes from word-aligned data)
-        let mut ecc_sig_r = [0u8; 48];
-        let mut ecc_sig_s = [0u8; 48];
-        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_r);
+        let mut ecc_sig_r = Zeroizing::new([0u8; 48]);
+        let mut ecc_sig_s = Zeroizing::new([0u8; 48]);
+        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_r[..]);
         woff += 12;
-        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_s);
+        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_s[..]);
         woff += 12;
 
         // MLDSA PK
-        let mut mldsa_pub_key = [0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS];
-        read_words(payload, woff, &mut mldsa_pub_key);
+        let mut mldsa_pub_key = Zeroizing::new([0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS]);
+        read_words(payload, woff, &mut mldsa_pub_key[..]);
         woff += crate::MLDSA87_PUB_KEY_SIZE_DWORDS;
 
         // MLDSA signature
-        let mut mldsa_signature = [0u32; crate::MLDSA87_SIGNATURE_SIZE_DWORDS];
-        read_words(payload, woff, &mut mldsa_signature);
+        let mut mldsa_signature = Zeroizing::new([0u32; crate::MLDSA87_SIGNATURE_SIZE_DWORDS]);
+        read_words(payload, woff, &mut mldsa_signature[..]);
 
-        let ctx = self.dot_ctx.as_mut().unwrap();
+        let Some(ctx) = self.dot_ctx.as_mut() else {
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        };
+        let mci = ctx.mci;
 
         let recovery_pk_hash = match ctx.dot_fuses.recovery_pk_hash.as_ref() {
             Some(hash) => hash,
@@ -460,7 +489,6 @@ impl<'a> I3cMailboxHandler<'a> {
             }
         };
 
-        let ecc_key = crate::EccP384PublicKey { x: ecc_x, y: ecc_y };
         let auth = crate::device_ownership_transfer::OverrideAuth {
             ecc_key: &ecc_key,
             ecc_sig_r: &ecc_sig_r,
@@ -500,8 +528,7 @@ impl<'a> I3cMailboxHandler<'a> {
 
         caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] DOT override complete, triggering reset");
         self.send_status(STATUS_SUCCESS);
-        let ctx = self.dot_ctx.as_ref().unwrap();
-        ctx.mci.trigger_warm_reset();
+        mci.trigger_warm_reset();
         DispatchResult::Done
     }
 
@@ -514,7 +541,7 @@ impl<'a> I3cMailboxHandler<'a> {
 
     /// Send a response with status byte followed by data via TX (private read).
     fn send_response(&self, status: u8, data: &[u8]) {
-        let mut buf = [0u8; 64];
+        let mut buf = Zeroizing::new([0u8; 64]);
         buf[0] = status;
         let copy_len = data.len().min(buf.len() - 1);
         let mut i = 0;
@@ -623,6 +650,15 @@ impl<'a> I3cMailboxHandler<'a> {
             .write(TtiResetControl::IbiQueueRst::SET + TtiResetControl::IbiRetryCtrRst::SET);
     }
 
+    fn reset_data_queues(&self) {
+        self.registers.tti_tti_reset_control.write(
+            TtiResetControl::RxDataRst::SET
+                + TtiResetControl::TxDataRst::SET
+                + TtiResetControl::RxDescRst::SET
+                + TtiResetControl::TxDescRst::SET,
+        );
+    }
+
     /// Try to receive and reassemble a complete command from packetized
     /// I3C private writes. Returns `Some((cmd, payload_len))` when all
     /// packets have arrived. The payload data is in the static `REASSEMBLY_BUF`.
@@ -639,13 +675,16 @@ impl<'a> I3cMailboxHandler<'a> {
         let rx_desc = regs.tti_rx_desc_queue_port.get();
         let data_len = (rx_desc & 0xFFFF) as usize;
         if data_len < PACKET_HEADER_SIZE {
+            if data_len != 0 {
+                self.zeroize_reassembly();
+            }
             return None;
         }
 
         // Read all words from the RX FIFO
         let total_words = data_len.div_ceil(4);
         let read_words = total_words.min(MAX_RX_WORDS);
-        let mut buf = [0u32; MAX_RX_WORDS];
+        let mut buf = Zeroizing::new([0u32; MAX_RX_WORDS]);
         let mut i = 0;
         while i < read_words {
             buf[i] = regs.tti_rx_data_port.get();
@@ -660,6 +699,7 @@ impl<'a> I3cMailboxHandler<'a> {
         let total_seqs = first_word[3];
 
         if total_seqs == 0 {
+            self.zeroize_reassembly();
             return None;
         }
 
@@ -679,6 +719,7 @@ impl<'a> I3cMailboxHandler<'a> {
         let buf_capacity = self.reassembly_buf.len() * 4; // in bytes
 
         if total_seqs == 1 {
+            self.zeroize_reassembly();
             self.reassembly_len = copy_bytes.min(buf_capacity);
             copy_payload_words(&buf, 1, self.reassembly_buf, 0, copy_words);
             return Some((cmd, self.reassembly_len));
@@ -686,6 +727,7 @@ impl<'a> I3cMailboxHandler<'a> {
 
         // Multi-packet: validate sequence
         if seq_num == 0 {
+            self.zeroize_reassembly();
             self.reassembly_cmd = cmd;
             self.reassembly_total = total_seqs;
             self.reassembly_next_seq = 1;
@@ -710,9 +752,7 @@ impl<'a> I3cMailboxHandler<'a> {
                 self.reassembly_next_seq,
                 self.reassembly_total,
             );
-            self.reassembly_len = 0;
-            self.reassembly_next_seq = 0;
-            self.reassembly_total = 0;
+            self.zeroize_reassembly();
             return None;
         }
 
@@ -731,6 +771,21 @@ impl<'a> I3cMailboxHandler<'a> {
     #[allow(dead_code)]
     pub fn services(&self) -> crate::I3cServicesModes {
         self.services
+    }
+
+    fn zeroize_reassembly(&mut self) {
+        self.reassembly_buf.zeroize();
+        self.reassembly_len = 0;
+        self.reassembly_cmd = 0;
+        self.reassembly_total = 0;
+        self.reassembly_next_seq = 0;
+    }
+}
+
+impl Drop for I3cMailboxHandler<'_> {
+    fn drop(&mut self) {
+        self.zeroize_reassembly();
+        self.override_state.zeroize();
     }
 }
 

--- a/runtime/kernel/capsules/src/doe/driver.rs
+++ b/runtime/kernel/capsules/src/doe/driver.rs
@@ -131,17 +131,31 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
 
     fn handle_doe_discovery(&self, doe_req: DoeDiscoveryRequest) {
         let data_object_protocol = DataObjectType::from(doe_req.index());
-        if data_object_protocol == DataObjectType::Unsupported {
-            capsule_debug!("DOE", "Unsupported DOE Discovery Request");
-            return;
-        }
 
-        let next_index = (data_object_protocol as u8 + 1) % NUM_DATA_OBJECT_PROTOCOL_TYPES as u8;
+        // An out-of-range index or an unsupported Discovery Version is still
+        // answered, with a Vendor ID of FFFFh, so the requester is not left waiting.
+        let unsupported =
+            !doe_req.is_version_supported() || data_object_protocol == DataObjectType::Unsupported;
 
+        let discovery_response = if unsupported {
+            capsule_debug!(
+                "DOE",
+                "Unsupported DOE Discovery Request: index {}, version {}",
+                doe_req.index(),
+                doe_req.version()
+            );
+            DoeDiscoveryResponse::unsupported()
+        } else {
+            let next_index =
+                (data_object_protocol as u8 + 1) % NUM_DATA_OBJECT_PROTOCOL_TYPES as u8;
+            DoeDiscoveryResponse::new(data_object_protocol as u8, next_index)
+        };
+
+        self.send_doe_discovery_response(discovery_response);
+    }
+
+    fn send_doe_discovery_response(&self, discovery_response: DoeDiscoveryResponse) {
         let mut doe_resp = [0u32; DOE_DISCOVERY_DATA_OBJECT_LEN_DW];
-
-        // Prepare the DOE Discovery Response
-        let discovery_response = DoeDiscoveryResponse::new(data_object_protocol as u8, next_index);
 
         // Prepare the response buffer
         let doe_header = DoeDataObjectHeader::new(DOE_DISCOVERY_DATA_OBJECT_LEN_DW as u32);

--- a/runtime/kernel/capsules/src/doe/protocol.rs
+++ b/runtime/kernel/capsules/src/doe/protocol.rs
@@ -14,6 +14,18 @@ const LENGTH_MASK: u32 = (1 << LENGTH_FIELD_BITS) - 1;
 const PCISIG_DOE_VENDOR_ID: u16 = 0x0001;
 const LENGTH_FIELD_BITS: u32 = 18;
 
+/// Vendor ID reported in a DOE Discovery Response when there is no Data Object
+/// Protocol associated with the requested index.
+const UNSUPPORTED_VENDOR_ID: u16 = 0xFFFF;
+
+/// DOE Discovery Version used when the DOE Extended Capability Version is 01h.
+/// The field is reserved (and therefore zero) in that revision.
+const DOE_DISCOVERY_VERSION_LEGACY: u8 = 0x00;
+
+/// DOE Discovery Version required when the DOE Extended Capability Version is
+/// 02h or greater.
+const DOE_DISCOVERY_VERSION_2: u8 = 0x02;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
 pub enum DataObjectType {
@@ -126,12 +138,20 @@ bitfield! {
     pub struct DoeDiscoveryRequest(u32);
     impl Debug;
     pub u8, index, _: 7, 0;
-    u32, reserved_1, _: 31, 8;
+    pub u8, version, _: 15, 8;
+    u16, reserved_1, _: 31, 16;
 }
 
 impl DoeDiscoveryRequest {
     pub fn decode(data: u32) -> Self {
         Self(data)
+    }
+
+    pub fn is_version_supported(&self) -> bool {
+        matches!(
+            self.version(),
+            DOE_DISCOVERY_VERSION_LEGACY | DOE_DISCOVERY_VERSION_2
+        )
     }
 }
 
@@ -151,6 +171,15 @@ impl DoeDiscoveryResponse {
         response.set_vendor_id(PCISIG_DOE_VENDOR_ID);
         response.set_data_object_protocol(data_object_protocol);
         response.set_next_index(next_index);
+        response
+    }
+
+    /// Response for a request that cannot be satisfied, i.e. the index is out of
+    /// range or the DOE Discovery Version is not supported. A Vendor ID of FFFFh
+    /// tells the requester there is no Data Object Protocol at the requested index.
+    pub fn unsupported() -> Self {
+        let mut response = Self(0);
+        response.set_vendor_id(UNSUPPORTED_VENDOR_ID);
         response
     }
 


### PR DESCRIPTION
## Summary

- zeroize private signing inputs and trust-anchor certificate storage
- scrub DOT recovery, mailbox SRAM, and I3C reassembly buffers on all exits
- zeroize derived CMKs and CM_HMAC request copies without introducing ROM panic paths

## Validation

- `cargo test -p caliptra-mcu-command-auth-challenge-signer -p caliptra-mcu-rom-common`
- `cargo test --manifest-path ocp-eat-verifier/Cargo.toml -p ocptoken-lib`
- `cargo xtask panic-check --variants emulator:`
- `cargo xtask panic-check --variants fpga:`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`