### PR TITLE
SPDM 1.4: Support v1.4 in FINISH and FINISH_RSP

### DIFF
--- a/runtime/userspace/api/spdm-lib/codec/src/finish.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/finish.rs
@@ -2,15 +2,28 @@
 
 //! FINISH / FINISH_RSP wire types.
 
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::{little_endian::U16, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
 
 // ---- Request ---------------------------------------------------------------
 
-/// FINISH request fixed body (after SPDM header).
+pub trait FinishReq {
+    /// Requester slot ID (used only with mutual auth).
+    fn slot_id(&self) -> u8;
+    /// Whether the requester signature is present (bit 0).
+    fn signature_present(&self) -> bool;
+    /// Length of the opaque data field (always 0 for version <= 1.3).
+    fn opaque_data_len(&self) -> u16;
+    fn size_of(&self) -> usize;
+}
+
+/// FINISH request fixed body (after SPDM header, version <= 1.3).
 ///
-/// After this struct the request carries:
+/// Starting in version 1.4 a new fixed field was added, which is
+/// represented in [FinishReqBody14].
+///
+/// After this struct a <= v1.3 request carries:
 /// - If `signature_present()`: requester signature (96 bytes, ECC P-384)
 /// - Requester verify_data (48 bytes, SHA-384 HMAC)
 #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
@@ -24,11 +37,70 @@ pub struct FinishReqBody {
 
 const _: () = assert!(core::mem::size_of::<FinishReqBody>() == 2);
 
-impl FinishReqBody {
-    /// Whether the requester signature is present (bit 0).
+impl FinishReq for FinishReqBody {
     #[inline]
-    pub fn signature_present(&self) -> bool {
+    fn signature_present(&self) -> bool {
         self.req_signature_present & 0x01 != 0
+    }
+
+    #[inline]
+    fn slot_id(&self) -> u8 {
+        self.req_slot_id
+    }
+
+    #[inline]
+    fn opaque_data_len(&self) -> u16 {
+        0
+    }
+
+    #[inline]
+    fn size_of(&self) -> usize {
+        size_of::<Self>()
+    }
+}
+
+/// FINISH request fixed body (after SPDM header, version 1.4).
+///
+/// Version 1.4 added the new fixed field `OpaqueDataLength`.
+///
+/// After this struct the request carries:
+/// - Requester OpaqueData (`OpaqueDataLength` bytes)
+/// - If `signature_present()`: requester signature (96 bytes, ECC P-384)
+/// - Requester verify_data (48 bytes, SHA-384 HMAC)
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct FinishReqBody14 {
+    /// Bit 0: requester signature present (mutual auth only).
+    pub req_signature_present: u8,
+    /// Requester slot ID (used only with mutual auth).
+    pub req_slot_id: u8,
+    /// The size of the `OpaqueData` field.
+    ///
+    /// Should be in the range from 0 to 1024.
+    pub req_opaque_data_length: U16,
+}
+
+const _: () = assert!(core::mem::size_of::<FinishReqBody14>() == 4);
+
+impl FinishReq for FinishReqBody14 {
+    #[inline]
+    fn signature_present(&self) -> bool {
+        self.req_signature_present & 0x01 != 0
+    }
+
+    #[inline]
+    fn slot_id(&self) -> u8 {
+        self.req_slot_id
+    }
+
+    #[inline]
+    fn opaque_data_len(&self) -> u16 {
+        self.req_opaque_data_length.get()
+    }
+
+    #[inline]
+    fn size_of(&self) -> usize {
+        size_of::<Self>()
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/codec/src/finish.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/finish.rs
@@ -14,7 +14,7 @@ pub trait FinishReq {
     /// Whether the requester signature is present (bit 0).
     fn signature_present(&self) -> bool;
     /// Length of the opaque data field (always 0 for version <= 1.3).
-    fn opaque_data_len(&self) -> u16;
+    fn opaque_data_len(&self) -> usize;
     fn size_of(&self) -> usize;
 }
 
@@ -49,7 +49,7 @@ impl FinishReq for FinishReqBody {
     }
 
     #[inline]
-    fn opaque_data_len(&self) -> u16 {
+    fn opaque_data_len(&self) -> usize {
         0
     }
 
@@ -94,8 +94,8 @@ impl FinishReq for FinishReqBody14 {
     }
 
     #[inline]
-    fn opaque_data_len(&self) -> u16 {
-        self.req_opaque_data_length.get()
+    fn opaque_data_len(&self) -> usize {
+        self.req_opaque_data_length.get() as usize
     }
 
     #[inline]
@@ -106,7 +106,7 @@ impl FinishReq for FinishReqBody14 {
 
 // ---- Response builder ------------------------------------------------------
 
-/// FINISH_RSP response builder.
+/// FINISH_RSP response builder (version <= 1.3).
 ///
 /// Wire layout: `reserved(1) + reserved(1)`.
 /// No ResponderVerifyData when HBITC is NOT negotiated (our case).
@@ -121,5 +121,42 @@ impl ResponseBody for FinishRsp {
 
     fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
         w.write_bytes(&[0u8, 0u8])
+    }
+}
+
+/// FINISH_RSP response builder for version 1.4.
+///
+/// Wire layout: `reserved(1) + reserved(1) + OpaqueDataLength(2)`.
+/// No opaque data supported at this point.
+/// No ResponderVerifyData when HBITC is NOT negotiated (our case).
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct FinishRsp14 {
+    reserved1: u8,
+    reserved2: u8,
+    opaque_data_length: U16,
+}
+
+const _: () = assert!(core::mem::size_of::<FinishRsp14>() == 4);
+
+impl FinishRsp14 {
+    pub fn new() -> Self {
+        FinishRsp14 {
+            reserved1: 0,
+            reserved2: 0,
+            opaque_data_length: 0.into(),
+        }
+    }
+}
+
+impl ResponseBody for FinishRsp14 {
+    const RESPONSE_CODE: ReqRespCode = ReqRespCode::FINISH_RSP;
+
+    fn body_size(&self) -> usize {
+        4
+    }
+
+    fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
+        w.write_bytes(self.as_bytes())
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -44,7 +44,7 @@ pub use chunk::{
 };
 pub use digests::{DigestsRsp, DigestsRspBody};
 pub use end_session::{EndSessionAck, EndSessionReqBody};
-pub use finish::{FinishReqBody, FinishRsp};
+pub use finish::{FinishReq, FinishReqBody, FinishReqBody14, FinishRsp};
 pub use header::{
     ReqRespCode, SpdmMsgHdrPdu, ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE,
     SPDM_CONTEXT_LEN, SPDM_MSG_HDR_SIZE, SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -44,7 +44,7 @@ pub use chunk::{
 };
 pub use digests::{DigestsRsp, DigestsRspBody};
 pub use end_session::{EndSessionAck, EndSessionReqBody};
-pub use finish::{FinishReq, FinishReqBody, FinishReqBody14, FinishRsp};
+pub use finish::{FinishReq, FinishReqBody, FinishReqBody14, FinishRsp, FinishRsp14};
 pub use header::{
     ReqRespCode, SpdmMsgHdrPdu, ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE,
     SPDM_CONTEXT_LEN, SPDM_MSG_HDR_SIZE, SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,

--- a/runtime/userspace/api/spdm-lib/codec/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/version.rs
@@ -17,6 +17,7 @@ pub enum SpdmVersion {
     V11 = 0x11,
     V12 = 0x12,
     V13 = 0x13,
+    V14 = 0x14,
 }
 
 impl SpdmVersion {
@@ -36,6 +37,7 @@ impl SpdmVersion {
             0x11 => Some(SpdmVersion::V11),
             0x12 => Some(SpdmVersion::V12),
             0x13 => Some(SpdmVersion::V13),
+            0x14 => Some(SpdmVersion::V14),
             _ => None,
         }
     }
@@ -48,6 +50,7 @@ impl SpdmVersion {
             SpdmVersion::V11 => "1.1",
             SpdmVersion::V12 => "1.2",
             SpdmVersion::V13 => "1.3",
+            SpdmVersion::V14 => "1.4",
         }
     }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -168,6 +168,7 @@ const SIGNING_CTX_V10: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"
 const SIGNING_CTX_V11: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.1.*");
 const SIGNING_CTX_V12: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.2.*");
 const SIGNING_CTX_V13: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.3.*");
+const SIGNING_CTX_V14: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context(b"1.4.*");
 
 /// Build the SPDM signing context for CHALLENGE_AUTH.
 const fn build_signing_context(ver: &[u8; 5]) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
@@ -211,6 +212,7 @@ fn signing_context(version: SpdmVersion) -> &'static [u8; SPDM_SIGNING_CONTEXT_L
         SpdmVersion::V11 => &SIGNING_CTX_V11,
         SpdmVersion::V12 => &SIGNING_CTX_V12,
         SpdmVersion::V13 => &SIGNING_CTX_V13,
+        SpdmVersion::V14 => &SIGNING_CTX_V14,
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/finish.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/finish.rs
@@ -15,8 +15,8 @@
 //! transitioning the session to [`SessionState::Established`].
 
 use caliptra_mcu_spdm_codec::{
-    FinishReqBody, FinishRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, WireWriter,
-    SHA384_HASH_SIZE,
+    FinishReq, FinishReqBody, FinishReqBody14, FinishRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    WireWriter, SHA384_HASH_SIZE,
 };
 use caliptra_mcu_spdm_traits::*;
 use zerocopy::FromBytes;
@@ -57,13 +57,29 @@ pub(crate) async fn handle_finish<Pal: SpdmPal>(
         return Err(crate::error::SPDM_VERSION_MISMATCH);
     }
 
-    let (finish_req, after) =
-        FinishReqBody::ref_from_prefix(rest).map_err(|_| SPDM_INVALID_REQUEST)?;
+    let (finish_req_fixed, after) = if version <= SpdmVersion::V13 {
+        let (finish_req, after) =
+            FinishReqBody::ref_from_prefix(rest).map_err(|_| SPDM_INVALID_REQUEST)?;
+        (finish_req as &dyn FinishReq, after)
+    } else {
+        let (finish_req, after) =
+            FinishReqBody14::ref_from_prefix(rest).map_err(|_| SPDM_INVALID_REQUEST)?;
+        (finish_req as &dyn FinishReq, after)
+    };
 
     // No mutual auth — reject if requester signature present.
-    if finish_req.signature_present() {
+    if finish_req_fixed.signature_present() {
         return Err(SPDM_INVALID_REQUEST);
     }
+
+    // Parse the Opaque data field (if present, introduced in version 1.4)
+    let opaque_data_length = finish_req_fixed.opaque_data_len();
+    if opaque_data_length > 1024 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let (_opaque_data, after) = after
+        .split_at_checked(opaque_data_length as usize)
+        .ok_or(SPDM_INVALID_REQUEST)?;
 
     // Requester verify_data (SHA-384 HMAC).
     if after.len() != SHA384_HASH_SIZE {
@@ -71,8 +87,10 @@ pub(crate) async fn handle_finish<Pal: SpdmPal>(
     }
     let req_verify_data = &after[..SHA384_HASH_SIZE];
 
-    // ── Feed FINISH header + params (without verify_data) to TH ────
-    let finish_hdr_len = SpdmMsgHdrPdu::SIZE + core::mem::size_of::<FinishReqBody>();
+    // ── Feed FINISH header + params + opaque data (without verify_data) to TH ────
+    let finish_hdr_len = SpdmMsgHdrPdu::SIZE
+        + finish_req_fixed.size_of()
+        + finish_req_fixed.opaque_data_len() as usize;
     session
         .transcript
         .append(pal, io, &spdm_msg[..finish_hdr_len])

--- a/runtime/userspace/api/spdm-lib/stack/src/finish.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/finish.rs
@@ -15,8 +15,8 @@
 //! transitioning the session to [`SessionState::Established`].
 
 use caliptra_mcu_spdm_codec::{
-    FinishReq, FinishReqBody, FinishReqBody14, FinishRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
-    WireWriter, SHA384_HASH_SIZE,
+    FinishReq, FinishReqBody, FinishReqBody14, FinishRsp, FinishRsp14, ResponseBody, SpdmMsgHdrPdu,
+    SpdmVersion, WireWriter, SHA384_HASH_SIZE,
 };
 use caliptra_mcu_spdm_traits::*;
 use zerocopy::FromBytes;
@@ -78,7 +78,7 @@ pub(crate) async fn handle_finish<Pal: SpdmPal>(
         return Err(SPDM_INVALID_REQUEST);
     }
     let (_opaque_data, after) = after
-        .split_at_checked(opaque_data_length as usize)
+        .split_at_checked(opaque_data_length)
         .ok_or(SPDM_INVALID_REQUEST)?;
 
     // Requester verify_data (SHA-384 HMAC).
@@ -88,9 +88,8 @@ pub(crate) async fn handle_finish<Pal: SpdmPal>(
     let req_verify_data = &after[..SHA384_HASH_SIZE];
 
     // ── Feed FINISH header + params + opaque data (without verify_data) to TH ────
-    let finish_hdr_len = SpdmMsgHdrPdu::SIZE
-        + finish_req_fixed.size_of()
-        + finish_req_fixed.opaque_data_len() as usize;
+    let finish_hdr_len =
+        SpdmMsgHdrPdu::SIZE + finish_req_fixed.size_of() + finish_req_fixed.opaque_data_len();
     session
         .transcript
         .append(pal, io, &spdm_msg[..finish_hdr_len])
@@ -132,9 +131,15 @@ pub(crate) async fn handle_finish<Pal: SpdmPal>(
 
     // ── Build FINISH_RSP SPDM message ──────────────────────────────
     let mut rsp_buf = [0u8; FINISH_RSP_SPDM_SIZE];
-    FinishRsp
-        .encode_with_header(version, &mut WireWriter::new(&mut rsp_buf))
-        .map_err(|_| SPDM_UNSPECIFIED)?;
+    if version <= SpdmVersion::V13 {
+        FinishRsp
+            .encode_with_header(version, &mut WireWriter::new(&mut rsp_buf))
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+    } else {
+        FinishRsp14::new()
+            .encode_with_header(version, &mut WireWriter::new(&mut rsp_buf))
+            .map_err(|_| SPDM_UNSPECIFIED)?;
+    }
 
     // ── Feed FINISH_RSP to TH ──────────────────────────────────────
     session.transcript.append(pal, io, &rsp_buf).await?;

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -46,6 +46,8 @@ const KEY_EXCHANGE_SIGNING_PREFIX_V12: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_L
     b"dmtf-spdm-v1.2.*";
 const KEY_EXCHANGE_SIGNING_PREFIX_V13: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_LEN] =
     b"dmtf-spdm-v1.3.*";
+const KEY_EXCHANGE_SIGNING_PREFIX_V14: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_LEN] =
+    b"dmtf-spdm-v1.4.*";
 const KEY_EXCHANGE_SIGNING_OP: &[u8; 34] = b"responder-key_exchange_rsp signing";
 
 pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
@@ -369,6 +371,7 @@ fn build_signing_context(version: SpdmVersion, ctx: &mut [u8; SPDM_SIGNING_CONTE
         SpdmVersion::V11 => KEY_EXCHANGE_SIGNING_PREFIX_V11,
         SpdmVersion::V12 => KEY_EXCHANGE_SIGNING_PREFIX_V12,
         SpdmVersion::V13 => KEY_EXCHANGE_SIGNING_PREFIX_V13,
+        SpdmVersion::V14 => KEY_EXCHANGE_SIGNING_PREFIX_V14,
     };
     let mut pos = 0;
     for _ in 0..4 {

--- a/runtime/userspace/api/spdm-lib/stack/src/key_schedule.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_schedule.rs
@@ -48,6 +48,7 @@ pub fn spdm_version_str(version: SpdmVersion) -> &'static [u8] {
         SpdmVersion::V11 => b"spdm1.1 ",
         SpdmVersion::V12 => b"spdm1.2 ",
         SpdmVersion::V13 => b"spdm1.3 ",
+        SpdmVersion::V14 => b"spdm1.4 ",
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -518,6 +518,7 @@ const SIGNING_CTX_V10: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_co
 const SIGNING_CTX_V11: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.1.*");
 const SIGNING_CTX_V12: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.2.*");
 const SIGNING_CTX_V13: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.3.*");
+const SIGNING_CTX_V14: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.4.*");
 
 const fn build_signing_context_const(ver: &[u8; 5]) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
     let mut ctx = [0u8; SPDM_SIGNING_CONTEXT_LEN];
@@ -556,6 +557,7 @@ fn signing_context(version: SpdmVersion) -> &'static [u8; SPDM_SIGNING_CONTEXT_L
         SpdmVersion::V11 => &SIGNING_CTX_V11,
         SpdmVersion::V12 => &SIGNING_CTX_V12,
         SpdmVersion::V13 => &SIGNING_CTX_V13,
+        SpdmVersion::V14 => &SIGNING_CTX_V14,
     }
 }
 


### PR DESCRIPTION
SPDM 1.4 adds an `OpaqueData` field to the FINISH and FINISH_RSP messages.
This is field can be used to pass parameters defined by vendors, standards bodies, and transport mechanisms for key exchange purposes.

We don't currently support this and this PR just adds the handling for the case where no opaque data is provided.