### PR TITLE
[tests] Add end-to-end integration tests for offline manifest signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "p384",
  "rand 0.8.5",
  "random-port",
+ "serde_json",
  "sha2",
  "simple_logger",
  "tempfile",

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -950,14 +950,50 @@ fn main() -> Result<()> {
         Ok((path, signing_request))
     }
 
+    /// Loads an LMS public key from a file path.
+    ///
+    /// Unlike ECC (`Crypto::ecc_pub_key_from_pem`) and ML-DSA (`Crypto::mldsa_pub_key_from_file`)
+    /// which are provided by upstream `caliptra-image-crypto`, `caliptra_image_crypto::lms_pub_key_from_pem`
+    /// does not handle standard SubjectPublicKeyInfo (SPKI) headers in PEM files. This helper
+    /// attempts:
+    /// 1. `caliptra_image_crypto::lms_pub_key_from_pem`
+    /// 2. Raw binary byte parsing (`ImageLmsPublicKey::read_from_bytes`)
+    /// 3. PEM decoding by stripping headers and extracting the 48-byte LMS public key from the SPKI DER payload
+    fn load_lms_pub_key(path: &Path) -> Result<caliptra_image_types::ImageLmsPublicKey> {
+        use zerocopy::FromBytes;
+        if let Ok(pub_key) = caliptra_image_crypto::lms_pub_key_from_pem(&path.to_path_buf()) {
+            return Ok(pub_key);
+        }
+        let data = std::fs::read(path)?;
+        if let Ok(pub_key) = caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&data) {
+            return Ok(pub_key);
+        }
+        if let Ok(pem_str) = std::str::from_utf8(&data) {
+            let b64_lines: String = pem_str
+                .lines()
+                .filter(|l| !l.starts_with("-----"))
+                .collect::<Vec<_>>()
+                .join("");
+            if let Ok(der) = openssl::base64::decode_block(&b64_lines) {
+                if der.len() >= 48 {
+                    let start = der.len() - 48;
+                    if let Ok(pub_key) =
+                        caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&der[start..])
+                    {
+                        return Ok(pub_key);
+                    }
+                }
+            }
+        }
+        anyhow::bail!("Failed to parse LMS public key from {}", path.display())
+    }
+
     /// Creates an unsigned `AuthorizationManifest` with the specified image metadata list and public key paths.
     fn create_unsigned_auth_manifest_with_metadata(
         image_metadata_list: Vec<AuthManifestImageMetadata>,
         svn: u32,
         pub_key_paths: Option<&AuthManifestPubKeysPaths>,
     ) -> Result<AuthorizationManifest> {
-        use zerocopy::FromBytes;
-
         let empty_paths = AuthManifestPubKeysPaths::default();
         let keys = pub_key_paths.unwrap_or(&empty_paths);
 
@@ -967,10 +1003,7 @@ fn main() -> Result<()> {
             VENDOR_ECC_KEY_0_PUBLIC
         };
         let vendor_fw_lms_pub = if let Some(path) = keys.vendor_fw_lms_pub_key {
-            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
-                .map_err(|_| {
-                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
-                })?
+            Self::load_lms_pub_key(path)?
         } else {
             VENDOR_LMS_KEY_0_PUBLIC
         };
@@ -986,10 +1019,7 @@ fn main() -> Result<()> {
             VENDOR_ECC_KEY_1_PUBLIC
         };
         let vendor_man_lms_pub = if let Some(path) = keys.vendor_man_lms_pub_key {
-            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
-                .map_err(|_| {
-                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
-                })?
+            Self::load_lms_pub_key(path)?
         } else {
             VENDOR_LMS_KEY_1_PUBLIC
         };
@@ -1005,10 +1035,7 @@ fn main() -> Result<()> {
             OWNER_ECC_KEY_PUBLIC
         };
         let owner_fw_lms_pub = if let Some(path) = keys.owner_fw_lms_pub_key {
-            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
-                .map_err(|_| {
-                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
-                })?
+            Self::load_lms_pub_key(path)?
         } else {
             OWNER_LMS_KEY_PUBLIC
         };
@@ -1024,10 +1051,7 @@ fn main() -> Result<()> {
             OWNER_ECC_KEY_PUBLIC
         };
         let owner_man_lms_pub = if let Some(path) = keys.owner_man_lms_pub_key {
-            caliptra_image_types::ImageLmsPublicKey::read_from_bytes(&std::fs::read(path)?)
-                .map_err(|_| {
-                    anyhow::anyhow!("Failed to parse LMS public key from {}", path.display())
-                })?
+            Self::load_lms_pub_key(path)?
         } else {
             OWNER_LMS_KEY_PUBLIC
         };

--- a/builder/src/offline_signing.rs
+++ b/builder/src/offline_signing.rs
@@ -180,9 +180,10 @@ impl ImagePqcSignatureExt for ImagePqcSignature {
                 max_size
             ));
         }
