### PR TITLE
[spdm] update spdm-lib CERTIFICATE to support large offset/length 

### DIFF
--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -11,7 +11,7 @@ on:
   # excluded: these tests build spdm-emu from source and run four emulator
   # suites, which is too slow to put in front of every pull request.
   pull_request:
-    branches: [ main, main-2.1 ]
+    branches: [main, main-2.1]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
@@ -95,7 +95,7 @@ jobs:
           repository: chipsalliance/caliptra-spdm-emu
           # TODO: Update this pull-request ref to the corresponding unmerged
           # caliptra-spdm-emu PR for each SPDM change.
-          ref: ${{ github.event_name == 'pull_request' && 'refs/pull/4/head' || 'caliptra-main-14' }}
+          ref: ${{ github.event_name == 'pull_request' && 'refs/pull/5/head' || 'caliptra-main-14' }}
           path: spdm-emu
           submodules: recursive
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
 name = "caliptra-mcu-spdm-codec"
 version = "0.1.0"
 dependencies = [
+ "bitfield-struct",
  "caliptra-mcu-runtime-userspace-error",
  "caliptra-mcu-spdm-errors",
  "caliptra-mcu-spdm-traits",

--- a/runtime/userspace/api/spdm-lib/codec/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/codec/Cargo.toml
@@ -11,3 +11,4 @@ zerocopy = { workspace = true }
 caliptra-mcu-spdm-traits = { workspace = true }
 caliptra-mcu-spdm-errors = { workspace = true }
 mcu-error = { workspace = true }
+bitfield-struct = { workspace = true }

--- a/runtime/userspace/api/spdm-lib/codec/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/certificate.rs
@@ -27,13 +27,43 @@
 //! `CertChain` carries `PortionLength` bytes of the SPDM cert-chain
 //! wire format (length(2) | reserved(2) | root_hash(48) | DER).
 
-use zerocopy::{little_endian::U16, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::{
+    little_endian::{U16, U32},
+    FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
+};
 
 use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
+use bitfield_struct::bitfield;
+
+/// `Param1` field of GET_CERTIFICATE / CERTIFICATE
+/// Bits 0..=3 carry the `SlotID`, and bit 7 is the `LargeCertChain` flag (SPDM 1.4).
+#[bitfield(u8)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, PartialEq, Eq)]
+pub struct GetCertificateParam1 {
+    #[bits(4)]
+    pub slot_id: u8,
+    #[bits(3)]
+    _reserved: u8,
+    pub large_cert_chain: bool,
+}
+
+const PARAM1_SLOT_ID_MASK: u8 = 0xF;
 
 /// 6-byte GET_CERTIFICATE request body (after the 2-byte SPDM
 /// common header).
-#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
 #[repr(C)]
 pub struct GetCertificateReqBody {
     /// `Param1` — `SlotID` in bits 0..=3.
@@ -52,13 +82,159 @@ impl GetCertificateReqBody {
 
 const _: () = assert!(core::mem::size_of::<GetCertificateReqBody>() == GetCertificateReqBody::SIZE);
 
+/// 14-byte GET_CERTIFICATE request body when LargeCertChain=1
+/// (after the 2-byte SPDM common header). DSP0274 §10.8 Table 39.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(C)]
+pub struct GetCertificateLargeReqBody {
+    /// `Param1` — `SlotID` in bits 0..=3, `LargeCertChain` in bit 7.
+    pub param1: GetCertificateParam1,
+    /// `Param2` — request attributes (bit 0 = SlotSizeRequested).
+    pub attributes: u8,
+    /// 16-bit offset (0 when LargeCertChain=1).
+    pub offset: U16,
+    /// 16-bit length (0 when LargeCertChain=1).
+    pub length: U16,
+    /// 32-bit LargeOffset into the SPDM cert chain (bytes).
+    pub large_offset: U32,
+    /// 32-bit LargeLength requested (bytes).
+    pub large_length: U32,
+}
+
+impl GetCertificateLargeReqBody {
+    pub const SIZE: usize = 14;
+}
+
+const _: () =
+    assert!(core::mem::size_of::<GetCertificateLargeReqBody>() == GetCertificateLargeReqBody::SIZE);
+
+/// Parsed representation of a GET_CERTIFICATE request body (standard 6-byte or SPDM 1.4 14-byte large).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GetCertificateReq<'a> {
+    Standard(&'a GetCertificateReqBody),
+    Large(&'a GetCertificateLargeReqBody),
+}
+
+impl<'a> GetCertificateReq<'a> {
+    /// Parse a GET_CERTIFICATE request body (excluding the 2-byte common SPDM header).
+    pub fn parse(body: &'a [u8]) -> Result<Self, WireError> {
+        let param1 = GetCertificateParam1::from_bits(*body.first().ok_or(WireError)?);
+        if param1.large_cert_chain() {
+            let (req, _) =
+                GetCertificateLargeReqBody::ref_from_prefix(body).map_err(|_| WireError)?;
+            if req.offset != 0 || req.length != 0 {
+                return Err(WireError);
+            }
+            Ok(Self::Large(req))
+        } else {
+            if body.len() != GetCertificateReqBody::SIZE {
+                return Err(WireError);
+            }
+            let (req, _) = GetCertificateReqBody::ref_from_prefix(body).map_err(|_| WireError)?;
+            Ok(Self::Standard(req))
+        }
+    }
+
+    /// Whether this is a large (SPDM 1.4 LargeCertChain) request.
+    #[inline]
+    pub fn is_large(&self) -> bool {
+        matches!(self, Self::Large(_))
+    }
+
+    /// Target SlotID (bits 0..=3).
+    #[inline]
+    pub fn slot_id(&self) -> u8 {
+        match self {
+            Self::Standard(req) => req.slot_id & PARAM1_SLOT_ID_MASK,
+            Self::Large(req) => req.param1.slot_id(),
+        }
+    }
+
+    /// Request attributes (Param2).
+    #[inline]
+    pub fn attributes(&self) -> u8 {
+        match self {
+            Self::Standard(req) => req.attributes,
+            Self::Large(req) => req.attributes,
+        }
+    }
+
+    /// Whether the SlotSizeRequested attribute bit is set.
+    #[inline]
+    pub fn is_slot_size_requested(&self) -> bool {
+        (self.attributes() & ATTR_SLOT_SIZE_REQUESTED) != 0
+    }
+
+    /// Offset into the cert chain in bytes (16-bit for standard, 32-bit for large).
+    #[inline]
+    pub fn offset(&self) -> usize {
+        match self {
+            Self::Standard(req) => req.offset.get() as usize,
+            Self::Large(req) => req.large_offset.get() as usize,
+        }
+    }
+
+    /// Requested portion length in bytes (16-bit for standard, 32-bit for large).
+    #[inline]
+    pub fn length(&self) -> usize {
+        match self {
+            Self::Standard(req) => req.length.get() as usize,
+            Self::Large(req) => req.large_length.get() as usize,
+        }
+    }
+
+    /// Body size of the corresponding response header (6 for standard, 14 for large).
+    #[inline]
+    pub fn rsp_header_body_size(&self) -> usize {
+        if self.is_large() {
+            CertificateLargeRspBody::SIZE
+        } else {
+            CertificateRspBody::SIZE
+        }
+    }
+
+    /// Maximum cert chain length that can be represented in this request mode.
+    #[inline]
+    pub fn max_length_cap(&self) -> usize {
+        if self.is_large() {
+            u32::MAX as usize
+        } else {
+            u16::MAX as usize
+        }
+    }
+}
+
 /// Request attribute bit: requester is asking for the total cert
 /// chain size only — responder sets `PortionLength = 0` and
 /// `RemainderLength = total_cert_chain_size`.
 pub const ATTR_SLOT_SIZE_REQUESTED: u8 = 0x01;
 
 /// 6-byte CERTIFICATE response body header.
-#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
 #[repr(C)]
 pub struct CertificateRspBody {
     pub slot_id: u8,
@@ -73,6 +249,43 @@ impl CertificateRspBody {
 }
 
 const _: () = assert!(core::mem::size_of::<CertificateRspBody>() == CertificateRspBody::SIZE);
+
+/// 14-byte CERTIFICATE response body header when LargeCertChain=1.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(C)]
+pub struct CertificateLargeRspBody {
+    /// `Param1` — `SlotID` in bits 0..=3, `LargeCertChain` in bit 7.
+    pub param1: GetCertificateParam1,
+    /// V1.3+: `CertModel` (bits 0..=2), else Reserved.
+    pub param2: u8,
+    /// 16-bit PortionLength (0 per spec when LargeCertChain=1).
+    pub portion_length: U16,
+    /// 16-bit RemainderLength (0 per spec when LargeCertChain=1).
+    pub remainder_length: U16,
+    /// 32-bit LargePortionLength.
+    pub large_portion_length: U32,
+    /// 32-bit LargeRemainderLength.
+    pub large_remainder_length: U32,
+}
+
+impl CertificateLargeRspBody {
+    pub const SIZE: usize = 14;
+}
+
+const _: () =
+    assert!(core::mem::size_of::<CertificateLargeRspBody>() == CertificateLargeRspBody::SIZE);
 
 /// Builder for a CERTIFICATE response. The handler pre-fills the
 /// `chain_portion` slice (from a pool-allocated buffer) before
@@ -102,5 +315,134 @@ impl ResponseBody for CertificateRsp<'_> {
             remainder_length: U16::new(self.remainder_length),
         })?;
         w.write_bytes(self.chain_portion)
+    }
+}
+
+/// Builder for a large CERTIFICATE response (SPDM 1.4 LargeCertChain=1).
+pub struct CertificateLargeRsp<'a> {
+    pub slot_id: u8,
+    pub param2: u8,
+    pub large_portion_length: u32,
+    pub large_remainder_length: u32,
+    /// Slice of `large_portion_length` bytes carrying SPDM cert-chain
+    /// content for `[large_offset, large_offset + large_portion_length)`.
+    pub chain_portion: &'a [u8],
+}
+
+impl ResponseBody for CertificateLargeRsp<'_> {
+    const RESPONSE_CODE: ReqRespCode = ReqRespCode::CERTIFICATE;
+
+    fn body_size(&self) -> usize {
+        CertificateLargeRspBody::SIZE + self.chain_portion.len()
+    }
+
+    fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
+        w.write(&CertificateLargeRspBody {
+            param1: GetCertificateParam1::new()
+                .with_slot_id(self.slot_id)
+                .with_large_cert_chain(true),
+            param2: self.param2,
+            portion_length: U16::new(0),
+            remainder_length: U16::new(0),
+            large_portion_length: U32::new(self.large_portion_length),
+            large_remainder_length: U32::new(self.large_remainder_length),
+        })?;
+        w.write_bytes(self.chain_portion)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SpdmVersion;
+
+    #[test]
+    fn test_large_req_body_size_and_decode() {
+        let bytes = [
+            0x81, // slot 1 | LargeCertChain (0x80)
+            0x01, // SlotSizeRequested
+            0x00, 0x00, // offset
+            0x00, 0x00, // length
+            0x40, 0x00, 0x00, 0x00, // large_offset = 64
+            0x00, 0x10, 0x00, 0x00, // large_length = 4096
+        ];
+        let (req, _) = GetCertificateLargeReqBody::ref_from_prefix(&bytes).unwrap();
+        assert_eq!(req.param1.into_bits(), 0x81);
+        assert_eq!(req.param1.slot_id(), 1);
+        assert!(req.param1.large_cert_chain());
+        assert_eq!(req.attributes, ATTR_SLOT_SIZE_REQUESTED);
+        assert_eq!(req.large_offset.get(), 64);
+        assert_eq!(req.large_length.get(), 4096);
+    }
+
+    #[test]
+    fn test_large_rsp_builder() {
+        let payload = [0xAA, 0xBB, 0xCC, 0xDD];
+        let rsp = CertificateLargeRsp {
+            slot_id: 1,
+            param2: 2,
+            large_portion_length: 4,
+            large_remainder_length: 100,
+            chain_portion: &payload,
+        };
+
+        assert_eq!(rsp.body_size(), 14 + 4);
+        let mut buf = [0u8; 2 + 14 + 4];
+        let mut w = WireWriter::new(&mut buf);
+        rsp.encode_with_header(SpdmVersion::V14, &mut w).unwrap();
+
+        assert_eq!(buf[0], SpdmVersion::V14.to_u8());
+        assert_eq!(buf[1], ReqRespCode::CERTIFICATE.0);
+        assert_eq!(buf[2], 0x81); // slot 1 | LargeCertChain
+        assert_eq!(buf[3], 2); // param2
+        assert_eq!(&buf[4..6], &[0, 0]); // portion_length == 0
+        assert_eq!(&buf[6..8], &[0, 0]); // remainder_length == 0
+        assert_eq!(&buf[8..12], &[4, 0, 0, 0]); // large_portion_length == 4
+        assert_eq!(&buf[12..16], &[100, 0, 0, 0]); // large_remainder_length == 100
+        assert_eq!(&buf[16..20], &payload);
+    }
+
+    #[test]
+    fn test_get_certificate_req_enum() {
+        // Standard request (6 bytes)
+        let std_bytes = [
+            0x02, // slot 2
+            0x01, // SlotSizeRequested
+            0x34, 0x12, // offset = 0x1234
+            0x00, 0x10, // length = 0x1000
+        ];
+        let req = GetCertificateReq::parse(&std_bytes).unwrap();
+        assert!(!req.is_large());
+        assert_eq!(req.slot_id(), 2);
+        assert_eq!(req.attributes(), 0x01);
+        assert!(req.is_slot_size_requested());
+        assert_eq!(req.offset(), 0x1234);
+        assert_eq!(req.length(), 0x1000);
+        assert_eq!(req.rsp_header_body_size(), CertificateRspBody::SIZE);
+        assert_eq!(req.max_length_cap(), u16::MAX as usize);
+
+        // Large request (14 bytes)
+        let large_bytes = [
+            0x83, // slot 3 | LargeCertChain
+            0x00, // attributes
+            0x00, 0x00, // offset
+            0x00, 0x00, // length
+            0x78, 0x56, 0x34, 0x12, // large_offset = 0x12345678
+            0x00, 0x00, 0x01, 0x00, // large_length = 0x00010000
+        ];
+        let req = GetCertificateReq::parse(&large_bytes).unwrap();
+        assert!(req.is_large());
+        assert_eq!(req.slot_id(), 3);
+        assert_eq!(req.attributes(), 0x00);
+        assert!(!req.is_slot_size_requested());
+        assert_eq!(req.offset(), 0x12345678);
+        assert_eq!(req.length(), 0x00010000);
+        assert_eq!(req.rsp_header_body_size(), CertificateLargeRspBody::SIZE);
+        assert_eq!(req.max_length_cap(), u32::MAX as usize);
+
+        // Truncated request errors
+        assert!(GetCertificateReq::parse(&[]).is_err());
+        assert!(GetCertificateReq::parse(&[0x00; 5]).is_err());
+        assert!(GetCertificateReq::parse(&[0x80; 13]).is_err());
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -34,7 +34,9 @@ pub use algorithms::{
 pub use builder::ResponseBody;
 pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp, ExtCapFlags};
 pub use certificate::{
-    CertificateRsp, CertificateRspBody, GetCertificateReqBody, ATTR_SLOT_SIZE_REQUESTED,
+    CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
+    GetCertificateLargeReqBody, GetCertificateParam1, GetCertificateReq, GetCertificateReqBody,
+    ATTR_SLOT_SIZE_REQUESTED,
 };
 pub use challenge::{ChallengeAuthRsp, ChallengeReqBody};
 pub use chunk::{

--- a/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
@@ -11,8 +11,9 @@
 //! stack-allocated `[u8; N]` array for cert payload.
 
 use caliptra_mcu_spdm_codec::{
-    CertificateRsp, CertificateRspBody, GetCertificateReqBody, ReqRespCode, ResponseBody,
-    SpdmMsgHdrPdu, SpdmVersion, WireWriter, ATTR_SLOT_SIZE_REQUESTED,
+    CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
+    GetCertificateParam1, GetCertificateReq, ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    WireWriter,
 };
 use caliptra_mcu_spdm_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
@@ -22,8 +23,8 @@ use zerocopy::{little_endian::U16, FromBytes};
 use crate::build::{build_error_response, build_response};
 use crate::chunk::LargeResponse;
 use crate::error::{
-    SpdmResult, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE, SPDM_UNEXPECTED_REQUEST,
-    SPDM_UNSPECIFIED,
+    SpdmResult, SPDM_DATA_TOO_LARGE, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE,
+    SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
 };
 use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 
@@ -33,15 +34,18 @@ use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 const SPDM_CERT_CHAIN_HDR_LEN: usize = 4 + 48;
 const SHA384_DIGEST_SIZE: usize = 48;
 const CERTIFICATE_RESPONSE_HEADER_SIZE: usize = SpdmMsgHdrPdu::SIZE + CertificateRspBody::SIZE;
+const CERTIFICATE_LARGE_RESPONSE_HEADER_SIZE: usize =
+    SpdmMsgHdrPdu::SIZE + CertificateLargeRspBody::SIZE;
 
 #[derive(Copy, Clone)]
 pub(crate) struct CertificateLargeResponse {
     slot_id: u8,
     param2: u8,
     asym_algo: SpdmPalAsymAlgo,
-    cert_offset: u16,
-    portion_len: u16,
-    remainder_len: u16,
+    cert_offset: u32,
+    portion_len: u32,
+    remainder_len: u32,
+    large: bool,
 }
 
 impl CertificateLargeResponse {
@@ -50,9 +54,10 @@ impl CertificateLargeResponse {
         slot_id: u8,
         param2: u8,
         asym_algo: SpdmPalAsymAlgo,
-        cert_offset: u16,
-        portion_len: u16,
-        remainder_len: u16,
+        cert_offset: u32,
+        portion_len: u32,
+        remainder_len: u32,
+        large: bool,
     ) -> Self {
         Self {
             slot_id,
@@ -61,12 +66,22 @@ impl CertificateLargeResponse {
             cert_offset,
             portion_len,
             remainder_len,
+            large,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn header_size(&self) -> usize {
+        if self.large {
+            CERTIFICATE_LARGE_RESPONSE_HEADER_SIZE
+        } else {
+            CERTIFICATE_RESPONSE_HEADER_SIZE
         }
     }
 
     #[inline]
     pub(crate) fn response_size(&self) -> usize {
-        CERTIFICATE_RESPONSE_HEADER_SIZE + self.portion_len as usize
+        self.header_size() + self.portion_len as usize
     }
 
     pub(crate) async fn fill_chunk<Pal: SpdmPal>(
@@ -84,22 +99,40 @@ impl CertificateLargeResponse {
             return Err(mcu_error::codes::INVARIANT);
         }
 
+        let hdr_size = self.header_size();
         let mut written = 0;
-        if offset < CERTIFICATE_RESPONSE_HEADER_SIZE {
-            let mut hdr = [0u8; CERTIFICATE_RESPONSE_HEADER_SIZE];
-            let mut writer = WireWriter::new(&mut hdr);
+        if offset < hdr_size {
+            let mut hdr = [0u8; CERTIFICATE_LARGE_RESPONSE_HEADER_SIZE];
+            let mut writer = WireWriter::new(&mut hdr[..hdr_size]);
             writer
                 .write(&SpdmMsgHdrPdu::new(version, ReqRespCode::CERTIFICATE))
                 .map_err(|_| mcu_error::codes::INVARIANT)?;
-            writer
-                .write(&CertificateRspBody {
-                    slot_id: self.slot_id,
-                    param2: self.param2,
-                    portion_length: U16::new(self.portion_len),
-                    remainder_length: U16::new(self.remainder_len),
-                })
-                .map_err(|_| mcu_error::codes::INVARIANT)?;
-            let hdr_end = CERTIFICATE_RESPONSE_HEADER_SIZE.min(end);
+            if self.large {
+                writer
+                    .write(&CertificateLargeRspBody {
+                        param1: GetCertificateParam1::new()
+                            .with_slot_id(self.slot_id)
+                            .with_large_cert_chain(true),
+                        param2: self.param2,
+                        portion_length: U16::new(0),
+                        remainder_length: U16::new(0),
+                        large_portion_length: zerocopy::little_endian::U32::new(self.portion_len),
+                        large_remainder_length: zerocopy::little_endian::U32::new(
+                            self.remainder_len,
+                        ),
+                    })
+                    .map_err(|_| mcu_error::codes::INVARIANT)?;
+            } else {
+                writer
+                    .write(&CertificateRspBody {
+                        slot_id: self.slot_id,
+                        param2: self.param2,
+                        portion_length: U16::new(self.portion_len as u16),
+                        remainder_length: U16::new(self.remainder_len as u16),
+                    })
+                    .map_err(|_| mcu_error::codes::INVARIANT)?;
+            }
+            let hdr_end = hdr_size.min(end);
             let copy_len = hdr_end - offset;
             let src = hdr
                 .get(offset..hdr_end)
@@ -112,8 +145,7 @@ impl CertificateLargeResponse {
         }
 
         if written < dst.len() {
-            let cert_offset =
-                self.cert_offset as usize + offset + written - CERTIFICATE_RESPONSE_HEADER_SIZE;
+            let cert_offset = self.cert_offset as usize + offset + written - hdr_size;
             fill_cert_chain_portion(
                 pal,
                 io,
@@ -149,24 +181,23 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
         return Err(SPDM_UNEXPECTED_REQUEST);
     }
 
-    // Decode the 6-byte request body.
     let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(spdm_msg).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8() {
         return Err(crate::error::SPDM_VERSION_MISMATCH);
     }
-    let req_body = GetCertificateReqBody::ref_from_bytes(
-        body.get(..GetCertificateReqBody::SIZE)
-            .ok_or(SPDM_INVALID_REQUEST)?,
-    )
-    .map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    let slot_id = req_body.slot_id & 0x0F;
+    let req = GetCertificateReq::parse(body).map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    if req.is_large() && state.version < SpdmVersion::V14 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let slot_id = req.slot_id();
     if slot_id >= MAX_SLOTS {
         return Err(SPDM_INVALID_REQUEST);
     }
+    let slot_size_only = state.version >= SpdmVersion::V13 && req.is_slot_size_requested();
     let provisioned = pal.provisioned_slots();
-    let slot_size_only =
-        state.version >= SpdmVersion::V13 && (req_body.attributes & ATTR_SLOT_SIZE_REQUESTED) != 0;
     if provisioned & (1 << slot_id) == 0 && !slot_size_only {
         return Err(SPDM_INVALID_REQUEST);
     }
@@ -182,35 +213,37 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
     let total_len_usize = SPDM_CERT_CHAIN_HDR_LEN
         .checked_add(der_len)
         .ok_or(SPDM_UNSPECIFIED)?;
-    let total_len = u16::try_from(total_len_usize).map_err(|_| SPDM_UNSPECIFIED)?;
+
+    if total_len_usize > req.max_length_cap() {
+        return Err(SPDM_DATA_TOO_LARGE);
+    }
 
     let single_frame_portion = state
         .effective_data_transfer_size(pal)
-        .saturating_sub(SpdmMsgHdrPdu::SIZE + CertificateRspBody::SIZE);
+        .saturating_sub(SpdmMsgHdrPdu::SIZE + req.rsp_header_body_size());
 
     let (offset, portion_len, remainder_len) = if slot_size_only {
-        // V1.3 SlotSizeRequested: report total in RemainderLength.
-        (0u16, 0u16, total_len)
+        (0u32, 0u32, total_len_usize as u32)
     } else {
-        let off = req_body.offset.get() as usize;
-        if off > total_len_usize {
+        if req.offset() > total_len_usize {
             return Err(SPDM_INVALID_REQUEST);
         }
-        let remaining = total_len_usize - off;
+        let remaining = total_len_usize - req.offset();
         let chunking = state.chunking_enabled();
         let max_portion = if chunking {
             state
                 .effective_max_spdm_msg_size(pal)
-                .saturating_sub(SpdmMsgHdrPdu::SIZE + CertificateRspBody::SIZE)
+                .saturating_sub(SpdmMsgHdrPdu::SIZE + req.rsp_header_body_size())
         } else {
             single_frame_portion
         };
-        let portion = (req_body.length.get() as usize)
+        let portion = req
+            .length()
             .min(remaining)
             .min(max_portion)
-            .min(u16::MAX as usize);
+            .min(req.max_length_cap());
         let remainder = remaining - portion;
-        (off as u16, portion as u16, remainder as u16)
+        (req.offset() as u32, portion as u32, remainder as u32)
     };
 
     let cert_info = if multi_key_conn_rsp(state)? {
@@ -227,6 +260,7 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
             offset,
             portion_len,
             remainder_len,
+            req.is_large(),
         );
         let handle = state.large_msg_ctx.next_handle();
         let resp = build_error_response(
@@ -248,55 +282,41 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
         return Ok((resp, SpdmMsgHdrPdu::SIZE + 2 + 1));
     }
 
-    if portion_len == 0 {
-        let resp = build_response(
-            pal,
-            io,
-            state.version,
-            &CertificateRsp {
-                slot_id,
-                param2: cert_info,
-                portion_length: 0,
-                remainder_length: remainder_len,
-                chain_portion: &[],
-            },
-        )?;
+    let portion = if portion_len > 0 {
+        let mut p = pal.alloc_bytes(io, portion_len as usize)?;
+        fill_cert_chain_portion(pal, io, slot_id, asym_algo, offset as usize, &mut p).await?;
+        Some(p)
+    } else {
+        None
+    };
+    let chain_slice: &[u8] = match &portion {
+        Some(p) => p.as_ref(),
+        None => &[],
+    };
 
-        let spdm_len = CertificateRsp {
+    let (resp, spdm_len) = if req.is_large() {
+        let cert_body = CertificateLargeRsp {
             slot_id,
             param2: cert_info,
-            portion_length: 0,
-            remainder_length: remainder_len,
-            chain_portion: &[],
-        }
-        .encoded_size();
-        let head = pal.header_size();
-        state.transcript.append_m1(pal, io, spdm_msg).await?;
-        state
-            .transcript
-            .append_m1(pal, io, &resp[head..head + spdm_len])
-            .await?;
-
-        state.phase = Phase::AfterCertificate;
-        return Ok((resp, spdm_len));
-    }
-
-    // Allocate the portion buffer from the per-IO pool. Bytes
-    // are spliced in below: [0, 52) from the SPDM cert-chain
-    // header, [52, total_len) from the raw DER chain.
-    let mut portion = pal.alloc_bytes(io, portion_len as usize)?;
-    fill_cert_chain_portion(pal, io, slot_id, asym_algo, offset as usize, &mut portion).await?;
-
-    let cert_body = CertificateRsp {
-        slot_id,
-        param2: cert_info,
-        portion_length: portion_len,
-        remainder_length: remainder_len,
-        chain_portion: &portion,
+            large_portion_length: portion_len,
+            large_remainder_length: remainder_len,
+            chain_portion: chain_slice,
+        };
+        let spdm_len = cert_body.encoded_size();
+        let resp = build_response(pal, io, state.version, &cert_body)?;
+        (resp, spdm_len)
+    } else {
+        let cert_body = CertificateRsp {
+            slot_id,
+            param2: cert_info,
+            portion_length: portion_len as u16,
+            remainder_length: remainder_len as u16,
+            chain_portion: chain_slice,
+        };
+        let spdm_len = cert_body.encoded_size();
+        let resp = build_response(pal, io, state.version, &cert_body)?;
+        (resp, spdm_len)
     };
-    let spdm_len = cert_body.encoded_size();
-
-    let resp = build_response(pal, io, state.version, &cert_body)?;
 
     let head = pal.header_size();
     state.transcript.append_m1(pal, io, spdm_msg).await?;

--- a/runtime/userspace/api/spdm-lib/stack/src/error.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/error.rs
@@ -152,6 +152,8 @@ pub const SPDM_RESET_REQUIRED: SpdmError = SpdmError::new(0x0C);
 /// `DecryptError` — secured-message decryption / MAC verification
 /// failed.
 pub const SPDM_DECRYPT_ERROR: SpdmError = SpdmError::new(0x06);
+/// `DataTooLarge` - Data is too large to be represented by message fields
+pub const SPDM_DATA_TOO_LARGE: SpdmError = SpdmError::new(0x12);
 /// `VersionMismatch` — requester's SPDM version is not supported.
 pub const SPDM_VERSION_MISMATCH: SpdmError = SpdmError::new(0x41);
 /// `ResponseNotReady` — responder needs more time; requester should

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -1117,3 +1117,7 @@ mod version_tests;
 #[cfg(test)]
 #[path = "tests/capabilities.rs"]
 mod capabilities_tests;
+
+#[cfg(test)]
+#[path = "tests/certificate.rs"]
+mod certificate_tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
@@ -1,0 +1,300 @@
+// Licensed under the Apache-2.0 license
+
+#![allow(clippy::field_reassign_with_default)]
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::{
+    CapFlags, CertificateLargeRspBody, CertificateRspBody, GetCertificateLargeReqBody,
+    GetCertificateParam1, GetCertificateReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
+    WireWriter, ATTR_SLOT_SIZE_REQUESTED,
+};
+use caliptra_mcu_spdm_traits::NoVdmBackend;
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
+
+use crate::error::SPDM_LARGE_RESPONSE;
+
+#[path = "support.rs"]
+mod support;
+use support::{
+    drain_chunked_response, negotiated_state, TestHashState, TestIo, TestPal,
+    SPDM_CERT_CHAIN_HDR_LEN, TEST_CERT_CHAIN,
+};
+
+fn init_cert_test_state(
+    version: SpdmVersion,
+    pal: &TestPal,
+) -> ConnectionState<TestHashState, Vec<u8>> {
+    let mut state = negotiated_state(version);
+    let io = TestIo::message(Vec::new());
+    block_on(state.transcript.append_vca(pal, &io, &[0xAA, 0xBB])).unwrap();
+    state
+}
+
+fn standard_cert_request(
+    version: SpdmVersion,
+    slot_id: u8,
+    attributes: u8,
+    offset: u16,
+    length: u16,
+) -> Vec<u8> {
+    let mut buf = vec![0u8; SpdmMsgHdrPdu::SIZE + GetCertificateReqBody::SIZE];
+    let mut w = WireWriter::new(&mut buf);
+    w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::GET_CERTIFICATE))
+        .unwrap();
+    w.write(&GetCertificateReqBody {
+        slot_id,
+        attributes,
+        offset: U16::new(offset),
+        length: U16::new(length),
+    })
+    .unwrap();
+    buf
+}
+
+fn large_cert_request(
+    version: SpdmVersion,
+    slot_id: u8,
+    attributes: u8,
+    large_offset: u32,
+    large_length: u32,
+) -> Vec<u8> {
+    let mut buf = vec![0u8; SpdmMsgHdrPdu::SIZE + GetCertificateLargeReqBody::SIZE];
+    let mut w = WireWriter::new(&mut buf);
+    w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::GET_CERTIFICATE))
+        .unwrap();
+    w.write(&GetCertificateLargeReqBody {
+        param1: GetCertificateParam1::new()
+            .with_slot_id(slot_id)
+            .with_large_cert_chain(true),
+        attributes,
+        offset: U16::new(0),
+        length: U16::new(0),
+        large_offset: U32::new(large_offset),
+        large_length: U32::new(large_length),
+    })
+    .unwrap();
+    buf
+}
+
+fn dispatch_cert_request(
+    state: &mut ConnectionState<TestHashState, Vec<u8>>,
+    sessions: &mut Sessions<TestPal, 1>,
+    pal: &TestPal,
+    request: Vec<u8>,
+) -> SpdmResult<Vec<u8>> {
+    let io = TestIo::message(request);
+    block_on(dispatch(
+        state,
+        sessions,
+        pal,
+        &io,
+        ReqRespCode::GET_CERTIFICATE,
+        &NoVdmBackend,
+    ))
+}
+
+#[test]
+fn test_get_certificate_v13_legacy_success() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V13, &pal);
+    let mut sessions = SessionManager::new();
+
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN + TEST_CERT_CHAIN.len();
+    let req = standard_cert_request(SpdmVersion::V13, 0, 0, 0, 0xFFFF);
+    let rsp = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap();
+
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(&rsp).unwrap();
+    assert_eq!(hdr.version, SpdmVersion::V13.to_u8());
+    assert_eq!(hdr.code, ReqRespCode::CERTIFICATE);
+
+    let (body, payload) = CertificateRspBody::ref_from_prefix(rest).unwrap();
+    let wanted_body = CertificateRspBody {
+        slot_id: 0,
+        param2: 0,
+        portion_length: U16::new(total_len as u16),
+        remainder_length: U16::new(0),
+    };
+    assert_eq!(body, &wanted_body);
+    assert_eq!(&payload[SPDM_CERT_CHAIN_HDR_LEN..], TEST_CERT_CHAIN);
+    assert_eq!(state.phase, Phase::AfterCertificate);
+}
+
+#[test]
+fn test_get_certificate_v14_large_success_pagination() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    state.advertised_cap_flags |= CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN + TEST_CERT_CHAIN.len(); // 52 + 8 = 60
+
+    // Fetch chunk 1: 32 bytes
+    let req1 = large_cert_request(SpdmVersion::V14, 0, 0, 0, 32);
+    let rsp1 = dispatch_cert_request(&mut state, &mut sessions, &pal, req1).unwrap();
+
+    let (hdr1, rest1) = SpdmMsgHdrPdu::ref_from_prefix(&rsp1).unwrap();
+    assert_eq!(hdr1.version, SpdmVersion::V14.to_u8());
+    assert_eq!(hdr1.code, ReqRespCode::CERTIFICATE);
+
+    let (body1, payload1) = CertificateLargeRspBody::ref_from_prefix(rest1).unwrap();
+    let wanted_body1 = CertificateLargeRspBody {
+        param1: GetCertificateParam1::new().with_large_cert_chain(true),
+        param2: 0,
+        portion_length: U16::new(0),
+        remainder_length: U16::new(0),
+        large_portion_length: U32::new(32),
+        large_remainder_length: U32::new((total_len - 32) as u32),
+    };
+    assert_eq!(body1, &wanted_body1);
+    assert_eq!(payload1.len(), 32);
+
+    // Fetch chunk 2: remainder
+    let req2 = large_cert_request(SpdmVersion::V14, 0, 0, 32, 0xFFFFFFFF);
+    let rsp2 = dispatch_cert_request(&mut state, &mut sessions, &pal, req2).unwrap();
+
+    let (hdr2, rest2) = SpdmMsgHdrPdu::ref_from_prefix(&rsp2).unwrap();
+    assert_eq!(hdr2.version, SpdmVersion::V14.to_u8());
+    assert_eq!(hdr2.code, ReqRespCode::CERTIFICATE);
+
+    let (body2, payload2) = CertificateLargeRspBody::ref_from_prefix(rest2).unwrap();
+    let wanted_body2 = CertificateLargeRspBody {
+        param1: GetCertificateParam1::new().with_large_cert_chain(true),
+        param2: 0,
+        portion_length: U16::new(0),
+        remainder_length: U16::new(0),
+        large_portion_length: U32::new((total_len - 32) as u32),
+        large_remainder_length: U32::new(0),
+    };
+    assert_eq!(body2, &wanted_body2);
+
+    // Verify concatenated data matches
+    let mut full = Vec::new();
+    full.extend_from_slice(payload1);
+    full.extend_from_slice(payload2);
+    assert_eq!(full.len(), total_len);
+    assert_eq!(&full[SPDM_CERT_CHAIN_HDR_LEN..], TEST_CERT_CHAIN);
+}
+
+#[test]
+fn test_get_certificate_v14_large_size_req() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    state.advertised_cap_flags |= CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN + TEST_CERT_CHAIN.len();
+    let req = large_cert_request(
+        SpdmVersion::V14,
+        0,
+        ATTR_SLOT_SIZE_REQUESTED,
+        0xFFFFFFFF,
+        0xAA55AA55,
+    );
+    let rsp = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap();
+
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(&rsp).unwrap();
+    assert_eq!(hdr.version, SpdmVersion::V14.to_u8());
+    assert_eq!(hdr.code, ReqRespCode::CERTIFICATE);
+
+    let (body, payload) = CertificateLargeRspBody::ref_from_prefix(rest).unwrap();
+    let wanted_body = CertificateLargeRspBody {
+        param1: GetCertificateParam1::new().with_large_cert_chain(true),
+        param2: 0,
+        portion_length: U16::new(0),
+        remainder_length: U16::new(0),
+        large_portion_length: U32::new(0),
+        large_remainder_length: U32::new(total_len as u32),
+    };
+    assert_eq!(body, &wanted_body);
+    assert!(payload.is_empty());
+}
+
+#[test]
+fn test_get_certificate_large_on_v13_returns_invalid_request() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V13, &pal);
+    state.advertised_cap_flags |= CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+
+    let req = large_cert_request(SpdmVersion::V13, 0, 0, 0, 1024);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+}
+
+#[test]
+fn test_get_certificate_v14_large_invalid_slot_or_offset() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    state.advertised_cap_flags |= CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+
+    // Invalid slot: 15 (MAX_SLOTS is 8)
+    let req_invalid_slot = large_cert_request(SpdmVersion::V14, 15, 0, 0, 1024);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req_invalid_slot).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+
+    // Invalid offset: 0xFFFFFFFF > total_len
+    let req_invalid_offset = large_cert_request(SpdmVersion::V14, 0, 0, 0xFFFFFFFF, 1024);
+    let err =
+        dispatch_cert_request(&mut state, &mut sessions, &pal, req_invalid_offset).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+}
+
+#[test]
+fn test_get_certificate_chunked_full_fetch() {
+    let pal = TestPal::default();
+
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    state.cap_flags |= CapFlags::CHUNK | CapFlags::LARGE_RESP;
+    state.peer_cap_flags |= CapFlags::CHUNK;
+    state.advertised_cap_flags |= CapFlags::CHUNK | CapFlags::LARGE_RESP;
+    state.peer_data_transfer_size = 42; // Constrained DataTransferSize to force chunking
+    state.peer_max_spdm_msg_size = 1024;
+    let mut sessions = SessionManager::new();
+
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN + TEST_CERT_CHAIN.len(); // 60 bytes
+    let total_spdm_msg_len = SpdmMsgHdrPdu::SIZE + CertificateLargeRspBody::SIZE + total_len; // 76 bytes
+
+    // Request full large cert
+    let req = large_cert_request(SpdmVersion::V14, 0, 0, 0, 0xFFFFFFFF);
+    let err_rsp = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap();
+
+    // Expect ERROR(LargeResponse)
+    let (err_hdr, err_body) = SpdmMsgHdrPdu::ref_from_prefix(&err_rsp).unwrap();
+    assert_eq!(err_hdr.version, SpdmVersion::V14.to_u8());
+    assert_eq!(err_hdr.code, ReqRespCode::ERROR);
+    assert_eq!(err_body[0], SPDM_LARGE_RESPONSE.spec_byte());
+    let handle = err_body[2]; // ErrorData is at byte index 2 of error body (spdm_msg[4])
+
+    // Drain entire chunked response using the helper in support.rs
+    let io = TestIo::message(Vec::new());
+    let reassembled_payload =
+        block_on(drain_chunked_response(&mut state, &pal, &io, handle)).unwrap();
+
+    assert_eq!(reassembled_payload.len(), total_spdm_msg_len);
+
+    // Reassembled message begins with SpdmMsgHdrPdu (version 1.4, CERTIFICATE)
+    let (rsp_hdr, rsp_rest) = SpdmMsgHdrPdu::ref_from_prefix(&reassembled_payload).unwrap();
+    assert_eq!(rsp_hdr.version, SpdmVersion::V14.to_u8());
+    assert_eq!(rsp_hdr.code, ReqRespCode::CERTIFICATE);
+
+    // Large body header
+    let (body, payload) = CertificateLargeRspBody::ref_from_prefix(rsp_rest).unwrap();
+    let wanted_body = CertificateLargeRspBody {
+        param1: GetCertificateParam1::new().with_large_cert_chain(true),
+        param2: 0,
+        portion_length: U16::new(0),
+        remainder_length: U16::new(0),
+        large_portion_length: U32::new(total_len as u32),
+        large_remainder_length: U32::new(0),
+    };
+    assert_eq!(body, &wanted_body);
+
+    // Followed by SPDM cert chain header + DER certs
+    assert_eq!(&payload[SPDM_CERT_CHAIN_HDR_LEN..], TEST_CERT_CHAIN);
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -5,8 +5,9 @@
 extern crate std;
 
 use caliptra_mcu_spdm_codec::{
-    AsymAlgos, CapFlags, HashAlgos, ReqRespCode, SpdmVersion, AES_256_GCM_TAG_SIZE,
-    CHUNK_ATTR_LAST_CHUNK, SECURED_MSG_HDR_SIZE,
+    AsymAlgos, CapFlags, ChunkGetReqBody, ChunkResponseBody, HashAlgos, ReqRespCode, SpdmMsgHdrPdu,
+    SpdmVersion, WireWriter, AES_256_GCM_TAG_SIZE, CHUNK_ATTR_LAST_CHUNK,
+    LARGE_RESPONSE_SIZE_FIELD_SIZE, SECURED_MSG_HDR_SIZE,
 };
 use caliptra_mcu_spdm_traits::{
     MeasurementInfo, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash, SpdmPalHashAlgo,
@@ -21,6 +22,7 @@ use std::boxed::Box;
 use std::cell::{Cell, RefCell};
 use std::vec;
 use std::vec::Vec;
+use zerocopy::FromBytes;
 
 use crate::stack::{ConnectionState, Phase, Sessions};
 
@@ -100,6 +102,7 @@ impl<T> DerefMut for TestBox<'_, T> {
 pub struct TestPal {
     pub mtu: usize,
     pub supported_slots: u8,
+    pub provisioned_slots: u8,
     pub authorized: bool,
     pub validate_error: Option<McuErrorCode>,
     pub write_error: Option<McuErrorCode>,
@@ -117,6 +120,7 @@ impl Default for TestPal {
         Self {
             mtu: 1024,
             supported_slots: u8::MAX,
+            provisioned_slots: 1,
             authorized: true,
             validate_error: None,
             write_error: None,
@@ -270,7 +274,7 @@ impl SpdmPalHash for TestPal {
 
 impl SpdmPalCertStore for TestPal {
     fn provisioned_slots(&self) -> u8 {
-        0
+        self.provisioned_slots
     }
 
     fn supported_slots(&self) -> u8 {
@@ -773,4 +777,62 @@ pub fn established_session(
     session.key_schedule.destroy_handshake_secrets();
     session.state = crate::session::SessionState::Established;
     (state, sessions, session_id)
+}
+
+/// Drive a multi-chunk `CHUNK_GET` transfer to reassemble a complete SPDM large response message.
+pub async fn drain_chunked_response(
+    state: &mut ConnectionState<TestHashState, Vec<u8>>,
+    pal: &TestPal,
+    io: &TestIo,
+    handle: u8,
+) -> Result<Vec<u8>, crate::error::SpdmError> {
+    let mut chunk_seq_num = 0u16;
+    let mut reassembled = Vec::new();
+
+    loop {
+        let mut chunk_get_buf = [0u8; SpdmMsgHdrPdu::SIZE + ChunkGetReqBody::SIZE];
+        let mut writer = WireWriter::new(&mut chunk_get_buf);
+        writer
+            .write(&SpdmMsgHdrPdu::new(state.version, ReqRespCode::CHUNK_GET))
+            .map_err(|_| crate::error::SPDM_INVALID_REQUEST)?;
+        writer
+            .write(&ChunkGetReqBody {
+                param1: 0,
+                handle,
+                chunk_seq_num: zerocopy::little_endian::U16::new(chunk_seq_num),
+            })
+            .map_err(|_| crate::error::SPDM_INVALID_REQUEST)?;
+
+        let chunk_rsp = crate::chunk::handle_chunk_get(state, pal, io, &chunk_get_buf).await?;
+        let head = pal.header_size();
+        let spdm_msg = &chunk_rsp[head..];
+
+        let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(spdm_msg)
+            .map_err(|_| crate::error::SPDM_INVALID_REQUEST)?;
+        assert_eq!(hdr.code, ReqRespCode::CHUNK_RESPONSE);
+
+        let (body, chunk_data) = ChunkResponseBody::ref_from_prefix(rest)
+            .map_err(|_| crate::error::SPDM_INVALID_REQUEST)?;
+        assert_eq!(body.handle, handle);
+        assert_eq!(body.chunk_seq_num.get(), chunk_seq_num);
+
+        let payload = if chunk_seq_num == 0 {
+            // First chunk is prepended with 4-byte large_response_size
+            assert!(chunk_data.len() >= LARGE_RESPONSE_SIZE_FIELD_SIZE);
+            &chunk_data[LARGE_RESPONSE_SIZE_FIELD_SIZE..]
+        } else {
+            chunk_data
+        };
+        reassembled.extend_from_slice(payload);
+
+        let is_last = (body.chunk_sender_attr & CHUNK_ATTR_LAST_CHUNK) != 0;
+        if is_last {
+            break;
+        }
+        chunk_seq_num = chunk_seq_num
+            .checked_add(1)
+            .ok_or(crate::error::SPDM_INVALID_REQUEST)?;
+    }
+
+    Ok(reassembled)
 }


### PR DESCRIPTION
New fields were added in SPDM 1.4 to support 32 bit length and offset fields in the GET_CERTIFICATE commands. Update the codec and stack modules to support these fields