### PR TITLE
fix: align SPDM VDM debug unlock with common format

### DIFF
--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -470,12 +470,12 @@ dependencies = [
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217#85981e1bc28662a9a9fa5040cbb38ac46e548217"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e5ceee831f1b6b49a8d139a705133e47deab8711#e5ceee831f1b6b49a8d139a705133e47deab8711"
 
 [[package]]
 name = "caliptra-util-host"

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -649,34 +649,43 @@ pub fn handle_prod_debug_unlock_req(
     let req = ProdDebugUnlockReqRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
 
-    // VDM payload: [unlock_level(1)]
-    let vdm_payload = [req.unlock_level];
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let resp_len = send_vdm_request(
         CaliptraVdmCommand::RequestDebugUnlock,
-        &vdm_payload,
+        req.as_bytes(),
         driver,
         &mut resp_buf,
     )?;
 
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
 
-    // Response data: [unique_device_identifier(32), challenge(48)]
-    if data.len() != UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+    const RESPONSE_LENGTH_DWORDS: u32 = 21;
+    const LENGTH_SIZE: usize = core::mem::size_of::<u32>();
+    if data.len() != LENGTH_SIZE + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+        return Err(TransportError::InvalidMessage);
+    }
+    let length = u32::from_le_bytes(
+        data[..LENGTH_SIZE]
+            .try_into()
+            .map_err(|_| TransportError::InvalidMessage)?,
+    );
+    if length != RESPONSE_LENGTH_DWORDS {
         return Err(TransportError::InvalidMessage);
     }
 
     let mut unique_device_identifier = [0u8; UNIQUE_DEVICE_ID_SIZE];
-    unique_device_identifier.copy_from_slice(&data[..UNIQUE_DEVICE_ID_SIZE]);
+    unique_device_identifier
+        .copy_from_slice(&data[LENGTH_SIZE..LENGTH_SIZE + UNIQUE_DEVICE_ID_SIZE]);
 
     let mut challenge = [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE];
     challenge.copy_from_slice(
-        &data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+        &data[LENGTH_SIZE + UNIQUE_DEVICE_ID_SIZE
+            ..LENGTH_SIZE + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
     );
 
     let internal_resp = ProdDebugUnlockReqResponse {
         common: CommonResponse { fips_status: 0 },
-        length: 0,
+        length,
         unique_device_identifier,
         challenge,
     };
@@ -1149,7 +1158,8 @@ mod tests {
     #[test]
     fn debug_unlock_req_rejects_trailing_response_bytes() {
         let req = ProdDebugUnlockReqRequest::new(1);
-        let mut data = vec![0xA5; UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE + 1];
+        let mut data = vec![0xA5; 4 + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE + 1];
+        data[..4].copy_from_slice(&21u32.to_le_bytes());
         let mut driver = FakeDriver {
             response: success_response(CaliptraVdmCommand::RequestDebugUnlock, &data),
             last_request: Vec::new(),
@@ -1160,7 +1170,7 @@ mod tests {
             .expect_err("DebugUnlock response with trailing bytes must be rejected");
 
         assert!(matches!(err, TransportError::InvalidMessage));
-        data.truncate(UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE);
+        data.truncate(4 + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE);
         driver.response = success_response(CaliptraVdmCommand::RequestDebugUnlock, &data);
         handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer)
             .expect("exact-length DebugUnlock response should be accepted");
@@ -1169,9 +1179,18 @@ mod tests {
             [
                 CALIPTRA_VDM_COMMAND_VERSION,
                 CaliptraVdmCommand::RequestDebugUnlock as u8,
-                req.unlock_level,
             ]
+            .into_iter()
+            .chain(req.as_bytes().iter().copied())
+            .collect::<Vec<_>>()
         );
+
+        data[..4].copy_from_slice(&20u32.to_le_bytes());
+        driver.response = success_response(CaliptraVdmCommand::RequestDebugUnlock, &data);
+        assert!(matches!(
+            handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer),
+            Err(TransportError::InvalidMessage)
+        ));
     }
 
     #[test]

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
@@ -20,15 +20,23 @@ where
     H: CaliptraCmdHandler,
     A: SpdmPalAlloc,
 {
-    let &[unlock_level] = req else {
+    const REQUEST_LENGTH_DWORDS: u32 = 2;
+    let Ok(&[length_0, length_1, length_2, length_3, unlock_level, _, _, _]) =
+        <&[u8; 8]>::try_from(req)
+    else {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
     };
+    if u32::from_le_bytes([length_0, length_1, length_2, length_3]) != REQUEST_LENGTH_DWORDS {
+        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
+    }
 
     let data = match super::write_success(out) {
         Ok(data) => data,
         Err(code) => return CaliptraVdmCmdResult::Error(code),
     };
-    let needed = DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
+    const RESPONSE_LENGTH_DWORDS: u32 = 21;
+    const LENGTH_SIZE: usize = core::mem::size_of::<u32>();
+    let needed = LENGTH_SIZE + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
     if data.len() < needed {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
     }
@@ -39,9 +47,11 @@ where
         .await
     {
         Ok(()) => {
-            data[..DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
+            data[..LENGTH_SIZE].copy_from_slice(&RESPONSE_LENGTH_DWORDS.to_le_bytes());
+            data[LENGTH_SIZE..LENGTH_SIZE + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
                 .copy_from_slice(&challenge.unique_device_identifier);
-            data[DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE..needed].copy_from_slice(&challenge.challenge);
+            data[LENGTH_SIZE + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE..needed]
+                .copy_from_slice(&challenge.challenge);
             CaliptraVdmCmdResult::Response(1 + needed)
         }
         Err(code) => CaliptraVdmCmdResult::Error(super::map_common_completion(code)),

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -2044,24 +2044,32 @@ mod tests {
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
+            2,
+            0,
+            0,
+            0,
             7,
+            0,
+            0,
+            0,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
 
         assert_inline(
             response,
-            2 + 1 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
+            2 + 1 + 4 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
         );
         assert_eq!(inline[0], CALIPTRA_VDM_COMMAND_VERSION);
         assert_eq!(inline[1], CaliptraVdmCommand::RequestDebugUnlock as u8);
         assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_eq!(u32::from_le_bytes(inline[3..7].try_into().unwrap()), 21);
         assert_eq!(
-            &inline[3..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+            &inline[7..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
             &[0x11; DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
         );
         assert_eq!(
-            &inline[3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
-                ..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+            &inline[7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
+                ..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
             &[0x22; DEBUG_UNLOCK_CHALLENGE_SIZE]
         );
     }
@@ -2093,13 +2101,46 @@ mod tests {
     }
 
     #[test]
-    fn request_debug_unlock_rejects_trailing_payload() {
+    fn request_debug_unlock_rejects_invalid_payload_size() {
+        let cmds = TestCommands::new(0);
+        let trailing = [
+            CALIPTRA_VDM_COMMAND_VERSION,
+            CaliptraVdmCommand::RequestDebugUnlock as u8,
+            2,
+            0,
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            0xaa,
+        ];
+        let (response, inline, _) = dispatch(&cmds, &trailing, 128, 0);
+
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+
+        let (response, inline, _) = dispatch(&cmds, &trailing[..trailing.len() - 2], 128, 0);
+
+        assert_inline(response, 3);
+        assert_eq!(inline[2], CaliptraCompletionCode::InvalidPayloadSize as u8);
+    }
+
+    #[test]
+    fn request_debug_unlock_rejects_invalid_length() {
         let cmds = TestCommands::new(0);
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
+            1,
+            0,
+            0,
+            0,
             7,
-            0xaa,
+            0,
+            0,
+            0,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
 

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -247,25 +247,76 @@ mod test {
             .to_string()
     }
 
+    fn debug_unlock_material(unlock_level: u8) -> (Vec<([u8; 96], [u8; 2592])>, DebugUnlockKeys) {
+        use caliptra_image_fake_keys::{
+            VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
+            VENDOR_MLDSA_KEY_0_PUBLIC,
+        };
+        use caliptra_image_types::{ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE};
+
+        let mut ecc_pub_key_u32 = [0u32; ECC384_SCALAR_WORD_SIZE * 2];
+        ecc_pub_key_u32[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
+        ecc_pub_key_u32[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
+        let ecc_pub_key_bytes: [u8; 96] = ecc_pub_key_u32.as_bytes().try_into().unwrap();
+
+        let mldsa_pub_key_u32: Vec<u32> = VENDOR_MLDSA_KEY_0_PUBLIC
+            .0
+            .as_bytes()
+            .chunks(4)
+            .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+        let mldsa_pub_key_bytes: [u8; 2592] = mldsa_pub_key_u32.as_bytes().try_into().unwrap();
+
+        let mut prod_dbg_keypairs = vec![([0u8; 96], [0u8; 2592]); 8];
+        prod_dbg_keypairs[(unlock_level - 1) as usize] = (ecc_pub_key_bytes, mldsa_pub_key_bytes);
+
+        let mut ecc_private_key_bytes = [0u8; ECC384_SCALAR_BYTE_SIZE];
+        for (index, word) in VENDOR_ECC_KEY_0_PRIVATE.iter().enumerate() {
+            ecc_private_key_bytes[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+        }
+
+        let keys = DebugUnlockKeys {
+            ecc_private_key_bytes,
+            ecc_public_key: ecc_pub_key_u32,
+            mldsa_private_key_bytes: VENDOR_MLDSA_KEY_0_PRIVATE.0.as_bytes().to_vec(),
+            mldsa_public_key: mldsa_pub_key_u32.try_into().unwrap(),
+        };
+        (prod_dbg_keypairs, keys)
+    }
+
     /// Exercises the non-fuse command suite: ExportAttestedCsr and
     /// GetAttestation. The fuse-suite tests below cannot cover these, because
     /// `--fuse-suite` makes the validator run that suite alone.
     ///
-    /// No debug-unlock keys are passed, so the validator skips ProdDebugUnlock;
-    /// this test needs neither provisioned fuses nor a Prod lifecycle.
     #[ignore]
     #[test]
     fn test_caliptra_util_host_spdm_vdm_validator_commands() {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+        let unlock_level = 1u8;
+        let (prod_dbg_unlock_keypairs, debug_unlock_keys) = debug_unlock_material(unlock_level);
+        let keys_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
+        debug_unlock_keys
+            .save_to_file(keys_file.path())
+            .expect("Failed to write debug unlock keys");
+        let keys_path = keys_file.path().to_str().unwrap().to_string();
+
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(TEST_FEATURE),
             i3c_port: Some(PortPicker::new().pick().unwrap()),
+            debug_intent: true,
+            lifecycle_controller_state: Some(caliptra_mcu_hw_model::LifecycleControllerState::Prod),
+            prod_dbg_unlock_keypairs,
+            use_strap_secrets: true,
             ..Default::default()
         });
 
         hw.start_i3c_controller();
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_dbg_manuf_service_reg_req()
+            .write(|w| w.prod_dbg_unlock_req(true));
 
         let config_path = test_config_path();
         let (completed, failed) = run_spdm_vdm_test(
@@ -279,6 +330,10 @@ mod test {
                 "1,2,3",
                 "--algorithm",
                 "1",
+                "--debug-unlock-keys-file",
+                &keys_path,
+                "--unlock-level",
+                &unlock_level.to_string(),
             ],
         );
 
@@ -291,55 +346,11 @@ mod test {
     }
 
     fn run_isolated_fuse_suite(suite: &str) {
-        use caliptra_image_fake_keys::{
-            VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
-            VENDOR_MLDSA_KEY_0_PUBLIC,
-        };
-        use caliptra_image_types::{ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE};
-
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         let unlock_level = 1u8;
-
-        // --- Prepare ECC public key in hardware format (big-endian u32 words) ---
-        let mut ecc_pub_key_u32 = [0u32; ECC384_SCALAR_WORD_SIZE * 2];
-        ecc_pub_key_u32[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
-        ecc_pub_key_u32[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
-        let ecc_pub_key_bytes: [u8; 96] = ecc_pub_key_u32.as_bytes().try_into().unwrap();
-
-        // --- Prepare MLDSA public key in hardware format (little-endian u32 words) ---
-        let mldsa_pub_key_raw = VENDOR_MLDSA_KEY_0_PUBLIC.0.as_bytes();
-        let mldsa_pub_key_u32: Vec<u32> = mldsa_pub_key_raw
-            .chunks(4)
-            .map(|chunk| {
-                let mut arr = [0u8; 4];
-                arr.copy_from_slice(chunk);
-                u32::from_le_bytes(arr)
-            })
-            .collect();
-        let mldsa_pub_key_bytes: [u8; 2592] = mldsa_pub_key_u32.as_bytes().try_into().unwrap();
-
-        // --- Set up keypairs for fuse provisioning ---
-        let mut prod_dbg_keypairs: Vec<([u8; 96], [u8; 2592])> = vec![([0u8; 96], [0u8; 2592]); 8];
-        prod_dbg_keypairs[(unlock_level - 1) as usize] = (ecc_pub_key_bytes, mldsa_pub_key_bytes);
-
-        // --- Prepare ECC private key bytes for signing ---
-        let mut be_ecc_priv_key_bytes = [0u8; ECC384_SCALAR_BYTE_SIZE];
-        for (i, word) in VENDOR_ECC_KEY_0_PRIVATE.iter().enumerate() {
-            be_ecc_priv_key_bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
-        }
-
-        // --- Prepare MLDSA private key bytes for signing ---
-        let mldsa_priv_key_bytes: Vec<u8> = VENDOR_MLDSA_KEY_0_PRIVATE.0.as_bytes().to_vec();
-
-        // --- Build DebugUnlockKeys and write to temp file for the validator binary ---
-        let debug_unlock_keys = DebugUnlockKeys {
-            ecc_private_key_bytes: be_ecc_priv_key_bytes,
-            ecc_public_key: ecc_pub_key_u32,
-            mldsa_private_key_bytes: mldsa_priv_key_bytes,
-            mldsa_public_key: <[u32; 648]>::try_from(mldsa_pub_key_u32.as_slice()).unwrap(),
-        };
+        let (prod_dbg_keypairs, debug_unlock_keys) = debug_unlock_material(unlock_level);
         let keys_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
         debug_unlock_keys
             .save_to_file(keys_file.path())


### PR DESCRIPTION
Implemented SPDM VDM command format for Request Debug unlock does not conform with the format defined in the Caliptra Common Commands Spec.

The SPDM implementation intentionally accepts exactly one byte, unlock_level, and rejects trailing bytes. However, the transport-agnostic documentation still specifies [length(4), unlock_level, reserved(3)].

The MCU Mailbox follows the format defined in spec.

This change is to make the format used by the SPDM VDM to be the same as the MCU Mailbox one as defined in the Caliptra Common Commands Spec.

Fixes https://github.com/chipsalliance/caliptra-mcu-sw/issues/1748