### PR TITLE
[OCP LOCK]: Remove EKP release TODO

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1864,7 +1864,6 @@ impl TryFrom<u16> for SekState {
     }
 }
 
-// TODO(clundin): Update to the release EKP spec once published.
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Default)]
 pub struct GetOcpLockEpochKeyReportReq {

--- a/runtime/userspace/api/caliptra-api/src/ocp_lock.rs
+++ b/runtime/userspace/api/caliptra-api/src/ocp_lock.rs
@@ -748,12 +748,6 @@ fn encode_subject_name<'a>(cn: &[u8], buf: &'a mut [u8]) -> CaliptraApiResult<An
     Ok(AnyRef::from_der(bytes)?)
 }
 
-// TODO(clundin): Update the code to the release EKP spec once published.
-// Spec Versioning Notice: The following EKP implementation is written against:
-// - TCG Storage Epoch Key Purge Feature Specification v1.00 r0.33
-// - OCP L.O.C.K. Specification v1.1
-// These are subject to change once official releases are available.
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EkpEvidence<'a> {
     pub nonce: &'a [u8; 32],
@@ -795,7 +789,6 @@ impl<'a> EkpEvidence<'a> {
         encoder.encode_uint(Self::CLAIM_EKP_ALLOWED)?;
         encoder.encode_bool(self.ekp_allowed)?;
 
-        // Note: Spec draft example encoded these as bytes(2), but CDDL specifies uint. We use uint (u16).
         encoder.encode_uint(Self::CLAIM_MAX_HEK_SANITIZATIONS)?;
         encoder.encode_uint(self.max_hek_sanitizations as u64)?;
 

--- a/tests/integration/src/test_ekp.rs
+++ b/tests/integration/src/test_ekp.rs
@@ -1,5 +1,4 @@
 // Licensed under the Apache-2.0 license
-// TODO(clundin): Update test assertions to the release EKP spec once published.
 
 #[cfg(all(test, not(feature = "fpga_realtime")))]
 mod test {


### PR DESCRIPTION
I have now verified that the implementation complies with the release v1 of the TCG EKP spec.