### PR TITLE
spdm: add SPDM 1.4 CAPABILITIES support

### DIFF
--- a/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-//! SPDM CAPABILITIES wire types (DSP0274 §10.5).
+//! SPDM CAPABILITIES wire types (DSP0274 §10.3).
 //!
 //! Two layers:
 //!
@@ -11,13 +11,16 @@
 //!    GET_CAPABILITIES request and CAPABILITIES response (same wire
 //!    shape in both directions).
 
-use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::{
+    little_endian::{U16, U32},
+    FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
+};
 
 use crate::flag_macros::def_flag_set_le;
 use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
 
 def_flag_set_le! {
-    /// SPDM capability bitfield (DSP0274 §10.5.1 Table 11). Constants
+    /// SPDM capability bitfield (DSP0274 §10.3). Constants
     /// cover single-bit flags directly. The 2-bit `MEAS` and `PSK`
     /// fields are exposed as per-value constants (`MEAS_NO_SIG`,
     /// `MEAS_SIG`, `PSK`, `PSK_WITH_CTX`).
@@ -46,9 +49,20 @@ def_flag_set_le! {
         CHUNK = 1 << 17,
         ALIAS_CERT = 1 << 18,
         SET_CERT = 1 << 19,
+        CSR = 1 << 20,
+        CERT_INSTALL_RESET = 1 << 21,
+        EP_INFO_NO_SIG = 1 << 22,
+        EP_INFO_SIG = 2 << 22,
+        MEL = 1 << 24,
+        EVENT = 1 << 25,
+        /// `MULTI_KEY_CAP` field bits 27:26 set to `01b` (`MultiKeyOnly`).
+        MULTI_KEY_ONLY = 1 << 26,
         /// `MULTI_KEY_CAP` field bits 27:26 set to `10b` (`MultiKeyConnRsp`).
         MULTI_KEY_CONN_RSP = 2 << 26,
         GET_KEY_PAIR_INFO = 1 << 28,
+        SET_KEY_PAIR_INFO = 1 << 29,
+        SET_KEY_PAIR_RESET = 1 << 30,
+        LARGE_RESP = 1 << 31,
     }
 }
 
@@ -69,6 +83,20 @@ impl CapFlags {
     pub fn multi_key_field(self) -> u8 {
         ((self.into_bits() >> 26) & 0b11) as u8
     }
+
+    /// 2-bit `EP_INFO_CAP` field value (bits 22..=23).
+    #[inline]
+    pub fn ep_info_field(self) -> u8 {
+        ((self.into_bits() >> 22) & 0b11) as u8
+    }
+}
+
+def_flag_set_le! {
+    /// SPDM V1.4 extended responder capability flags. Requester
+    /// ExtFlags are reserved in V1.4 and therefore must be zero.
+    pub struct ExtCapFlags(U16: u16) {
+        SLOT_MGMT = 1 << 0,
+    }
 }
 
 /// 18-byte CAPABILITIES body (DSP0274 §10.5.1, v1.2+). Identical
@@ -81,7 +109,8 @@ pub struct CapabilitiesBody {
     pub param2: u8,
     pub reserved: u8,
     pub ct_exponent: u8,
-    pub reserved2: [u8; 2],
+    /// Extended capability flags in V1.4; reserved and zero in older versions.
+    pub ext_flags: ExtCapFlags,
     pub flags: CapFlags,
     pub data_transfer_size: U32,
     pub max_spdm_msg_size: U32,
@@ -94,8 +123,8 @@ impl CapabilitiesBody {
     /// ("MinDataTransferSize" in the spec).
     pub const MIN_DATA_TRANSFER_SIZE: u32 = 42;
 
-    /// Practical upper bound on CTExponent (CT = 2^32 µs ≈ 1.2 h).
-    pub const MAX_CT_EXPONENT: u8 = 32;
+    /// Maximum CTExponent accepted by libspdm and the responder validator.
+    pub const MAX_CT_EXPONENT: u8 = 31;
 }
 
 const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBody::SIZE);
