### PR TITLE
spdm: add SPDM 1.4 ALGORITHMS support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,5 +20,5 @@ jobs:
   spdm_validator_version_1_4_tests:
     uses: ./.github/workflows/spdm-validator.yml
     with:
-      validator_test_groups: VERSION,CAPABILITIES
+      validator_test_groups: VERSION,CAPABILITIES,ALGORITHMS
 

--- a/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
@@ -66,6 +66,47 @@ def_flag_set_le! {
     }
 }
 
+/// SPDM 1.4 PQCAsymAlgo/PQCAsymSel bitmap.
+///
+/// This semantic type uses a native `u32`; endian conversion remains confined
+/// to the zerocopy wire structs below.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct PqcAsymAlgos(u32);
+
+impl PqcAsymAlgos {
+    pub const EMPTY: Self = Self(0);
+    pub const ML_DSA_44: Self = Self(1 << 0);
+    pub const ML_DSA_65: Self = Self(1 << 1);
+    pub const ML_DSA_87: Self = Self(1 << 2);
+    pub const SLH_DSA_SHA2_128S: Self = Self(1 << 3);
+    pub const SLH_DSA_SHAKE_128S: Self = Self(1 << 4);
+    pub const SLH_DSA_SHA2_128F: Self = Self(1 << 5);
+    pub const SLH_DSA_SHAKE_128F: Self = Self(1 << 6);
+    pub const SLH_DSA_SHA2_192S: Self = Self(1 << 7);
+    pub const SLH_DSA_SHAKE_192S: Self = Self(1 << 8);
+    pub const SLH_DSA_SHA2_192F: Self = Self(1 << 9);
+    pub const SLH_DSA_SHAKE_192F: Self = Self(1 << 10);
+    pub const SLH_DSA_SHA2_256S: Self = Self(1 << 11);
+    pub const SLH_DSA_SHAKE_256S: Self = Self(1 << 12);
+    pub const SLH_DSA_SHA2_256F: Self = Self(1 << 13);
+    pub const SLH_DSA_SHAKE_256F: Self = Self(1 << 14);
+
+    const VALID_MASK: u32 = 0x0000_7fff;
+
+    pub const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    pub const fn has_reserved_bits(self) -> bool {
+        self.0 & !Self::VALID_MASK != 0
+    }
+}
+
 def_flag_set_le! {
   /// BaseHashAlgo / BaseHashSel.
     pub struct HashAlgos(U32: u32) {
@@ -138,7 +179,10 @@ pub struct NegotiateAlgorithmsReqBodyFixed {
     pub other_param_support: OtherParamSupport,
     pub base_asym_algo: AsymAlgos,
     pub base_hash_algo: HashAlgos,
-    pub reserved1: [u8; 12],
+    /// PQC asymmetric algorithms offered by the requester in V1.4.
+    /// Reserved and zero in earlier versions.
+    pub pqc_asym_algo: U32,
+    pub reserved1: [u8; 8],
     pub ext_asym_count: u8,
     pub ext_hash_count: u8,
     /// Byte 28: Reserved.
@@ -173,7 +217,11 @@ pub struct AlgorithmsRspBodyFixed {
     pub meas_hash_algo: MeasHashAlgos,
     pub base_asym_sel: AsymAlgos,
     pub base_hash_sel: HashAlgos,
-    pub reserved3: [u8; 12],
+    /// Selected PQC asymmetric algorithm in V1.4. This classical-only
+    /// responder always returns zero.
+    pub pqc_asym_sel: U32,
+    pub reserved3: [u8; 7],
+    pub mel_specification_sel: u8,
     pub ext_asym_sel_count: u8,
     pub ext_hash_sel_count: u8,
     pub reserved4: [u8; 2],
@@ -242,6 +290,7 @@ pub struct AlgorithmsRsp {
     pub meas_hash_algo: MeasHashAlgos,
     pub base_asym_sel: AsymAlgos,
     pub base_hash_sel: HashAlgos,
+    pub pqc_asym_sel: PqcAsymAlgos,
     /// AlgStruct entries to advertise; `None` slots are skipped.
     pub alg_structs: [Option<AlgStructEntry>; MAX_ALG_STRUCT_ENTRIES],
 }
@@ -271,7 +320,9 @@ impl ResponseBody for AlgorithmsRsp {
             meas_hash_algo: self.meas_hash_algo,
             base_asym_sel: self.base_asym_sel,
             base_hash_sel: self.base_hash_sel,
-            reserved3: [0; 12],
+            pqc_asym_sel: U32::new(self.pqc_asym_sel.bits()),
+            reserved3: [0; 7],
+            mel_specification_sel: 0,
             ext_asym_sel_count: 0,
             ext_hash_sel_count: 0,
             reserved4: [0; 2],

--- a/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-//! SPDM CAPABILITIES wire types (DSP0274 §10.5).
+//! SPDM CAPABILITIES wire types (DSP0274 §10.3).
 //!
 //! Two layers:
 //!
@@ -11,13 +11,16 @@
 //!    GET_CAPABILITIES request and CAPABILITIES response (same wire
 //!    shape in both directions).
 
-use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::{
+    little_endian::{U16, U32},
+    FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
+};
 
 use crate::flag_macros::def_flag_set_le;
 use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
 
 def_flag_set_le! {
-    /// SPDM capability bitfield (DSP0274 §10.5.1 Table 11). Constants
+    /// SPDM capability bitfield (DSP0274 §10.3). Constants
     /// cover single-bit flags directly. The 2-bit `MEAS` and `PSK`
     /// fields are exposed as per-value constants (`MEAS_NO_SIG`,
     /// `MEAS_SIG`, `PSK`, `PSK_WITH_CTX`).
@@ -46,9 +49,20 @@ def_flag_set_le! {
         CHUNK = 1 << 17,
         ALIAS_CERT = 1 << 18,
         SET_CERT = 1 << 19,
+        CSR = 1 << 20,
+        CERT_INSTALL_RESET = 1 << 21,
+        EP_INFO_NO_SIG = 1 << 22,
+        EP_INFO_SIG = 2 << 22,
+        MEL = 1 << 24,
+        EVENT = 1 << 25,
+        /// `MULTI_KEY_CAP` field bits 27:26 set to `01b` (`MultiKeyOnly`).
+        MULTI_KEY_ONLY = 1 << 26,
         /// `MULTI_KEY_CAP` field bits 27:26 set to `10b` (`MultiKeyConnRsp`).
         MULTI_KEY_CONN_RSP = 2 << 26,
         GET_KEY_PAIR_INFO = 1 << 28,
+        SET_KEY_PAIR_INFO = 1 << 29,
+        SET_KEY_PAIR_RESET = 1 << 30,
+        LARGE_RESP = 1 << 31,
     }
 }
 
@@ -69,6 +83,20 @@ impl CapFlags {
     pub fn multi_key_field(self) -> u8 {
         ((self.into_bits() >> 26) & 0b11) as u8
     }
+
+    /// 2-bit `EP_INFO_CAP` field value (bits 22..=23).
+    #[inline]
+    pub fn ep_info_field(self) -> u8 {
+        ((self.into_bits() >> 22) & 0b11) as u8
+    }
+}
+
+def_flag_set_le! {
+    /// SPDM V1.4 extended responder capability flags. Requester
+    /// ExtFlags are reserved in V1.4 and therefore must be zero.
+    pub struct ExtCapFlags(U16: u16) {
+        SLOT_MGMT = 1 << 0,
+    }
 }
 
 /// 18-byte CAPABILITIES body (DSP0274 §10.5.1, v1.2+). Identical
@@ -81,7 +109,8 @@ pub struct CapabilitiesBody {
     pub param2: u8,
     pub reserved: u8,
     pub ct_exponent: u8,
-    pub reserved2: [u8; 2],
+    /// Extended capability flags in V1.4; reserved and zero in older versions.
+    pub ext_flags: ExtCapFlags,
     pub flags: CapFlags,
     pub data_transfer_size: U32,
     pub max_spdm_msg_size: U32,
@@ -94,8 +123,8 @@ impl CapabilitiesBody {
     /// ("MinDataTransferSize" in the spec).
     pub const MIN_DATA_TRANSFER_SIZE: u32 = 42;
 
-    /// Practical upper bound on CTExponent (CT = 2^32 µs ≈ 1.2 h).
-    pub const MAX_CT_EXPONENT: u8 = 32;
+    /// Maximum CTExponent accepted by libspdm and the responder validator.
+    pub const MAX_CT_EXPONENT: u8 = 31;
 }
 
 const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBody::SIZE);
@@ -103,6 +132,7 @@ const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBo
 /// Builder for a CAPABILITIES response.
 pub struct CapabilitiesRsp {
     pub ct_exponent: u8,
+    pub ext_flags: ExtCapFlags,
     pub flags: CapFlags,
     pub data_transfer_size: u32,
     pub max_spdm_msg_size: u32,
@@ -121,7 +151,7 @@ impl ResponseBody for CapabilitiesRsp {
             param2: 0,
             reserved: 0,
             ct_exponent: self.ct_exponent,
-            reserved2: [0; 2],
+            ext_flags: self.ext_flags,
             flags: self.flags,
             data_transfer_size: U32::new(self.data_transfer_size),
             max_spdm_msg_size: U32::new(self.max_spdm_msg_size),

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -32,7 +32,7 @@ pub use algorithms::{
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
-pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp};
+pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags};
 pub use certificate::{
     CertificateRsp, CertificateRspBody, GetCertificateReqBody, ATTR_SLOT_SIZE_REQUESTED,
 };

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -29,7 +29,7 @@ mod wire;
 pub use algorithms::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, AlgorithmsRspBodyFixed, AsymAlgos,
     DheAlgos, HashAlgos, KeyScheduleAlgos, MeasHashAlgos, MeasSpec,
-    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, MAX_ALG_STRUCT_ENTRIES,
+    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, MAX_ALG_STRUCT_ENTRIES,
 };
 pub use builder::ResponseBody;
 pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags};

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -24,7 +24,8 @@
 
 use caliptra_mcu_spdm_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, CapFlags, DheAlgos, KeyScheduleAlgos,
-    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, PqcAsymAlgos, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -84,15 +85,20 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
     )
     .map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    let alg_structs = locate_alg_structs(fixed, body)?;
-    let peer = parse_peer_algs(alg_structs)?;
-    let rsp_body = build_response_body(state, fixed, &peer, pal.secure_message_supported());
-    let spdm_len = rsp_body.encoded_size();
-    state.other_param_sel = rsp_body.other_param_support;
-    state.negotiated_base_asym_sel = rsp_body.base_asym_sel;
-    state.negotiated_base_hash_sel = rsp_body.base_hash_sel;
+    // Keep negotiation-only values out of the async state carried across
+    // transcript hashing. The encoded response itself is scratch-backed.
+    let (resp, spdm_len) = {
+        let alg_structs = locate_alg_structs(state.version, fixed, body)?;
+        let peer = parse_peer_algs(alg_structs)?;
+        let rsp_body = build_response_body(state, fixed, &peer, pal.secure_message_supported());
+        let spdm_len = rsp_body.encoded_size();
+        state.other_param_sel = rsp_body.other_param_support;
+        state.negotiated_base_asym_sel = rsp_body.base_asym_sel;
+        state.negotiated_base_hash_sel = rsp_body.base_hash_sel;
 
-    let resp = build_response(pal, io, state.version, &rsp_body)?;
+        let resp = build_response(pal, io, state.version, &rsp_body)?;
+        (resp, spdm_len)
+    };
 
     // SPDM: NEGOTIATE_ALGORITHMS + ALGORITHMS contribute to VCA.
     let head = pal.header_size();
@@ -128,10 +134,21 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
 ///   extended-hash entries overflow the body, or the trailing
 ///   `AlgStruct[]` does not consume the remaining bytes exactly.
 fn locate_alg_structs<'a>(
+    version: SpdmVersion,
     fixed: &NegotiateAlgorithmsReqBodyFixed,
     body: &'a [u8],
 ) -> SpdmResult<&'a [u8]> {
-    if fixed.param2 != 0 || fixed.reserved1 != [0; 12] || fixed.reserved2 != 0 {
+    if fixed.param2 != 0 || fixed.reserved1 != [0; 8] || fixed.reserved2 != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    // PQCAsymAlgo occupies bytes that were reserved before V1.4. A
+    // classical-only responder still has to accept valid V1.4 offers and
+    // select zero rather than treating the field as reserved.
+    let pqc_asym_algo = PqcAsymAlgos::from_bits(fixed.pqc_asym_algo.get());
+    if (version < SpdmVersion::V14 && pqc_asym_algo != PqcAsymAlgos::EMPTY)
+        || (version >= SpdmVersion::V14 && pqc_asym_algo.has_reserved_bits())
+    {
         return Err(SPDM_INVALID_REQUEST);
     }
 
@@ -270,6 +287,8 @@ fn build_response_body<S, L>(
         meas_hash_algo: state.meas_hash_algo,
         base_asym_sel: state.base_asym_sel & fixed.base_asym_algo,
         base_hash_sel: state.base_hash_sel & fixed.base_hash_algo,
+        // This responder currently implements only classical signatures.
+        pqc_asym_sel: PqcAsymAlgos::EMPTY,
         alg_structs: [
             (!dhe.is_empty()).then(|| AlgStructEntry::dhe(dhe)),
             (!aead.is_empty()).then(|| AlgStructEntry::aead(aead)),
@@ -297,12 +316,20 @@ mod tests {
     use futures::executor::block_on;
     use std::vec;
     use std::vec::Vec;
-    use zerocopy::{little_endian::U16, FromBytes, IntoBytes};
+    use zerocopy::{
+        little_endian::{U16, U32},
+        FromBytes, IntoBytes,
+    };
 
     use crate::measurements::support;
     use support::{test_digest, TestHashState, TestIo, TestPal};
 
-    fn negotiate_request(base_asym_algo: AsymAlgos, include_req_base_asym: bool) -> Vec<u8> {
+    fn negotiate_request(
+        version: SpdmVersion,
+        pqc_asym_algo: PqcAsymAlgos,
+        base_asym_algo: AsymAlgos,
+        include_req_base_asym: bool,
+    ) -> Vec<u8> {
         let mut alg_structs = vec![
             AlgStructEntry::dhe(DheAlgos::SECP_384_R1),
             AlgStructEntry::aead(AeadAlgos::AES_256_GCM),
@@ -327,7 +354,8 @@ mod tests {
             other_param_support: OtherParamSupport::OPAQUE_DATA_FMT1,
             base_asym_algo,
             base_hash_algo: HashAlgos::SHA_384,
-            reserved1: [0; 12],
+            pqc_asym_algo: U32::new(pqc_asym_algo.bits()),
+            reserved1: [0; 8],
             ext_asym_count: 0,
             ext_hash_count: 0,
             reserved2: 0,
@@ -336,7 +364,7 @@ mod tests {
 
         let mut request = Vec::with_capacity(total_len);
         request.extend_from_slice(
-            SpdmMsgHdrPdu::new(SpdmVersion::V12, ReqRespCode::NEGOTIATE_ALGORITHMS).as_bytes(),
+            SpdmMsgHdrPdu::new(version, ReqRespCode::NEGOTIATE_ALGORITHMS).as_bytes(),
         );
         request.extend_from_slice(fixed.as_bytes());
         for entry in &alg_structs {
@@ -348,8 +376,10 @@ mod tests {
 
     fn run_negotiate(request: Vec<u8>) -> (ConnectionState<TestHashState, Vec<u8>>, Vec<u8>) {
         let pal = TestPal::default();
+        let version = SpdmVersion::from_u8(request[0]).unwrap();
         let mut state = ConnectionState {
             phase: Phase::AfterCapabilities,
+            version,
             ..ConnectionState::default()
         };
         let io = TestIo::message(request);
@@ -359,6 +389,7 @@ mod tests {
 
     fn assert_algorithms_response(
         response: &[u8],
+        expected_version: SpdmVersion,
         expected_base_asym: AsymAlgos,
         expected_entries: &[AlgStructEntry],
     ) {
@@ -368,7 +399,7 @@ mod tests {
         assert_eq!(response.len(), expected_len);
 
         let (header, body) = SpdmMsgHdrPdu::ref_from_prefix(response).unwrap();
-        assert_eq!(header.version, SpdmVersion::V12.to_u8());
+        assert_eq!(header.version, expected_version.to_u8());
         assert_eq!(header.code, ReqRespCode::ALGORITHMS);
         let fixed = AlgorithmsRspBodyFixed::ref_from_bytes(
             body.get(..AlgorithmsRspBodyFixed::SIZE).unwrap(),
@@ -396,7 +427,9 @@ mod tests {
             fixed.base_hash_sel.into_bits(),
             HashAlgos::SHA_384.into_bits()
         );
-        assert_eq!(fixed.reserved3, [0; 12]);
+        assert_eq!(fixed.pqc_asym_sel.get(), 0);
+        assert_eq!(fixed.reserved3, [0; 7]);
+        assert_eq!(fixed.mel_specification_sel, 0);
         assert_eq!(fixed.ext_asym_sel_count, 0);
         assert_eq!(fixed.ext_hash_sel_count, 0);
         assert_eq!(fixed.reserved4, [0; 2]);
@@ -425,7 +458,12 @@ mod tests {
 
     #[test]
     fn algorithms_omits_peer_only_req_base_asym_structure_from_response_and_vca() {
-        let request = negotiate_request(AsymAlgos::ECDSA_ECC_NIST_P384, true);
+        let request = negotiate_request(
+            SpdmVersion::V12,
+            PqcAsymAlgos::EMPTY,
+            AsymAlgos::ECDSA_ECC_NIST_P384,
+            true,
+        );
         let (mut state, response) = run_negotiate(request);
         let expected_entries = [
             AlgStructEntry::dhe(DheAlgos::SECP_384_R1),
@@ -433,7 +471,12 @@ mod tests {
             AlgStructEntry::key_schedule(KeyScheduleAlgos::SPDM),
         ];
 
-        assert_algorithms_response(&response, AsymAlgos::ECDSA_ECC_NIST_P384, &expected_entries);
+        assert_algorithms_response(
+            &response,
+            SpdmVersion::V12,
+            AsymAlgos::ECDSA_ECC_NIST_P384,
+            &expected_entries,
+        );
         assert_eq!(
             state.negotiated_base_asym_sel.into_bits(),
             AsymAlgos::ECDSA_ECC_NIST_P384.into_bits()
@@ -444,7 +487,12 @@ mod tests {
 
     #[test]
     fn algorithms_keeps_zero_base_asym_selection_and_advances_state_without_common_algorithm() {
-        let request = negotiate_request(AsymAlgos::EMPTY, false);
+        let request = negotiate_request(
+            SpdmVersion::V12,
+            PqcAsymAlgos::EMPTY,
+            AsymAlgos::EMPTY,
+            false,
+        );
         let (mut state, response) = run_negotiate(request);
         let expected_entries = [
             AlgStructEntry::dhe(DheAlgos::SECP_384_R1),
@@ -452,10 +500,40 @@ mod tests {
             AlgStructEntry::key_schedule(KeyScheduleAlgos::SPDM),
         ];
 
-        assert_algorithms_response(&response, AsymAlgos::EMPTY, &expected_entries);
+        assert_algorithms_response(
+            &response,
+            SpdmVersion::V12,
+            AsymAlgos::EMPTY,
+            &expected_entries,
+        );
         assert_eq!(
             state.negotiated_base_asym_sel.into_bits(),
             AsymAlgos::EMPTY.into_bits()
+        );
+        assert_eq!(state.phase, Phase::AfterAlgorithms);
+        assert_response_was_appended_to_vca(&mut state, &response);
+    }
+
+    #[test]
+    fn v14_accepts_pqc_offer_and_selects_classical_algorithms_only() {
+        let request = negotiate_request(
+            SpdmVersion::V14,
+            PqcAsymAlgos::ML_DSA_87,
+            AsymAlgos::ECDSA_ECC_NIST_P384,
+            false,
+        );
+        let (mut state, response) = run_negotiate(request);
+        let expected_entries = [
+            AlgStructEntry::dhe(DheAlgos::SECP_384_R1),
+            AlgStructEntry::aead(AeadAlgos::AES_256_GCM),
+            AlgStructEntry::key_schedule(KeyScheduleAlgos::SPDM),
+        ];
+
+        assert_algorithms_response(
+            &response,
+            SpdmVersion::V14,
+            AsymAlgos::ECDSA_ECC_NIST_P384,
+            &expected_entries,
         );
         assert_eq!(state.phase, Phase::AfterAlgorithms);
         assert_response_was_appended_to_vca(&mut state, &response);

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -8,14 +8,16 @@
 //! 2. Negotiates the SPDM version using the requester's
 //!    common-header `version` byte (must be one of
 //!    [`SUPPORTED_VERSIONS`](crate::version::SUPPORTED_VERSIONS)).
-//! 3. Validates the V1.2+ `CapabilitiesBody` fields per the corresponding table.
+//! 3. Validates the V1.2+ `CapabilitiesBody`, version-specific capability
+//!    masks, extended flags, and capability dependencies.
 //! 4. Stashes the peer's advertised `DataTransferSize`,
 //!    `MaxSPDMmsgSize`, and capability flags into [`ConnectionState`].
 //! 5. Builds the `CAPABILITIES` response from the responder's fixed
 //!    local policy, then transitions to [`Phase::AfterCapabilities`].
 
 use caliptra_mcu_spdm_codec::{
-    CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion,
 };
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -64,7 +66,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 
     let req = io.request();
     let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
-    let version = select_version(state, hdr.version)?;
+    let version = select_version(hdr.version)?;
 
     let body = CapabilitiesBody::ref_from_bytes(
         rest.get(..CapabilitiesBody::SIZE)
@@ -72,17 +74,14 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     )
     .map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    let (peer_dts, peer_max) = validate_capabilities_body(body)?;
+    let (peer_dts, peer_max) = validate_capabilities_body(version, body)?;
+    state.version = version;
     state.peer_data_transfer_size = peer_dts;
     state.peer_max_spdm_msg_size = peer_max;
     state.peer_cap_flags = body.flags;
 
     let mtu = pal.mtu();
-    let mut flags = state.cap_flags;
-    if version < SpdmVersion::V13 {
-        let cleared = flags.into_bits() & !(0b11 << 26);
-        flags = CapFlags::from_bits(cleared);
-    }
+    let mut flags = CapFlags::from_bits(state.cap_flags.into_bits() & responder_cap_mask(version));
     if !pal.secure_message_supported() {
         let secure_session_caps = CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC;
         flags = CapFlags::from_bits(flags.into_bits() & !secure_session_caps.into_bits());
@@ -95,6 +94,8 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     } as u32;
     let body = CapabilitiesRsp {
         ct_exponent: state.ct_exponent,
+        // SLOT_MANAGEMENT is not implemented by this responder.
+        ext_flags: ExtCapFlags::EMPTY,
         flags,
         data_transfer_size: mtu as u32,
         max_spdm_msg_size,
@@ -114,7 +115,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     Ok(resp)
 }
 
-/// Validates a `CapabilitiesBody` against SPDM the corresponding table.
+/// Validates a `CapabilitiesBody` against the negotiated SPDM version.
 ///
 /// # Parameters
 ///
@@ -128,19 +129,38 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 ///
 /// # Errors
 ///
-/// * [`SPDM_INVALID_REQUEST`] — any reserved field is non-zero,
-///   `ct_exponent` exceeds the protocol maximum, `DataTransferSize` is
-///   below the spec minimum or above `MaxSPDMmsgSize`, or the
-///   requester clears `CHUNK` but advertises
-///   `DataTransferSize != MaxSPDMmsgSize`.
-fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)> {
-    // Param1/Param2 are reserved in V1.2; Param1 bit 0 = "Supported
-    // Algorithms request" in V1.3, which we don't implement, so both
-    // versions require these bytes to be zero.
-    if body.param1 != 0 || body.param2 != 0 || body.reserved != 0 || body.reserved2 != [0; 2] {
+/// * [`SPDM_INVALID_REQUEST`] — a reserved/version-inapplicable field or flag
+///   is non-zero, capability dependencies are invalid, `ct_exponent` exceeds
+///   the protocol maximum, transfer sizes are invalid, or the Supported
+///   Algorithms request is made without CHUNK support at both endpoints.
+fn validate_capabilities_body(
+    version: SpdmVersion,
+    body: &CapabilitiesBody,
+) -> SpdmResult<(u32, u32)> {
+    let param1_mask = if version >= SpdmVersion::V13 { 0x01 } else { 0 };
+    if body.param1 & !param1_mask != 0 || body.param2 != 0 || body.reserved != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    // Requester ExtFlags are reserved in SPDM V1.4 and the same bytes
+    // are reserved in all earlier versions.
+    if !body.ext_flags.is_empty() {
         return Err(SPDM_INVALID_REQUEST);
     }
     if body.ct_exponent > CapabilitiesBody::MAX_CT_EXPONENT {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let flags = body.flags;
+    if flags.into_bits() & !requester_cap_mask(version) != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    validate_request_flag_compatibility(version, flags)?;
+
+    // A requester can only request the Supported Algorithms block when it
+    // supports chunking. This responder does not currently include the
+    // optional block, so Param1 remains zero in the response even when this
+    // valid request bit is set.
+    if body.param1 & 0x01 != 0 && !flags.contains(CapFlags::CHUNK) {
         return Err(SPDM_INVALID_REQUEST);
     }
 
@@ -157,11 +177,103 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
     Ok((peer_dts, peer_max))
 }
 
-/// Picks the negotiated SPDM version and records it on `state`.
+fn validate_request_flag_compatibility(version: SpdmVersion, flags: CapFlags) -> SpdmResult<()> {
+    let cert = flags.contains(CapFlags::CERT);
+    let chal = flags.contains(CapFlags::CHAL);
+    let encrypt = flags.contains(CapFlags::ENCRYPT);
+    let mac = flags.contains(CapFlags::MAC);
+    let mut_auth = flags.contains(CapFlags::MUT_AUTH);
+    let key_ex = flags.contains(CapFlags::KEY_EX);
+    let psk = flags.psk_field();
+    let pub_key_id = flags.contains(CapFlags::PUB_KEY_ID);
+    let ep_info = flags.ep_info_field();
+    let multi_key = flags.multi_key_field();
+
+    // Requesters may advertise PSK_CAP=00b or 01b. The 10b value is
+    // responder-only and 11b is reserved.
+    if psk > 1 || ep_info == 3 || multi_key == 3 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let has_session_exchange = key_ex || psk != 0;
+    if has_session_exchange {
+        if !encrypt && !mac {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if encrypt
+        || mac
+        || flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR)
+        || flags.contains(CapFlags::HBEAT)
+        || flags.contains(CapFlags::KEY_UPD)
+        || (version >= SpdmVersion::V13 && flags.contains(CapFlags::EVENT))
+    {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if !key_ex && psk == 1 && flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if cert || pub_key_id {
+        if cert && pub_key_id {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        if !(chal || key_ex || (version >= SpdmVersion::V13 && ep_info == 2)) {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if chal || mut_auth || (version >= SpdmVersion::V13 && ep_info == 2) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if mut_auth && !key_ex && !chal {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if version >= SpdmVersion::V13 && multi_key != 0 && (!cert || pub_key_id) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
+}
+
+const REQUESTER_CAP_FLAGS_V12_MASK: u32 = (1 << 1)
+    | (1 << 2)
+    | (1 << 6)
+    | (1 << 7)
+    | (1 << 8)
+    | (1 << 9)
+    | (0b11 << 10)
+    | (1 << 12)
+    | (1 << 13)
+    | (1 << 14)
+    | (1 << 15)
+    | (1 << 16)
+    | (1 << 17);
+const REQUESTER_CAP_FLAGS_V13_MASK: u32 =
+    REQUESTER_CAP_FLAGS_V12_MASK | (0b11 << 22) | (1 << 25) | (0b11 << 26);
+const REQUESTER_CAP_FLAGS_V14_MASK: u32 = REQUESTER_CAP_FLAGS_V13_MASK | (1 << 31);
+
+const RESPONDER_CAP_FLAGS_V12_MASK: u32 = (1 << 22) - 1;
+const RESPONDER_CAP_FLAGS_V13_MASK: u32 = (1 << 30) - 1;
+const RESPONDER_CAP_FLAGS_V14_MASK: u32 = u32::MAX;
+
+fn requester_cap_mask(version: SpdmVersion) -> u32 {
+    match version {
+        SpdmVersion::V10 | SpdmVersion::V11 | SpdmVersion::V12 => REQUESTER_CAP_FLAGS_V12_MASK,
+        SpdmVersion::V13 => REQUESTER_CAP_FLAGS_V13_MASK,
+        SpdmVersion::V14 => REQUESTER_CAP_FLAGS_V14_MASK,
+    }
+}
+
+fn responder_cap_mask(version: SpdmVersion) -> u32 {
+    match version {
+        SpdmVersion::V10 | SpdmVersion::V11 | SpdmVersion::V12 => RESPONDER_CAP_FLAGS_V12_MASK,
+        SpdmVersion::V13 => RESPONDER_CAP_FLAGS_V13_MASK,
+        SpdmVersion::V14 => RESPONDER_CAP_FLAGS_V14_MASK,
+    }
+}
+
+/// Picks the requested SPDM version without mutating connection state.
 ///
 /// # Parameters
 ///
-/// * `state` — Connection state; `state.version` is updated on success.
 /// * `requested` — Raw `version` byte from the request's common header.
 ///
 /// # Returns
@@ -172,14 +284,10 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
 ///
 /// * [`SPDM_VERSION_MISMATCH`] — byte is not a recognised version or
 ///   not in [`SUPPORTED_VERSIONS`].
-fn select_version<S, L>(
-    state: &mut ConnectionState<S, L>,
-    requested: u8,
-) -> SpdmResult<SpdmVersion> {
+fn select_version(requested: u8) -> SpdmResult<SpdmVersion> {
     let v = SpdmVersion::from_u8(requested).ok_or(SPDM_VERSION_MISMATCH)?;
     if !SUPPORTED_VERSIONS.contains(&v) {
         return Err(SPDM_VERSION_MISMATCH);
     }
-    state.version = v;
     Ok(v)
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -1113,3 +1113,7 @@ mod tests;
 #[cfg(test)]
 #[path = "tests/version.rs"]
 mod version_tests;
+
+#[cfg(test)]
+#[path = "tests/capabilities.rs"]
+mod capabilities_tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -1,0 +1,278 @@
+// Licensed under the Apache-2.0 license
+
+#![allow(clippy::field_reassign_with_default)]
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmVersion};
+use caliptra_mcu_spdm_traits::NoVdmBackend;
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+
+#[path = "support.rs"]
+mod support;
+use support::{TestHashState, TestIo, TestPal};
+
+fn capabilities_request(
+    version: SpdmVersion,
+    param1: u8,
+    ext_flags: u16,
+    flags: CapFlags,
+    data_transfer_size: u32,
+    max_spdm_msg_size: u32,
+) -> Vec<u8> {
+    let mut req = vec![
+        version.to_u8(),
+        ReqRespCode::GET_CAPABILITIES.0,
+        param1,
+        0,
+        0,
+        0,
+    ];
+    req.extend_from_slice(&ext_flags.to_le_bytes());
+    req.extend_from_slice(&flags.into_bits().to_le_bytes());
+    req.extend_from_slice(&data_transfer_size.to_le_bytes());
+    req.extend_from_slice(&max_spdm_msg_size.to_le_bytes());
+    req
+}
+
+fn dispatch_request(
+    state: &mut ConnectionState<TestHashState, Vec<u8>>,
+    sessions: &mut Sessions<TestPal, 1>,
+    pal: &TestPal,
+    request: Vec<u8>,
+) -> SpdmResult<Vec<u8>> {
+    let io = TestIo::message(request);
+    block_on(dispatch(
+        state,
+        sessions,
+        pal,
+        &io,
+        ReqRespCode::GET_CAPABILITIES,
+        &NoVdmBackend,
+    ))
+}
+
+#[test]
+fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::LARGE_RESP;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 4096),
+    )
+    .unwrap();
+
+    assert_eq!(rsp.len(), 20);
+    assert_eq!(rsp[0], SpdmVersion::V14.to_u8());
+    assert_eq!(rsp[1], ReqRespCode::CAPABILITIES.0);
+    assert_eq!(&rsp[6..8], &[0, 0]);
+    assert_eq!(
+        u32::from_le_bytes(rsp[8..12].try_into().unwrap()),
+        state.advertised_cap_flags.into_bits()
+    );
+    assert_eq!(state.version, SpdmVersion::V14);
+    assert_eq!(state.phase, Phase::AfterCapabilities);
+    assert_eq!(state.peer_cap_flags.into_bits(), peer_flags.into_bits());
+    assert_eq!(state.peer_data_transfer_size, 1024);
+    assert_eq!(state.peer_max_spdm_msg_size, 4096);
+}
+
+#[test]
+fn get_capabilities_masks_flags_added_after_v12() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags |= CapFlags::GET_KEY_PAIR_INFO | CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V12, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+
+    assert!(!advertised.contains(CapFlags::GET_KEY_PAIR_INFO));
+    assert!(!advertised.contains(CapFlags::LARGE_RESP));
+}
+
+#[test]
+fn invalid_v14_capabilities_does_not_commit_negotiation_state() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 1, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::EMPTY.into_bits()
+    );
+    assert_eq!(state.peer_data_transfer_size, 0);
+    assert_eq!(state.peer_max_spdm_msg_size, 0);
+}
+
+#[test]
+fn v14_capabilities_rejects_incompatible_session_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    // KEY_EX requires at least one of ENCRYPT or MAC.
+    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
+}
+
+#[test]
+fn v14_capabilities_accepts_supported_algorithms_request_with_chunking() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 1, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+
+    // The request is valid, but this responder does not implement the
+    // optional Supported Algorithms block and therefore clears Param1.
+    assert_eq!(rsp[2], 0);
+    assert_eq!(state.phase, Phase::AfterCapabilities);
+}
+
+#[test]
+fn v14_supported_algorithms_request_does_not_require_responder_chunking() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags =
+        CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 1, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+
+    assert_eq!(rsp[2], 0);
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+    assert!(!advertised.contains(CapFlags::CHUNK));
+}
+
+#[test]
+fn capabilities_enforces_ct_exponent_limit() {
+    let pal = TestPal::default();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    for (ct_exponent, accepted) in [(31, true), (32, false)] {
+        let mut state = ConnectionState::default();
+        state.phase = Phase::AfterVersion;
+        let mut sessions = SessionManager::new();
+        let mut request = capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024);
+        request[5] = ct_exponent;
+
+        assert_eq!(
+            dispatch_request(&mut state, &mut sessions, &pal, request).is_ok(),
+            accepted
+        );
+    }
+}
+
+#[test]
+fn v13_capabilities_rejects_v14_requester_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::LARGE_RESP;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V13, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+}
+
+#[test]
+fn v13_capabilities_masks_v14_responder_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    state.cap_flags |= CapFlags::SET_KEY_PAIR_RESET | CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    let rsp = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V13, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap();
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+
+    assert!(!advertised.contains(CapFlags::SET_KEY_PAIR_RESET));
+    assert!(!advertised.contains(CapFlags::LARGE_RESP));
+}


### PR DESCRIPTION
The responder negotiates SPDM 1.4 but does not yet decode the PQC asymmetric fields added to NEGOTIATE_ALGORITHMS and ALGORITHMS.

Decode and validate the SPDM 1.4 PQC asymmetric offer while retaining the responder's classical-only policy. Valid PQC and KEM offers are accepted, reserved PQC bits are rejected, and the response returns a zero PQC selection. Include ALGORITHMS in the targeted SPDM 1.4 nightly validator run.

This PR is stacked on #2012 and uses:
- chipsalliance/caliptra-spdm-emu#4
- chipsalliance/caliptra-SPDM-Responder-Validator#7

End-to-end responder-validator results at MCU `25b14db3`, spdm-emu `fc5a6551`, and responder-validator integration revision `067d7099`:

| transport | selection | process | pass | fail | ALGORITHMS group | ALGORITHMS 1.4 case 3.9 |
|---|---|---:|---:|---:|---:|---:|
| MCTP | VERSION,CAPABILITIES,ALGORITHMS | 0 | 188 | 0 | 88 pass, 0 fail | 18 pass, 0 fail |
| DOE | VERSION,CAPABILITIES,ALGORITHMS | 0 | 205 | 0 | 96 pass, 0 fail | 22 pass, 0 fail |

MCTP SPDM attestation with a PCR quote also passed after SPDM 1.4 negotiation.

Memory:
- Kernel: text 153,536 B; data 36 B; BSS 28,632 B
- User app: flash 301,858 B; RAM 76,096 B
- SPDM-attributed: flash 105,830 B; RAM 31,649 B
- Runtime bundle: 457,728 B
