### PR TITLE
docs: fix Caliptra 2.1 PLDM package layout

### DIFF
--- a/docs/src/pldm_package.md
+++ b/docs/src/pldm_package.md
@@ -12,21 +12,18 @@ The update package follows the [DMTF Firmware Update Specification v.1.3.0](http
 | Component Image Information                           |
 | Package Header Checksum                               |
 | Package Payload Checksum                              |
-| Component 1 (Caliptra FMC + RT)                       |
-| Component 2 (SoC Manifest)                            |
-| Component 3 (MCU RT)                                  |
-| Component 4 (SoC Image 1)                             |
-| ...                                                   |
-| Component N (SoC Image N-3)                           |
-| Component N + 1 (Streaming Boot Image for full flash) |
+| Component 1 (Full SPI flash image)                    |
 
-The PLDM FW Update Package contains:
+The reference Caliptra 2.1 package contains one PLDM component: a full SPI
+flash image. The flash image contains its own table of contents and embeds the
+Caliptra FMC + RT bundle, SoC manifest, MCU RT image, and any vendor-defined
+SoC images. See [SPI Flash Layout](./flash_layout.md) for the component payload
+format.
 
-1. Caliptra FMC (First Mutable Code) and RT (Runtime) Image Bundle
-2. The SOC Manifest for the MCU RT image and other SOC Images
-3. The MCU RT image
-4. Other SOC Images, if any
-5. A full image of the flash containing all images (see [SPI Flash Layout Documentation](https://github.com/chipsalliance/caliptra-mcu-sw/blob/main/docs/src/flash_layout.md))
+These embedded images are flash-image subcomponents, not separate PLDM
+components. The PLDM package format and package-generation library can support
+multiple components, but the reference Caliptra 2.1 Firmware Device advertises
+and consumes the single full-image component described here.
 
 *Note: All fields are little-endian byte-ordered unless specified otherwise.*
 
@@ -64,11 +61,7 @@ The PLDM FW Update Package contains:
 |                                      |          | If no data is provided, set to `0x0000`.                                                                                                                                                                                                                                                                                                            |
 | ReferenceManifestLength              | 4        | Length in bytes of the ReferenceManifestData field. If no data is provided, set to `0x00000000`.                                                                                                                                                                                                                                                    |
 | ApplicableComponents                 | Variable | Bitmap indicating which firmware components apply to devices matching this Device Identifier record. A set bit indicates the Nth component in the payload is applicable to this device.                                                                                                                                                             |
-|                                      |          | bit 0: Caliptra FMC + RT                                                                                                                                                                                                                                                                                                                            |
-|                                      |          | bit 1: SOC Manifest                                                                                                                                                                                                                                                                                                                                 |
-|                                      |          | bit 2 : MCU RT                                                                                                                                                                                                                                                                                                                                      |
-|                                      |          | bit 3 to N: Reserved for other SoC images                                                                                                                                                                                                                                                                                                           |
-|                                      |          | bit N+1: Full SPI Flash image used in streaming boot                                                                                                                                                                                                                                                                                                |
+|                                      |          | bit 0: Full SPI flash image                                                                                                                                                                                                                                                                                                                          |
 | ComponentImageSetVersionString       | Variable | Component Image Set version information, up to 255 bytes.                                                                                                                                                                                                                                                                                           |
 |                                      |          | Describes the version of component images applicable to the firmware device indicated in this record.                                                                                                                                                                                                                                               |
 | RecordDescriptors                    | Variable | These descriptors are defined by the vendor (i.e. integrators of Caliptra ROT)                                                                                                                                                                                                                                                                      |
@@ -91,22 +84,16 @@ There are no Downstream Device ID records for this package
 
 | Field                     | Size     | Definition                                                                                    |
 | ------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| ComponentImageCount       | 2        | Count of individually defined component images contained within this firmware update package. |
+| ComponentImageCount       | 2        | Count of individually defined component images contained within this firmware update package. The reference Caliptra 2.1 package sets this value to `1`. |
 | ComponentImageInformation | Variable | Contains details for each component image within this firmware update package.                |
 
 ### Component Image Information Record
 
 | Field                              | Size     | Definition                                                                                                                                                                                                                                      |
 | ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ComponentClassification            | 2        | `0x000A`: For Caliptra FMC+RT  (Firmware)                                                                                                                                                                                                       |
-|                                    |          | `0x0001`: For SoC Manifest  (Other)                                                                                                                                                                                                             |
-|                                    |          | `0x000A`: For MCU RT: (Firmware)                                                                                                                                                                                                                |
-|                                    |          | For other SoC images, Refer to [DMTF Firmware Update Specification v.1.3.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0267_1.3.0.pdf) Table 32 for values.                                                                |
+| ComponentClassification            | 2        | `0x000A`: Full SPI flash image (Firmware)                                                                                                                                                                                                       |
 | ComponentIdentifier                | 2        | Unique value selected by the FD vendor to distinguish between component images.                                                                                                                                                                 |
-|                                    |          | `0x0001`: Caliptra FMC+RT                                                                                                                                                                                                                       |
-|                                    |          | `0x0002`: SoC Manifest:                                                                                                                                                                                                                         |
-|                                    |          | `0x0003`: MCU RT                                                                                                                                                                                                                                |
-|                                    |          | `0x1000`-`0xFFFF` - Reserved for other vendor-defined SoC images                                                                                                                                                                                |
+|                                    |          | `0xFFFF`: Full SPI flash image in the reference Caliptra 2.1 package                                                                                                                                                                             |
 | ComponentComparisonStamp           | 4        | Value used as a comparison in determining if a firmware component is down-level or up-level. When ComponentOptions bit 1 is set, this field should use a comparison stamp format (e.g., MajorMinorRevisionPatch). If not set, use `0xFFFFFFFF`. |
 | ComponentOptions                   | 2        | Refer to ComponentOptions definition in [DMTF Firmware Update Specification v.1.3.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0267_1.3.0.pdf)                                                                            |
 | RequestedComponentActivationMethod | 2        | Refer to RequestedComponentActivationMethoddefinition in[DMTF Firmware Update Specification v.1.3.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0267_1.3.0.pdf)                                                            |
@@ -125,24 +112,15 @@ There are no Downstream Device ID records for this package
 | PackageHeaderChecksum  | 4    | The integrity checksum of the PLDM Package Header. It is calculated starting at the first byte of the PLDM Firmware Update Header and includes all bytes of the package header structure except for the bytes in this field and the PackagePayloadChecksum field. The CRC-32 algorithm with polynomial `0x04C11DB7` (as used by IEEE 802.3) is used for checksum computation, processing one byte at a time with the least significant bit first. |
 | PackagePayloadChecksum | 4    | The integrity checksum of the PLDM Package Payload. It is calculated starting at the first byte immediately following this field and includes all bytes of the firmware package payload structure, including any padding between component images. The CRC-32 algorithm with polynomial `0x04C11DB7` (as used by IEEE 802.3) is used for checksum computation, processing one byte at a time with the least significant bit first.                |
 
-## Component 1 - Caliptra FMC + RT
+## Component 1 - Full SPI Flash Image
 
-This is the package bundle for the Caliptra FMC + RT defined in [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#firmware-image-bundle).
+This component contains the full flash image defined in
+[SPI Flash Layout](./flash_layout.md), from the flash header through the end of
+the embedded images. The reference Firmware Device advertises this component
+as classification `0x000A` and identifier `0xFFFF` for both firmware update
+and streaming boot.
 
-## Component 2 - SOC Manifest
-
-This is the SoC Manifest defined in [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md).
-
-It provides the signature verification and specific data needed to decode the image.
-
-## Component 3 - MCU RT
-
-This is the Image binary of the MCU Realtime firmware.
-
-## Component 4 to N - SoC Images
-
-These are reserved for vendor SoC images, if any.
-
-## Component N + 1 - Full SPI Flash image
-
-This component contains the full flash image as defined in the [SPI Flash Layout Documentation](https://github.com/chipsalliance/caliptra-mcu-sw/blob/main/docs/src/flash_layout.md) from the Header section until the end of the images section. This is can be used for loading all the images at once for streaming boot.
+The component's flash table of contents identifies the embedded Caliptra
+FMC + RT bundle, SoC manifest, MCU RT image, and any vendor-defined SoC images.
+The MCU processes and verifies those embedded images according to their flash
+image identifiers.


### PR DESCRIPTION
## Summary

- align the PLDM package documentation with the implemented Caliptra 2.1 reference flow
- document the single `0xFFFF` PLDM component containing the full SPI flash image
- clarify that Caliptra FW, the SoC manifest, MCU RT, and SoC images are embedded flash-image subcomponents
- retain the distinction that the generic package format can support multiple components

## Validation

- `mdbook build docs`
- `git diff --check`