-        if bytes.len() != 2420 && bytes.len() != 4627 {
+        if bytes.len() != 1620 && bytes.len() != 2420 && bytes.len() != 4627 && bytes.len() != 4628
+        {
             return Err(anyhow!(
-                "Invalid PQC signature length {} (expected LMS 2420 bytes or ML-DSA-87 4627 bytes)",
+                "Invalid PQC signature length {} (expected LMS 1620/2420 bytes or ML-DSA-87 4627/4628 bytes)",
                 bytes.len()
             ));
         }
@@ -196,9 +197,13 @@ impl ImagePqcSignatureExt for ImagePqcSignature {
             return Err(anyhow!("PQC signature cannot be zero-filled"));
         }
         let non_zero_len = bytes.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
-        if non_zero_len != 2420 && non_zero_len != 4627 {
+        if non_zero_len != 1620
+            && non_zero_len != 2420
+            && non_zero_len != 4627
+            && non_zero_len != 4628
+        {
             return Err(anyhow!(
-                "Invalid PQC signature payload size {} (expected LMS 2420 bytes or ML-DSA-87 4627 bytes)",
+                "Invalid PQC signature payload size {} (expected LMS 1620/2420 bytes or ML-DSA-87 4627/4628 bytes)",
                 non_zero_len
             ));
         }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -21,8 +21,8 @@ caliptra-auth-man-types.workspace = true
 caliptra-builder.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-hw-model.workspace = true
-caliptra-image-gen.workspace = true
 caliptra-image-crypto.workspace = true
+caliptra-image-gen.workspace = true
 caliptra-image-types = { workspace = true, features = ["std"] }
 caliptra-image-fake-keys.workspace = true
 chrono.workspace = true
@@ -69,6 +69,7 @@ simple_logger.workspace = true
 openssl.workspace = true
 caliptra-mcu-romtime.workspace = true
 tempfile.workspace = true
+serde_json.workspace = true
 uio = { workspace = true, optional = true }
 uuid.workspace = true
 zerocopy.workspace = true

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -33,6 +33,7 @@ mod test_mctp_vdm_cmds;
 mod test_mctp_vdm_validator;
 mod test_mcu_mbox;
 mod test_ocp_dev_identity_provision_tool;
+mod test_offline_signing;
 mod test_pldm_fw_update;
 mod test_raw_lifecycle_boot;
 mod test_soc_boot;

--- a/tests/integration/src/test_offline_signing.rs
+++ b/tests/integration/src/test_offline_signing.rs
@@ -1,0 +1,483 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use caliptra_auth_man_types::AuthorizationManifest;
+    use caliptra_image_crypto::RustCrypto as Crypto;
+    use caliptra_image_gen::ImageGeneratorCrypto;
+    use caliptra_mcu_builder::offline_signing::{
+        attach_auth_manifest_signatures, verify_ecdsa384_signature, ImagePqcSignatureExt,
+    };
+    use caliptra_mcu_builder::{
+        caliptra_sw_workspace_root, AuthManifestPubKeysPaths, CaliptraBuildArgs, CaliptraBuilder,
+        ImageCfg,
+    };
+    use caliptra_mcu_fw_signer::{generate_offline_signatures, KeyManifest, KeyManifestEntry};
+    use sha2::Digest;
+    use tempfile::tempdir;
+    use zerocopy::{FromBytes, IntoBytes};
+
+    #[test]
+    fn test_e2e_offline_manifest_signing_flow_mldsa() {
+        let temp_dir = tempdir().unwrap();
+        let work_dir = temp_dir.path();
+
+        let sw_root = caliptra_sw_workspace_root();
+        let keys_dir = sw_root.join("image/fake-keys/keys");
+
+        let vendor_fw_ecc_key = keys_dir.join("vendor_ecc_0_key.pem");
+        let vendor_fw_ecc_pub = keys_dir.join("vendor_ecc_0_pub.pem");
+        let vendor_fw_mldsa_key = keys_dir.join("vendor_mldsa_0_key.pem");
+        let vendor_fw_mldsa_pub = keys_dir.join("vendor_mldsa_0_pub.pem");
+
+        let owner_fw_ecc_key = keys_dir.join("owner_ecc_key.pem");
+        let owner_fw_ecc_pub = keys_dir.join("owner_ecc_pub.pem");
+        let owner_fw_mldsa_key = keys_dir.join("owner_mldsa_key.pem");
+        let owner_fw_mldsa_pub = keys_dir.join("owner_mldsa_pub.pem");
+
+        let vendor_man_ecc_key = keys_dir.join("vendor_ecc_1_key.pem");
+        let vendor_man_ecc_pub = keys_dir.join("vendor_ecc_1_pub.pem");
+        let vendor_man_mldsa_key = keys_dir.join("vendor_mldsa_1_key.pem");
+        let vendor_man_mldsa_pub = keys_dir.join("vendor_mldsa_1_pub.pem");
+
+        let owner_man_ecc_key = keys_dir.join("owner_ecc_key.pem");
+        let owner_man_ecc_pub = keys_dir.join("owner_ecc_pub.pem");
+        let owner_man_mldsa_key = keys_dir.join("owner_mldsa_key.pem");
+        let owner_man_mldsa_pub = keys_dir.join("owner_mldsa_pub.pem");
+
+        // 1. Create dummy MCU and SoC image files
+        let mcu_bin = work_dir.join("mcu-runtime.bin");
+        std::fs::write(&mcu_bin, vec![0xa5u8; 1024]).unwrap();
+
+        let soc_bin = work_dir.join("soc-fw.bin");
+        std::fs::write(&soc_bin, vec![0x5au8; 2048]).unwrap();
+
+        let unsigned_manifest_path = work_dir.join("unsigned_auth_manifest.bin");
+        let signing_request_path = work_dir.join("signing_request.json");
+        let signatures_path = work_dir.join("signatures.json");
+        let signed_manifest_path = work_dir.join("signed_auth_manifest.bin");
+
+        let mcu_image_cfg = ImageCfg {
+            path: mcu_bin,
+            network_filename: None,
+            load_addr: 0xA800_0000,
+            staging_addr: 0x6000_0000,
+            image_id: 1,
+            exec_bit: 2,
+            component_id: 0,
+            is_tcb: true,
+            is_ak_target: false,
+            feature: "test".to_string(),
+        };
+
+        let soc_image_cfg = ImageCfg {
+            path: soc_bin,
+            network_filename: None,
+            load_addr: 0x8000_0000,
+            staging_addr: 0x6000_0000,
+            image_id: 2,
+            exec_bit: 2,
+            component_id: 1,
+            is_tcb: false,
+            is_ak_target: false,
+            feature: "test".to_string(),
+        };
+
+        // Step 1: Create unsigned manifest and export signing request
+        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+            mcu_firmware: Some(mcu_image_cfg.path.clone()),
+            soc_images: Some(vec![soc_image_cfg]),
+            mcu_image_cfg: Some(mcu_image_cfg),
+            soc_manifest_svn: Some(1),
+            ..Default::default()
+        });
+
+        let key_paths = AuthManifestPubKeysPaths {
+            vendor_fw_ecc_pub_key: Some(&vendor_fw_ecc_pub),
+            vendor_fw_mldsa_pub_key: Some(&vendor_fw_mldsa_pub),
+            owner_fw_ecc_pub_key: Some(&owner_fw_ecc_pub),
+            owner_fw_mldsa_pub_key: Some(&owner_fw_mldsa_pub),
+            vendor_man_ecc_pub_key: Some(&vendor_man_ecc_pub),
+            vendor_man_mldsa_pub_key: Some(&vendor_man_mldsa_pub),
+            owner_man_ecc_pub_key: Some(&owner_man_ecc_pub),
+            owner_man_mldsa_pub_key: Some(&owner_man_mldsa_pub),
+            ..Default::default()
+        };
+
+        let (path, signing_req) = builder
+            .get_unsigned_auth_manifest(
+                Some(unsigned_manifest_path.to_str().unwrap()),
+                Some(&key_paths),
+            )
+            .unwrap();
+
+        let req_json_bytes = serde_json::to_string_pretty(&signing_req).unwrap();
+        std::fs::write(&signing_request_path, req_json_bytes).unwrap();
+
+        assert!(path.exists());
+        assert!(signing_request_path.exists());
+
+        // Step 2: Compute offline signatures for signing request using fw-signer
+        let key_manifest = KeyManifest {
+            vendor_fw: KeyManifestEntry {
+                ecc_priv_key: vendor_fw_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_fw_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: vendor_fw_mldsa_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(vendor_fw_mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            owner_fw: KeyManifestEntry {
+                ecc_priv_key: owner_fw_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_fw_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: owner_fw_mldsa_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(owner_fw_mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            vendor_man: KeyManifestEntry {
+                ecc_priv_key: vendor_man_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_man_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: vendor_man_mldsa_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(vendor_man_mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+            owner_man: KeyManifestEntry {
+                ecc_priv_key: owner_man_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_man_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: owner_man_mldsa_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(owner_man_mldsa_pub.to_str().unwrap().to_string()),
+                pqc_type: "MLDSA".to_string(),
+            },
+        };
+
+        generate_offline_signatures(&signing_request_path, &key_manifest, &signatures_path)
+            .unwrap();
+
+        assert!(signatures_path.exists());
+
+        // Step 3: Reattach signatures and verify output
+        attach_auth_manifest_signatures(
+            &unsigned_manifest_path,
+            &signatures_path,
+            Some(&vendor_fw_ecc_pub),
+            Some(&owner_fw_ecc_pub),
+            &signed_manifest_path,
+        )
+        .unwrap();
+
+        assert!(signed_manifest_path.exists());
+
+        // Step 4: Parse final signed manifest and verify cryptographic signatures
+        let signed_data = std::fs::read(&signed_manifest_path).unwrap();
+        let manifest = AuthorizationManifest::read_from_bytes(&signed_data).unwrap();
+
+        assert_eq!(manifest.preamble.version, 1);
+        assert_eq!(manifest.preamble.svn, 1);
+
+        let vendor_fw_pub_key = Crypto::ecc_pub_key_from_pem(&vendor_fw_ecc_pub).unwrap();
+        let owner_fw_pub_key = Crypto::ecc_pub_key_from_pem(&owner_fw_ecc_pub).unwrap();
+
+        let vendor_range =
+            caliptra_auth_man_types::AuthManifestPreamble::vendor_signed_data_range();
+        let vendor_signed_bytes = manifest
+            .preamble
+            .as_bytes()
+            .get(vendor_range.start as usize..vendor_range.end as usize)
+            .unwrap();
+        let vendor_digest: [u8; 48] = sha2::Sha384::digest(vendor_signed_bytes).into();
+
+        verify_ecdsa384_signature(
+            &vendor_digest,
+            &vendor_fw_pub_key,
+            &manifest.preamble.vendor_pub_keys_signatures.ecc_sig,
+        )
+        .expect("Vendor pub keys signature verification failed");
+
+        let owner_bytes = manifest.preamble.owner_pub_keys.as_bytes();
+        let owner_digest: [u8; 48] = sha2::Sha384::digest(owner_bytes).into();
+
+        verify_ecdsa384_signature(
+            &owner_digest,
+            &owner_fw_pub_key,
+            &manifest.preamble.owner_pub_keys_signatures.ecc_sig,
+        )
+        .expect("Owner pub keys signature verification failed");
+
+        let imc_bytes = manifest.image_metadata_col.as_bytes();
+        let imc_digest: [u8; 48] = sha2::Sha384::digest(imc_bytes).into();
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.vendor_pub_keys.ecc_pub_key,
+            &manifest.preamble.vendor_image_metdata_signatures.ecc_sig,
+        )
+        .expect("Vendor IMC signature verification failed");
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.owner_pub_keys.ecc_pub_key,
+            &manifest.preamble.owner_image_metdata_signatures.ecc_sig,
+        )
+        .expect("Owner IMC signature verification failed");
+
+        // Verify PQC signatures
+        manifest
+            .preamble
+            .vendor_pub_keys_signatures
+            .pqc_sig
+            .verify()
+            .expect("Vendor pub keys PQC signature verification failed");
+
+        manifest
+            .preamble
+            .owner_pub_keys_signatures
+            .pqc_sig
+            .verify()
+            .expect("Owner pub keys PQC signature verification failed");
+
+        manifest
+            .preamble
+            .vendor_image_metdata_signatures
+            .pqc_sig
+            .verify()
+            .expect("Vendor IMC PQC signature verification failed");
+
+        manifest
+            .preamble
+            .owner_image_metdata_signatures
+            .pqc_sig
+            .verify()
+            .expect("Owner IMC PQC signature verification failed");
+    }
+
+    #[test]
+    fn test_e2e_offline_manifest_signing_flow_lms() {
+        let temp_dir = tempdir().unwrap();
+        let work_dir = temp_dir.path();
+
+        let sw_root = caliptra_sw_workspace_root();
+        let keys_dir = sw_root.join("image/fake-keys/keys");
+
+        let vendor_fw_ecc_key = keys_dir.join("vendor_ecc_0_key.pem");
+        let vendor_fw_ecc_pub = keys_dir.join("vendor_ecc_0_pub.pem");
+        let vendor_fw_lms_key = keys_dir.join("vendor_lms_0_key.pem");
+        let vendor_fw_lms_pub = keys_dir.join("vendor_lms_0_pub.pem");
+
+        let owner_fw_ecc_key = keys_dir.join("owner_ecc_key.pem");
+        let owner_fw_ecc_pub = keys_dir.join("owner_ecc_pub.pem");
+        let owner_fw_lms_key = keys_dir.join("owner_lms_key.pem");
+        let owner_fw_lms_pub = keys_dir.join("owner_lms_pub.pem");
+
+        let vendor_man_ecc_key = keys_dir.join("vendor_ecc_1_key.pem");
+        let vendor_man_ecc_pub = keys_dir.join("vendor_ecc_1_pub.pem");
+        let vendor_man_lms_key = keys_dir.join("vendor_lms_1_key.pem");
+        let vendor_man_lms_pub = keys_dir.join("vendor_lms_1_pub.pem");
+
+        let owner_man_ecc_key = keys_dir.join("owner_ecc_key.pem");
+        let owner_man_ecc_pub = keys_dir.join("owner_ecc_pub.pem");
+        let owner_man_lms_key = keys_dir.join("owner_lms_key.pem");
+        let owner_man_lms_pub = keys_dir.join("owner_lms_pub.pem");
+
+        // 1. Create dummy MCU and SoC image files
+        let mcu_bin = work_dir.join("mcu-runtime.bin");
+        std::fs::write(&mcu_bin, vec![0xa5u8; 1024]).unwrap();
+
+        let soc_bin = work_dir.join("soc-fw.bin");
+        std::fs::write(&soc_bin, vec![0x5au8; 2048]).unwrap();
+
+        let unsigned_manifest_path = work_dir.join("unsigned_auth_manifest.bin");
+        let signing_request_path = work_dir.join("signing_request.json");
+        let signatures_path = work_dir.join("signatures.json");
+        let signed_manifest_path = work_dir.join("signed_auth_manifest.bin");
+
+        let mcu_image_cfg = ImageCfg {
+            path: mcu_bin,
+            network_filename: None,
+            load_addr: 0xA800_0000,
+            staging_addr: 0x6000_0000,
+            image_id: 1,
+            exec_bit: 2,
+            component_id: 0,
+            is_tcb: true,
+            is_ak_target: false,
+            feature: "test".to_string(),
+        };
+
+        let soc_image_cfg = ImageCfg {
+            path: soc_bin,
+            network_filename: None,
+            load_addr: 0x8000_0000,
+            staging_addr: 0x6000_0000,
+            image_id: 2,
+            exec_bit: 2,
+            component_id: 1,
+            is_tcb: false,
+            is_ak_target: false,
+            feature: "test".to_string(),
+        };
+
+        // Step 1: Create unsigned manifest and export signing request
+        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+            mcu_firmware: Some(mcu_image_cfg.path.clone()),
+            soc_images: Some(vec![soc_image_cfg]),
+            mcu_image_cfg: Some(mcu_image_cfg),
+            soc_manifest_svn: Some(1),
+            ..Default::default()
+        });
+
+        let key_paths = AuthManifestPubKeysPaths {
+            vendor_fw_ecc_pub_key: Some(&vendor_fw_ecc_pub),
+            vendor_fw_lms_pub_key: Some(&vendor_fw_lms_pub),
+            owner_fw_ecc_pub_key: Some(&owner_fw_ecc_pub),
+            owner_fw_lms_pub_key: Some(&owner_fw_lms_pub),
+            vendor_man_ecc_pub_key: Some(&vendor_man_ecc_pub),
+            vendor_man_lms_pub_key: Some(&vendor_man_lms_pub),
+            owner_man_ecc_pub_key: Some(&owner_man_ecc_pub),
+            owner_man_lms_pub_key: Some(&owner_man_lms_pub),
+            ..Default::default()
+        };
+
+        let (path, signing_req) = builder
+            .get_unsigned_auth_manifest(
+                Some(unsigned_manifest_path.to_str().unwrap()),
+                Some(&key_paths),
+            )
+            .unwrap();
+
+        let req_json_bytes = serde_json::to_string_pretty(&signing_req).unwrap();
+        std::fs::write(&signing_request_path, req_json_bytes).unwrap();
+
+        assert!(path.exists());
+        assert!(signing_request_path.exists());
+
+        // Step 2: Compute offline signatures for signing request using fw-signer
+        let key_manifest = KeyManifest {
+            vendor_fw: KeyManifestEntry {
+                ecc_priv_key: vendor_fw_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_fw_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: vendor_fw_lms_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(vendor_fw_lms_pub.to_str().unwrap().to_string()),
+                pqc_type: "LMS".to_string(),
+            },
+            owner_fw: KeyManifestEntry {
+                ecc_priv_key: owner_fw_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_fw_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: owner_fw_lms_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(owner_fw_lms_pub.to_str().unwrap().to_string()),
+                pqc_type: "LMS".to_string(),
+            },
+            vendor_man: KeyManifestEntry {
+                ecc_priv_key: vendor_man_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: vendor_man_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: vendor_man_lms_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(vendor_man_lms_pub.to_str().unwrap().to_string()),
+                pqc_type: "LMS".to_string(),
+            },
+            owner_man: KeyManifestEntry {
+                ecc_priv_key: owner_man_ecc_key.to_str().unwrap().to_string(),
+                ecc_pub_key: owner_man_ecc_pub.to_str().unwrap().to_string(),
+                pqc_priv_key: owner_man_lms_key.to_str().unwrap().to_string(),
+                pqc_pub_key: Some(owner_man_lms_pub.to_str().unwrap().to_string()),
+                pqc_type: "LMS".to_string(),
+            },
+        };
+
+        generate_offline_signatures(&signing_request_path, &key_manifest, &signatures_path)
+            .unwrap();
+
+        assert!(signatures_path.exists());
+
+        // Step 3: Reattach signatures and verify output
+        attach_auth_manifest_signatures(
+            &unsigned_manifest_path,
+            &signatures_path,
+            Some(&vendor_fw_ecc_pub),
+            Some(&owner_fw_ecc_pub),
+            &signed_manifest_path,
+        )
+        .unwrap();
+
+        assert!(signed_manifest_path.exists());
+
+        // Step 4: Parse final signed manifest and verify cryptographic signatures
+        let signed_data = std::fs::read(&signed_manifest_path).unwrap();
+        let manifest = AuthorizationManifest::read_from_bytes(&signed_data).unwrap();
+
+        assert_eq!(manifest.preamble.version, 1);
+        assert_eq!(manifest.preamble.svn, 1);
+
+        let vendor_fw_pub_key = Crypto::ecc_pub_key_from_pem(&vendor_fw_ecc_pub).unwrap();
+        let owner_fw_pub_key = Crypto::ecc_pub_key_from_pem(&owner_fw_ecc_pub).unwrap();
+
+        let vendor_range =
+            caliptra_auth_man_types::AuthManifestPreamble::vendor_signed_data_range();
+        let vendor_signed_bytes = manifest
+            .preamble
+            .as_bytes()
+            .get(vendor_range.start as usize..vendor_range.end as usize)
+            .unwrap();
+        let vendor_digest: [u8; 48] = sha2::Sha384::digest(vendor_signed_bytes).into();
+
+        verify_ecdsa384_signature(
+            &vendor_digest,
+            &vendor_fw_pub_key,
+            &manifest.preamble.vendor_pub_keys_signatures.ecc_sig,
+        )
+        .expect("Vendor pub keys signature verification failed");
+
+        let owner_bytes = manifest.preamble.owner_pub_keys.as_bytes();
+        let owner_digest: [u8; 48] = sha2::Sha384::digest(owner_bytes).into();
+
+        verify_ecdsa384_signature(
+            &owner_digest,
+            &owner_fw_pub_key,
+            &manifest.preamble.owner_pub_keys_signatures.ecc_sig,
+        )
+        .expect("Owner pub keys signature verification failed");
+
+        let imc_bytes = manifest.image_metadata_col.as_bytes();
+        let imc_digest: [u8; 48] = sha2::Sha384::digest(imc_bytes).into();
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.vendor_pub_keys.ecc_pub_key,
+            &manifest.preamble.vendor_image_metdata_signatures.ecc_sig,
+        )
+        .expect("Vendor IMC signature verification failed");
+
+        verify_ecdsa384_signature(
+            &imc_digest,
+            &manifest.preamble.owner_pub_keys.ecc_pub_key,
+            &manifest.preamble.owner_image_metdata_signatures.ecc_sig,
+        )
+        .expect("Owner IMC signature verification failed");
+
+        // Verify PQC signatures
+        manifest
+            .preamble
+            .vendor_pub_keys_signatures
+            .pqc_sig
+            .verify()
+            .expect("Vendor pub keys PQC signature verification failed");
+
+        manifest
+            .preamble
+            .owner_pub_keys_signatures
+            .pqc_sig
+            .verify()
+            .expect("Owner pub keys PQC signature verification failed");
+
+        manifest
+            .preamble
+            .vendor_image_metdata_signatures
+            .pqc_sig
+            .verify()
+            .expect("Vendor IMC PQC signature verification failed");
+
+        manifest
+            .preamble
+            .owner_image_metdata_signatures
+            .pqc_sig
+            .verify()
+            .expect("Owner IMC PQC signature verification failed");
+    }
+}


### PR DESCRIPTION
Add end-to-end integration tests for the offline authorization manifest signing flow in tests/integration/src/test_offline_signing.rs covering both ML-DSA-87 and LMS PQC algorithms along with ECC P-384.

The tests verify:
1. Exporting unsigned manifest templates and signing requests.
2. Generating offline signatures via caliptra-mcu-fw-signer.
3. Reattaching signatures with attach_auth_manifest_signatures.
4. Performing cryptographic pre-flight verification on all signature targets.

Also enhance CaliptraBuilder to support loading LMS public keys from PEM files and update ImagePqcSignatureExt to accept standard PQC signature lengths.