@@ -103,6 +132,7 @@ const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBo
 /// Builder for a CAPABILITIES response.
 pub struct CapabilitiesRsp {
     pub ct_exponent: u8,
+    pub ext_flags: ExtCapFlags,
     pub flags: CapFlags,
     pub data_transfer_size: u32,
     pub max_spdm_msg_size: u32,
@@ -121,7 +151,7 @@ impl ResponseBody for CapabilitiesRsp {
             param2: 0,
             reserved: 0,
             ct_exponent: self.ct_exponent,
-            reserved2: [0; 2],
+            ext_flags: self.ext_flags,
             flags: self.flags,
             data_transfer_size: U32::new(self.data_transfer_size),
             max_spdm_msg_size: U32::new(self.max_spdm_msg_size),

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -32,7 +32,7 @@ pub use algorithms::{
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
-pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp};
+pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags};
 pub use certificate::{
     CertificateRsp, CertificateRspBody, GetCertificateReqBody, ATTR_SLOT_SIZE_REQUESTED,
 };

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -8,14 +8,16 @@
 //! 2. Negotiates the SPDM version using the requester's
 //!    common-header `version` byte (must be one of
 //!    [`SUPPORTED_VERSIONS`](crate::version::SUPPORTED_VERSIONS)).
-//! 3. Validates the V1.2+ `CapabilitiesBody` fields per the corresponding table.
+//! 3. Validates the V1.2+ `CapabilitiesBody`, version-specific capability
+//!    masks, extended flags, and capability dependencies.
 //! 4. Stashes the peer's advertised `DataTransferSize`,
 //!    `MaxSPDMmsgSize`, and capability flags into [`ConnectionState`].
 //! 5. Builds the `CAPABILITIES` response from the responder's fixed
 //!    local policy, then transitions to [`Phase::AfterCapabilities`].
 
 use caliptra_mcu_spdm_codec::{
-    CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -64,7 +66,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 
     let req = io.request();
     let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
-    let version = select_version(state, hdr.version)?;
+    let version = select_version(hdr.version)?;
 
     let body = CapabilitiesBody::ref_from_bytes(
         rest.get(..CapabilitiesBody::SIZE)
@@ -72,17 +74,14 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     )
     .map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    let (peer_dts, peer_max) = validate_capabilities_body(body)?;
+    let (peer_dts, peer_max) = validate_capabilities_body(version, body)?;
+    state.version = version;
     state.peer_data_transfer_size = peer_dts;
     state.peer_max_spdm_msg_size = peer_max;
     state.peer_cap_flags = body.flags;
 
     let mtu = pal.mtu();
-    let mut flags = state.cap_flags;
-    if version < SpdmVersion::V13 {
-        let cleared = flags.into_bits() & !(0b11 << 26);
-        flags = CapFlags::from_bits(cleared);
-    }
+    let mut flags = CapFlags::from_bits(state.cap_flags.into_bits() & responder_cap_mask(version));
     if !pal.secure_message_supported() {
         let secure_session_caps = CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC;
         flags = CapFlags::from_bits(flags.into_bits() & !secure_session_caps.into_bits());
@@ -95,6 +94,8 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     } as u32;
     let body = CapabilitiesRsp {
         ct_exponent: state.ct_exponent,
+        // SLOT_MANAGEMENT is not implemented by this responder.
+        ext_flags: ExtCapFlags::EMPTY,
         flags,
         data_transfer_size: mtu as u32,
         max_spdm_msg_size,
@@ -114,7 +115,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     Ok(resp)
 }
 
-/// Validates a `CapabilitiesBody` against SPDM the corresponding table.
+/// Validates a `CapabilitiesBody` against the negotiated SPDM version.
 ///
 /// # Parameters
 ///
@@ -128,19 +129,38 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 ///
 /// # Errors
 ///
-/// * [`SPDM_INVALID_REQUEST`] — any reserved field is non-zero,
-///   `ct_exponent` exceeds the protocol maximum, `DataTransferSize` is
-///   below the spec minimum or above `MaxSPDMmsgSize`, or the
-///   requester clears `CHUNK` but advertises
-///   `DataTransferSize != MaxSPDMmsgSize`.
-fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)> {
-    // Param1/Param2 are reserved in V1.2; Param1 bit 0 = "Supported
-    // Algorithms request" in V1.3, which we don't implement, so both
-    // versions require these bytes to be zero.
-    if body.param1 != 0 || body.param2 != 0 || body.reserved != 0 || body.reserved2 != [0; 2] {
+/// * [`SPDM_INVALID_REQUEST`] — a reserved/version-inapplicable field or flag
+///   is non-zero, capability dependencies are invalid, `ct_exponent` exceeds
+///   the protocol maximum, transfer sizes are invalid, or the Supported
+///   Algorithms request is made without CHUNK support at both endpoints.
+fn validate_capabilities_body(
+    version: SpdmVersion,
+    body: &CapabilitiesBody,
+) -> SpdmResult<(u32, u32)> {
+    let param1_mask = if version >= SpdmVersion::V13 { 0x01 } else { 0 };
+    if body.param1 & !param1_mask != 0 || body.param2 != 0 || body.reserved != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    // Requester ExtFlags are reserved in SPDM V1.4 and the same bytes
+    // are reserved in all earlier versions.
+    if !body.ext_flags.is_empty() {
         return Err(SPDM_INVALID_REQUEST);
     }
     if body.ct_exponent > CapabilitiesBody::MAX_CT_EXPONENT {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let flags = body.flags;
+    if flags.into_bits() & !requester_cap_mask(version) != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    validate_request_flag_compatibility(version, flags)?;
+
+    // A requester can only request the Supported Algorithms block when it
+    // supports chunking. This responder does not currently include the
+    // optional block, so Param1 remains zero in the response even when this
+    // valid request bit is set.
+    if body.param1 & 0x01 != 0 && !flags.contains(CapFlags::CHUNK) {
         return Err(SPDM_INVALID_REQUEST);
     }
 
@@ -157,11 +177,103 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
     Ok((peer_dts, peer_max))
 }
 
-/// Picks the negotiated SPDM version and records it on `state`.
+fn validate_request_flag_compatibility(version: SpdmVersion, flags: CapFlags) -> SpdmResult<()> {
+    let cert = flags.contains(CapFlags::CERT);
+    let chal = flags.contains(CapFlags::CHAL);
+    let encrypt = flags.contains(CapFlags::ENCRYPT);
+    let mac = flags.contains(CapFlags::MAC);
+    let mut_auth = flags.contains(CapFlags::MUT_AUTH);
+    let key_ex = flags.contains(CapFlags::KEY_EX);
+    let psk = flags.psk_field();
+    let pub_key_id = flags.contains(CapFlags::PUB_KEY_ID);
+    let ep_info = flags.ep_info_field();
+    let multi_key = flags.multi_key_field();
+
+    // Requesters may advertise PSK_CAP=00b or 01b. The 10b value is
+    // responder-only and 11b is reserved.
+    if psk > 1 || ep_info == 3 || multi_key == 3 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let has_session_exchange = key_ex || psk != 0;
+    if has_session_exchange {
+        if !encrypt && !mac {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if encrypt
+        || mac
+        || flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR)
+        || flags.contains(CapFlags::HBEAT)
+        || flags.contains(CapFlags::KEY_UPD)
+        || (version >= SpdmVersion::V13 && flags.contains(CapFlags::EVENT))
+    {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if !key_ex && psk == 1 && flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if cert || pub_key_id {
+        if cert && pub_key_id {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        if !(chal || key_ex || (version >= SpdmVersion::V13 && ep_info == 2)) {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if chal || mut_auth || (version >= SpdmVersion::V13 && ep_info == 2) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if mut_auth && !key_ex && !chal {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if version >= SpdmVersion::V13 && multi_key != 0 && (!cert || pub_key_id) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
+}
+
+const REQUESTER_CAP_FLAGS_V12_MASK: u32 = (1 << 1)
+    | (1 << 2)
+    | (1 << 6)
+    | (1 << 7)
+    | (1 << 8)
+    | (1 << 9)
+    | (0b11 << 10)
+    | (1 << 12)
+    | (1 << 13)
+    | (1 << 14)
+    | (1 << 15)
+    | (1 << 16)
+    | (1 << 17);
+const REQUESTER_CAP_FLAGS_V13_MASK: u32 =
+    REQUESTER_CAP_FLAGS_V12_MASK | (0b11 << 22) | (1 << 25) | (0b11 << 26);
+const REQUESTER_CAP_FLAGS_V14_MASK: u32 = REQUESTER_CAP_FLAGS_V13_MASK | (1 << 31);
+
+const RESPONDER_CAP_FLAGS_V12_MASK: u32 = (1 << 22) - 1;
+const RESPONDER_CAP_FLAGS_V13_MASK: u32 = (1 << 30) - 1;
+const RESPONDER_CAP_FLAGS_V14_MASK: u32 = u32::MAX;
+
+fn requester_cap_mask(version: SpdmVersion) -> u32 {
+    match version {
+        SpdmVersion::V10 | SpdmVersion::V11 | SpdmVersion::V12 => REQUESTER_CAP_FLAGS_V12_MASK,
+        SpdmVersion::V13 => REQUESTER_CAP_FLAGS_V13_MASK,
+        SpdmVersion::V14 => REQUESTER_CAP_FLAGS_V14_MASK,
+    }
+}
+
+fn responder_cap_mask(version: SpdmVersion) -> u32 {
+    match version {
+        SpdmVersion::V10 | SpdmVersion::V11 | SpdmVersion::V12 => RESPONDER_CAP_FLAGS_V12_MASK,
+        SpdmVersion::V13 => RESPONDER_CAP_FLAGS_V13_MASK,
+        SpdmVersion::V14 => RESPONDER_CAP_FLAGS_V14_MASK,
+    }
+}
+
+/// Picks the requested SPDM version without mutating connection state.
 ///
 /// # Parameters
 ///
-/// * `state` — Connection state; `state.version` is updated on success.
 /// * `requested` — Raw `version` byte from the request's common header.
 ///
 /// # Returns
@@ -172,14 +284,10 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
 ///
 /// * [`SPDM_VERSION_MISMATCH`] — byte is not a recognised version or
 ///   not in [`SUPPORTED_VERSIONS`].
-fn select_version<S, L>(
-    state: &mut ConnectionState<S, L>,
-    requested: u8,
-) -> SpdmResult<SpdmVersion> {
+fn select_version(requested: u8) -> SpdmResult<SpdmVersion> {
     let v = SpdmVersion::from_u8(requested).ok_or(SPDM_VERSION_MISMATCH)?;
     if !SUPPORTED_VERSIONS.contains(&v) {
         return Err(SPDM_VERSION_MISMATCH);
     }
-    state.version = v;
     Ok(v)
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -1113,3 +1113,7 @@ mod tests;
 #[cfg(test)]
 #[path = "tests/version.rs"]
 mod version_tests;
+
+#[cfg(test)]
+#[path = "tests/capabilities.rs"]
+mod capabilities_tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -1,0 +1,278 @@
+// Licensed under the Apache-2.0 license
+
+#![allow(clippy::field_reassign_with_default)]
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmVersion};
+use caliptra_mcu_spdm_traits::NoVdmBackend;
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+
+#[path = "support.rs"]
+mod support;
+use support::{TestHashState, TestIo, TestPal};
+
+fn capabilities_request(
+    version: SpdmVersion,
+    param1: u8,
+    ext_flags: u16,
+    flags: CapFlags,
+    data_transfer_size: u32,
+    max_spdm_msg_size: u32,
+) -> Vec<u8> {
+    let mut req = vec![
+        version.to_u8(),
+        ReqRespCode::GET_CAPABILITIES.0,
+        param1,
+        0,
+        0,
+        0,
+    ];
+    req.extend_from_slice(&ext_flags.to_le_bytes());
+    req.extend_from_slice(&flags.into_bits().to_le_bytes());
+    req.extend_from_slice(&data_transfer_size.to_le_bytes());
+    req.extend_from_slice(&max_spdm_msg_size.to_le_bytes());
+    req
+}
+
+fn dispatch_request(
+    state: &mut ConnectionState<TestHashState, Vec<u8>>,
+    sessions: &mut Sessions<TestPal, 1>,
+    pal: &TestPal,
+    request: Vec<u8>,
+) -> SpdmResult<Vec<u8>> {
+    let io = TestIo::message(request);
+    block_on(dispatch(
+        state,
+        sessions,
+        pal,
+        &io,
+        ReqRespCode::GET_CAPABILITIES,
+        &NoVdmBackend,
+    ))
+}
+
+#[test]
+fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::LARGE_RESP;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 4096),
+    )
+    .unwrap();
+
+    assert_eq!(rsp.len(), 20);
+    assert_eq!(rsp[0], SpdmVersion::V14.to_u8());
+    assert_eq!(rsp[1], ReqRespCode::CAPABILITIES.0);
+    assert_eq!(&rsp[6..8], &[0, 0]);
+    assert_eq!(
+        u32::from_le_bytes(rsp[8..12].try_into().unwrap()),
+        state.advertised_cap_flags.into_bits()
+    );
+    assert_eq!(state.version, SpdmVersion::V14);
+    assert_eq!(state.phase, Phase::AfterCapabilities);
+    assert_eq!(state.peer_cap_flags.into_bits(), peer_flags.into_bits());
+    assert_eq!(state.peer_data_transfer_size, 1024);
+    assert_eq!(state.peer_max_spdm_msg_size, 4096);
+}
+
+#[test]
+fn get_capabilities_masks_flags_added_after_v12() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags |= CapFlags::GET_KEY_PAIR_INFO | CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V12, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+
+    assert!(!advertised.contains(CapFlags::GET_KEY_PAIR_INFO));
+    assert!(!advertised.contains(CapFlags::LARGE_RESP));
+}
+
+#[test]
+fn invalid_v14_capabilities_does_not_commit_negotiation_state() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 1, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::EMPTY.into_bits()
+    );
+    assert_eq!(state.peer_data_transfer_size, 0);
+    assert_eq!(state.peer_max_spdm_msg_size, 0);
+}
+
+#[test]
+fn v14_capabilities_rejects_incompatible_session_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    // KEY_EX requires at least one of ENCRYPT or MAC.
+    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
+}
+
+#[test]
+fn v14_capabilities_accepts_supported_algorithms_request_with_chunking() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 1, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+
+    // The request is valid, but this responder does not implement the
+    // optional Supported Algorithms block and therefore clears Param1.
+    assert_eq!(rsp[2], 0);
+    assert_eq!(state.phase, Phase::AfterCapabilities);
+}
+
+#[test]
+fn v14_supported_algorithms_request_does_not_require_responder_chunking() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags =
+        CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 1, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+
+    assert_eq!(rsp[2], 0);
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+    assert!(!advertised.contains(CapFlags::CHUNK));
+}
+
+#[test]
+fn capabilities_enforces_ct_exponent_limit() {
+    let pal = TestPal::default();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    for (ct_exponent, accepted) in [(31, true), (32, false)] {
+        let mut state = ConnectionState::default();
+        state.phase = Phase::AfterVersion;
+        let mut sessions = SessionManager::new();
+        let mut request = capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024);
+        request[5] = ct_exponent;
+
+        assert_eq!(
+            dispatch_request(&mut state, &mut sessions, &pal, request).is_ok(),
+            accepted
+        );
+    }
+}
+
+#[test]
+fn v13_capabilities_rejects_v14_requester_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::LARGE_RESP;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V13, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+}
+
+#[test]
+fn v13_capabilities_masks_v14_responder_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags |= CapFlags::SET_KEY_PAIR_RESET | CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V13, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+
+    assert!(!advertised.contains(CapFlags::SET_KEY_PAIR_RESET));
+    assert!(!advertised.contains(CapFlags::LARGE_RESP));
+}


### PR DESCRIPTION
The responder advertises SPDM 1.4 VERSION support but does not yet handle the SPDM 1.4 CAPABILITIES fields and version-specific capability masks.

Add the SPDM 1.4 capability and extended-flag definitions, validate requester fields and capability relationships before saving negotiated state, and mask response capabilities according to the selected protocol version. The optional Supported Algorithms request is accepted when the requester supports chunking; this responder currently returns the normal CAPABILITIES body without that optional block.

This PR is stacked on #1891 and uses:
- chipsalliance/caliptra-spdm-emu#2
- chipsalliance/caliptra-SPDM-Responder-Validator#6

Pre-rebase end-to-end responder-validator results for the same SPDM changes at MCU `8c1b500e`, spdm-emu `59993917`, and responder-validator `03a5888b`:

| transport | selection | process | pass | fail | CAPABILITIES 1.4 | invalid CAPABILITIES |
|---|---|---:|---:|---:|---:|---:|
| MCTP | VERSION,CAPABILITIES | 0 | 100 | 0 | 12 pass, 0 fail | 40 pass, 0 fail |
| DOE | VERSION,CAPABILITIES | 0 | 109 | 0 | 15 pass, 0 fail | 40 pass, 0 fail |

Both transports advertised VERSION `0x1400`. Logs and packet captures are retained locally under `.local/spdm-capabilities-e2e/`.

Pre-rebase memory:
- Kernel: text 152,684 B; data 36 B; BSS 24,536 B
- User app: flash 297,780 B; RAM 79,632 B
- SPDM-attributed: flash 105,010 B; RAM 31,297 B
- Runtime bundle: 453,632 B

`cargo xtask precheckin` completed formatting, Clippy, license, and dependency checks, then reached an existing base-branch documentation failure because `docs/src/spdm-future-recommendations.md` is not linked from `SUMMARY.md`.

Refs #1788



