### PR TITLE
Align DOT documentation with MCU implementation

### DIFF
--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -30,11 +30,12 @@ The following table describes the commands defined under this specification. The
 | Request Debug Unlock            | O   | SPDM VDM, MCI Mailbox | Request debug unlock in production environment.                                                                                      |
 | Authorize Debug Unlock Token    | O   | SPDM VDM, MCI Mailbox | Send debug unlock token to device for authorization.                                                                                 |
 | Export Attested CSR             | O   | SPDM VDM, MCI Mailbox | Export attested CSR for a Caliptra device identity key (LDevID, FMC Alias, or RT Alias).                                             |
-| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands. SPDM VDM uses a one-use challenge and hybrid signature.                        |
+| Device Ownership Transfer       | O   | SPDM VDM, MCI Mailbox | Query and change the implemented DOT state.                                                                                          |
+| Authorization-Gated Subcommands | O   | SPDM VDM, MCI Mailbox | Security-sensitive provisioning and fuse subcommands using a one-use challenge and hybrid signature.                                |
 
 ### Authorization-Gated Subcommands
 
-The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. SPDM VDM requests use the challenge and hybrid-signature flow described in [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow). For the MCI mailbox path, access control is governed by the mailbox security boundary and platform policy.
+The following subcommands are assigned to the SPDM VDM IANA authorization-gated path and are also available through the MCI mailbox path where implemented. Both paths use the same one-use challenge and hybrid-signature verification described in [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow); only their outer framing differs.
 
 | Subcommand Name                | Transport(s)               | Description                                        |
 | ------------------------------ | -------------------------- | -------------------------------------------------- |
@@ -46,8 +47,8 @@ The following subcommands are assigned to the SPDM VDM IANA authorization-gated 
 | Fuse Revoke Vendor PK Hash     | SPDM VDM IANA, MCI Mailbox | Revoke vendor public key hash.                     |
 | Fuse Lock Partition            | SPDM VDM IANA, MCI Mailbox | Lock fuse partition.                               |
 | Dot Lock                       | SPDM VDM IANA, MCI Mailbox | Lock the DOT after ownership validation.          |
-| Dot Disable                    | SPDM VDM IANA, MCI Mailbox | Disable DOT while preserving ownership state.     |
-| Dot Rotate                     | SPDM VDM IANA, MCI Mailbox | Rotate ownership keys and increment the epoch.    |
+| Dot Disable                    | SPDM VDM IANA, MCI Mailbox | Enter ODD state with no DOT-supplied CAK.          |
+| Dot Rotate                     | SPDM VDM IANA, MCI Mailbox | Replace DOT key digests and advance the epoch.     |
 | Get Dot Backup Blob            | SPDM VDM IANA, MCI Mailbox | Export the current DOT backup blob.               |
 
 ## Command Definitions
@@ -143,15 +144,7 @@ The authorized-subcommand assignments are stable capability indexes; they are no
 | 6   | `MCI_MAILBOX_SERVICE` | MCU Runtime includes the external MCI mailbox service |
 | 7   | `DOE`                 | MCU Runtime includes the DOE transport                |
 
-The `mcu_rom` field is reserved for a future versioned ROM-to-Runtime capability handoff. Until that handoff is specified, responders set `mcu_rom` to zero and the following assignments are not advertised.
-
-**Proposed MCU ROM Capability Flags**:
-
-| Bit | Name                 | Description                              |
-| --- | -------------------- | ---------------------------------------- |
-| 0   | `STREAMING_BOOT_I3C` | MCU ROM supports streaming boot over I3C |
-| 1   | `FLASH_BOOT`         | MCU ROM supports flash boot              |
-| 2   | `NETWORK_BOOT`       | MCU ROM supports network boot            |
+The `mcu_rom` field is reserved and responders currently set it to zero.
 
 ### Get Debug Log
 
@@ -218,11 +211,8 @@ request naming an unsupported `(evidence_format, algorithm)` pair returns
 | `0x0001` | Owner  | Owner hierarchy. Reserved.     |
 
 A value not listed above returns `INVALID_PARAMS`. `Owner` is reserved and
-returns `UNSUPPORTED_OPERATION` today: signing is not yet slot-aware, so every
-entity would resolve to the same vendor key, and serving it would return
-evidence claiming an endorsement that was never selected or provisioned. Once
-signing is slot-aware, whether an entity can be served follows the provisioning
-state of its endorsement slot.
+returns `UNSUPPORTED_OPERATION`; the current signer supports only the Vendor
+entity.
 
 #### Format Discovery
 
@@ -316,9 +306,9 @@ Authorizes the debug unlock token. The request body is identical for MCI mailbox
 | 41:43     | reserved                 | u8[3]     | Reserved field                                                                        |
 | 44:91     | challenge                | u8[48]    | Random number challenge                                                               |
 | 92:187    | ecc_public_key           | u32[24]   | ECC public key in hardware format (little endian)                                     |
-| 188:2639  | mldsa_public_key         | u32[648]  | MLDSA public key in hardware format (little endian)                                   |
-| 2640:2735 | ecc_signature            | u32[24]   | ECC P-384 signature of the message hashed using SHA2-384 (R and S coordinates)        |
-| 2736:6199 | mldsa_signature          | u32[1157] | MLDSA signature of the message hashed using SHA2-512 (4627 bytes + 1 reserved byte)   |
+| 188:2779  | mldsa_public_key         | u32[648]  | MLDSA public key in hardware format (little endian)                                   |
+| 2780:2875 | ecc_signature            | u32[24]   | ECC P-384 signature of the message hashed using SHA2-384 (R and S coordinates)        |
+| 2876:7503 | mldsa_signature          | u32[1157] | MLDSA signature of the message hashed using SHA2-512 (4627 bytes + 1 reserved byte)   |
 
 **Response Payload**: Empty. Command completion status is carried by the transport-specific response framing.
 
@@ -343,7 +333,14 @@ Exports an attested Certificate Signing Request (CSR) for a specified device key
 
 ### Authorization-Gated Subcommand Wrapper
 
-Security-sensitive provisioning and fuse subcommands are assigned to the SPDM VDM IANA authorization-gated path and the MCI mailbox path. The SPDM VDM transport uses an `Authorized Command` wrapper. Its requester first obtains a one-use 48-byte challenge, then appends a hybrid signature over `sub_cmd_id(BE) || sub_payload || challenge`. See [Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow) for the byte-exact transport payloads.
+Security-sensitive provisioning and fuse subcommands are assigned to the SPDM
+VDM IANA authorization-gated path and the MCI mailbox path. The SPDM VDM
+transport uses an `Authorized Command` wrapper, while MCI uses each operation's
+mailbox command ID directly. In both cases the requester first obtains a one-use
+48-byte challenge and appends the common public-key and hybrid-signature trailer
+over `command_id(BE) || command_payload || challenge`. See
+[Caliptra SPDM VDM Commands](caliptra_spdm_vdm_cmds.md#authorization-flow) for
+the byte-exact SPDM framing.
 
 #### Request Payload
 
@@ -421,9 +418,9 @@ Revokes a vendor public key hash.
 
 Locks a fuse partition.
 
-**Request Payload**: TBD
+**Request Payload**: `partition:u32 | HybridSignature`
 
-**Response Payload**: TBD
+**Response Payload**: Empty
 
 ### Device Ownership Transfer (DOT)
 
@@ -436,12 +433,12 @@ The authorization-gated DOT commands are sent via the `AuthorizedCommand` wrappe
 
 | FourCC | Command | Path | Description |
 | ------ | ------- | ---- | ----------- |
-| `MDLK` | `DotLock` | Authorized | Lock DOT after validating the CAK/LAK ownership state. |
-| `MDDS` | `DotDisable` | Authorized | Disable DOT while preserving the ownership blob. |
-| `MDRT` | `DotRotate` | Authorized | Rotate ownership state and advance the DOT epoch. |
+| `MDLK` | `DotLock` | Authorized | Lock DOT with a nonzero CAK digest and LAK digest. |
+| `MDDS` | `DotDisable` | Authorized | Enter ODD state with a zero CAK digest and a nonzero LAK digest. |
+| `MDRT` | `DotRotate` | Authorized | Replace the CAK and LAK digests and advance the DOT epoch by two. |
 | `MDBB` | `GetDotBackupBlob` | Authorized | Export a valid backup copy of the active DOT blob. |
 | `MDUC` | `DotUnlockChallenge` | Native | Request the unlock challenge for a valid ODD DOT state. |
-| `MDUL` | `DotUnlock` | Native | Complete ownership unlock using the stored LAK and challenge signatures. |
+| `MDUL` | `DotUnlock` | Native | Complete ownership unlock using public keys matching the stored LAK digest and both challenge signatures. |
 | `MDST` | `DotStatus` | Native/read-only | Return the current DOT status and fuse state. |
 | `MDRC` | `DotRecovery` | Native | Restore DOT from a previously backed-up blob. |
 | `DOTW` | `DotOverrideChallenge` | Native | Start DOT recovery using the recovery-key challenge flow. |

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -204,20 +204,20 @@ Native-authenticated/read-only DOT request:
 
 | FourCC | Command | Path | DOT payload | Validation |
 | ------ | ------- | ---- | ----------- | ---------- |
-| `MDLK` | Lock | Authorized | `cak[48] || lak_hash[48]` | Nonzero keys; EVEN state |
-| `MDDS` | Disable | Authorized | `lak_hash[48]` | Nonzero LAK hash; EVEN state |
-| `MDRT` | Rotate | Authorized | `min_fuse_count:u32 || cak[48] || lak_hash[48]` | Runs when burned count is below the minimum |
+| `MDLK` | Lock | Authorized | `cak_digest[48] || lak_digest[48]` | Nonzero digests; EVEN state |
+| `MDDS` | Disable | Authorized | `lak_digest[48]` | Nonzero LAK digest; EVEN state |
+| `MDRT` | Rotate | Authorized | `min_fuse_count:u32 || cak_digest[48] || lak_digest[48]` | Runs when burned count is below the minimum |
 | `MDBB` | Get backup blob | Authorized | Empty | ODD state and valid blob HMAC |
 | `MDUC` | Unlock challenge | Native | Empty | ODD state and valid current blob |
-| `MDUL` | Unlock | Native | LAK ECC key, ML-DSA key, hybrid signature | Existing LAK hash and challenge signatures |
+| `MDUL` | Unlock | Native | LAK ECC key, ML-DSA key, hybrid signature | Existing LAK digest and challenge signatures |
 | `MDST` | Status | Native/read-only | Empty | Returns `enabled:u8 || locked:u8 || burned:u16` |
 | `MDRC` | Recovery | Native | `DOT_BLOB[168]` | ODD state and current-epoch blob HMAC |
 | `DOTW` | Override challenge | Native | Recovery ECC key and ML-DSA key | Keys match fused recovery-key hash |
 | `DOTX` | Override | Native | Recovery keys and hybrid signature | Fused key hash and challenge signatures |
 
 `MDLK`, `MDDS`, `MDRT`, and `MDBB` are rejected with `AccessDenied` when sent
-directly under top-level command `0x11`. Recovery-mode gating for `MDRC`,
-`DOTW`, and `DOTX` is deferred; their native cryptographic and state checks are
-always enforced.
+directly under top-level command `0x11`. `MDRC`, `DOTW`, and `DOTX` are not
+gated by a ROM recovery-mode signal; their native cryptographic and state checks
+are always enforced.
 
 **For detailed command flows, state transitions, security properties, and use cases**, see [Device Ownership Transfer (DOT)](dot.md#runtime-commands).

--- a/docs/src/dot.md
+++ b/docs/src/dot.md
@@ -2,14 +2,14 @@
 
 This contains details about the Caliptra implementation of Device Ownership Transfer (DOT) with MCU to assist.
 
-Device Ownership Transfer (DOT) is a security mechanism implemented in Caliptra that enables device owners to establish code signing capabilities rooted in the hardware root of trust without permanently burning the Code Authentication Key (CAK) into fuses. This provides flexibility in ownership management while maintaining strong security guarantees.
+Device Ownership Transfer (DOT) is a security mechanism implemented in Caliptra that enables device owners to establish code signing capabilities rooted in the hardware root of trust without permanently burning the Code Authentication Key (CAK) digest into fuses. This provides flexibility in ownership management while maintaining strong security guarantees.
 
 Reference: [OCP Device Ownership Transfer specification](https://opencomputeproject.github.io/Security/device-ownership-transfer/HEAD/).
 
 ## Table of Contents
 1. [Diagrams](#diagrams)
 1. [Glossary](#glossary)
-1. [DOT Modes](#dot-modes)
+1. [Implemented DOT Model](#implemented-dot-model)
 1. [Cryptographic Binding Mechanism](#cryptographic-binding-mechanism)
 1. [System Components](#system-components)
 1. [State Machine](#state-machine)
@@ -17,14 +17,14 @@ Reference: [OCP Device Ownership Transfer specification](https://opencomputeproj
 1. [Runtime Commands](#runtime-commands)
 1. [Lifecycle Transitions](#lifecycle-transitions)
 1. [Recovery Mechanisms](#recovery-mechanisms)
-1. [Ownership RAM Recommendations](#ownership-ram-recommendations)
 1. [Security Considerations](#security-considerations)
+1. [Appendix: Command Reference](#appendix-command-reference)
 
 
 ## Diagrams
 
 * [ROM Startup and DOT State Initialization](#dot-1-init)
-* [Recovery Mode and FMC Flow Management](#dot-2-recovery)
+* [Locked-State Recovery](#dot-2-recovery)
 * [State Management](#dot-3-state)
 * [Runtime Commands: DOT_LOCK / DOT_DISABLE](#dot-5-command-lock)
 * [Runtime Commands: DOT_UNLOCK_CHALLENGE / DOT_UNLOCK](#dot-6-command-unlock)
@@ -38,81 +38,71 @@ Reference: [OCP Device Ownership Transfer specification](https://opencomputeproj
 
 **BMC (Baseboard Management Controller)**: System management controller that interfaces with Caliptra to issue DOT commands and manage recovery procedures.
 
-**CAK (Code Authentication Key)**: The public key used to authenticate firmware and code running on the device. This is the owner's code signing key rooted in Caliptra.
+**CAK (Code Authentication Key)**: The owner's public code-signing key set used
+to authenticate owner-signed firmware before execution.
+
+**CAK digest**: The SHA-384 digest of the CAK. DOT carries this 48-byte digest
+and installs it into Caliptra as the owner public-key hash, thereby rooting the
+CAK in Caliptra.
 
 **Caliptra**: Hardware root of trust providing secure boot and cryptographic services.
 
 **Caliptra_Core**: Component within Caliptra that performs cryptographic operations offload (key derivation, HMAC, signature verification), derives DOT_EFFECTIVE_KEY, authenticates DOT_BLOBs and commands, and manages owner public key hash.
 
-**Caliptra_MCU**: Microcontroller component that manages DOT state machine, handles runtime commands, controls fuse burning operations, coordinates with Caliptra_Core, and manages Ownership_Storage.
+**Caliptra_MCU**: Microcontroller component that manages the DOT state machine, handles runtime commands, controls fuse burning operations, coordinates with Caliptra_Core, and reads and writes the DOT_BLOB.
 
 **DOT (Device Ownership Transfer)**: Security mechanism for flexible ownership management that enables device owners to establish code signing capabilities rooted in hardware without permanently burning keys into fuses.
 
-**DOT_BLOB**: A cryptographically authenticated data structure containing the CAK and LAK, sealed with the DOT_EFFECTIVE_KEY via HMAC. Stored in external flash storage.
+**DOT_BLOB**: A cryptographically authenticated data structure containing the
+CAK digest and LAK digest, sealed with the DOT_EFFECTIVE_KEY via HMAC.
+Stored in external flash storage.
 
-**DOT_EFFECTIVE_KEY**: A key derived from DOT_ROOT_KEY and the DOT_FUSE_ARRAY value, used to authenticate DOT_BLOBs via HMAC. The derivation varies based on EVEN/ODD state.
+**DOT_EFFECTIVE_KEY**: An HMAC key derived inside Caliptra from a selected stable
+identity root, the DOT domain-separation label, and the DOT fuse epoch. The
+reference ROM and Runtime use the stable IDevID root. The key is returned to MCU only as an
+opaque encrypted CMK and is used to authenticate DOT_BLOBs via HMAC.
 
 **DOT_FUSE_ARRAY**: A minimal fuse array using 1 bit per state change to track DOT state transitions. The fuse value acts as a counter that increments with each state change (one-time programmable). Must reside in a non-ECC protected fuse partition (e.g., `VENDOR_TEST_PARTITION` in the reference map) so that individual bits can be burned sequentially over time without invalidating partition ECC protections.
 
-**DOT_ROOT_KEY**: A hardware-derived secret key unique to the silicon, used as the basis for deriving DOT_EFFECTIVE_KEY. Provides silicon binding.
-
-**EVEN STATE**: Uninitialized/Volatile state (fuse value % 2 == 0) where no persistent ownership is bound to the silicon.
-
-**FMC (First Mutable Code)**: First stage of mutable firmware. In Caliptra MCU architecture, FMC and RT are not differentiated as separate binaries (FMC is RT).
+**EVEN STATE**: Uninitialized state (fuse value % 2 == 0) where DOT does not provide an active owner.
 
 **HMAC (Hash-based Message Authentication Code)**: Cryptographic authentication method used to seal and verify DOT_BLOBs.
 
-**LAK (Lock Authentication Key)**: The private key used to lock/unlock the DOT state and control the Disabled state. The entity possessing LAK.priv has the authority to:
-- Lock ownership to the device (DOT_LOCK)
-- Disable DOT while maintaining ownership (DOT_DISABLE)
-- Unlock and release ownership (DOT_UNLOCK)
+**LAK (Lock Authentication Key)**: The owner's hybrid authorization key set,
+comprising an ECDSA P-384 key pair and an ML-DSA-87 key pair. To authorize
+`DOT_UNLOCK`, the owner signs the one-time challenge transcript with both LAK
+private keys, and the device verifies both signatures with the corresponding
+LAK public keys. The private keys remain with the owner.
+
+**LAK digest**: The SHA-384 digest of the LAK public-key set. DOT carries this
+48-byte digest in lock, disable, and rotate requests and stores it in the
+authenticated DOT_BLOB. During `DOT_UNLOCK`, the device hashes the supplied LAK
+public keys and compares the result with the stored LAK digest before verifying
+both signatures. Current Rust APIs use the legacy field name `lak_hash` for
+this value.
 
 **ODD STATE**: Locked/Disabled state (fuse value % 2 == 1) where ownership is cryptographically bound to the silicon via DOT_BLOB.
 
-**Ownership_Storage**: Volatile memory (e.g., FLOP-based register) that stores the current CAK and LAK during runtime. Must be retained across at least one MCU reset level and invalidated on power cycle. Contents are not updatable once marked valid by a non-Caliptra entity.
-
 **ROM (Read-Only Memory)**: Immutable boot code that executes first on device startup.
 
-**RT (Runtime)**: Main operating firmware that executes after ROM and FMC initialization.
+**RT (Runtime)**: Main operating firmware that executes after ROM.
 
 **DOT recovery key**: Hybrid ECC and ML-DSA key used to authorize DOT_OVERRIDE in catastrophic recovery scenarios. Its public-key hash is provisioned in OTP.
 
-**Volatile DOT**: Operating mode where CAK is installed per boot cycle and ownership is lost on power cycle. No fuse burning required.
-
-**Mutable Locking DOT**: Operating mode where ownership is locked and bound to silicon via cryptographic binding using DOT_FUSE_ARRAY. Persists across power cycles.
+**Mutable Locking DOT**: The implemented ownership model, where ownership is locked and bound to silicon via cryptographic binding using DOT_FUSE_ARRAY. It persists across power cycles.
 
 ### Goals
 - Enable owner-specific code signing rooted in Caliptra (the root of trust)
 - Avoid permanent fuse programming for ownership keys
-- Support both temporary (volatile) and persistent (mutable locking) ownership models
+- Support persistent mutable-locking ownership
 - Provide secure ownership transfer mechanisms
 - Enable recovery from corrupted states
 
 ---
 
-## DOT Modes
+## Implemented DOT Model
 
-### 1. Volatile DOT
-
-**Characteristics:**
-- CAK is installed per boot cycle
-- Ownership information is stored only in Ownership_Storage
-- Power cycle clears ownership
-- No fuse burning required
-- DOT_FUSE_ARRAY remains in EVEN state
-
-**Use Cases:**
-- Temporary ownership scenarios
-
-The current Runtime DOT command family does not expose a volatile-install
-operation.
-
-**Flow:**
-```
-Volatile (EVEN) → [Power Cycle] → Uninitialized (EVEN)
-```
-
-### 2. Mutable Locking DOT
+### Mutable Locking DOT
 
 **Characteristics:**
 - CAK is locked and bound to silicon via cryptographic binding
@@ -140,11 +130,27 @@ The mutable locking DOT mechanism achieves secure binding without secure storage
 
 ### Key Derivation
 
-The DOT_EFFECTIVE_KEY is derived as follows:
+Caliptra ROM derives and write-locks stable IDevID and LDevID roots in its key
+vault. The IDevID root is ultimately derived from the device UDS; the LDevID
+root additionally incorporates Field Entropy. The reference DOT ROM and Runtime
+paths both use the stable IDevID root.
 
+`RomParameters::dot_stable_key_type` can change the root used by ROM-only DOT
+paths, but the reference Runtime always requests IDevID. A platform that changes
+the ROM setting must make the corresponding Runtime change and migrate or
+recover any existing blob; the reference implementation does neither.
+
+MCU requests the effective key with `CM_DERIVE_STABLE_KEY` using this 32-byte
+context:
+
+```text
+info = "Caliptra DOT stable key" || epoch_u16_le || zero_padding
+DOT_EFFECTIVE_KEY = CM_DERIVE_STABLE_KEY(selected_stable_identity_root, info)
 ```
-DOT_EFFECTIVE_KEY = KDF(DOT_ROOT_KEY, DOT_FUSE_ARRAY_VALUE)
-```
+
+The selected stable identity root and plaintext effective key remain inside
+Caliptra. MCU receives an opaque encrypted CMK that it can pass to Caliptra's
+HMAC service.
 
 ### State-Dependent Derivation
 
@@ -161,15 +167,16 @@ DOT_EFFECTIVE_KEY = KDF(DOT_ROOT_KEY, DOT_FUSE_ARRAY_VALUE)
 ### DOT_BLOB Authentication
 
 ```
-DOT_BLOB = {CAK, LAK, metadata}
+DOT_BLOB = {CAK_DIGEST, LAK_DIGEST, metadata}
 HMAC_TAG = HMAC-SHA-512(DOT_EFFECTIVE_KEY, DOT_BLOB)
 ```
 
-The DOT_BLOB is authenticated on every boot in ODD state to ensure the CAK and LAK is authentic.
+The DOT_BLOB is authenticated on every boot in ODD state to ensure the CAK and
+LAK digests are authentic.
 
 ### Security Properties
 
-1. **Binding to Silicon**: DOT_ROOT_KEY is unique per device, preventing DOT_BLOB portability
+1. **Binding to Silicon**: The selected stable identity root is device-derived, preventing DOT_BLOB portability
 2. **Binding to State**: Fuse value is incorporated into key derivation, preventing rollback attacks
 3. **Forward Security**: Unlocking increments fuses, invalidating old DOT_BLOBs
 4. **No Secure Storage Required**: Cryptographic binding replaces need for secure non-volatile storage
@@ -183,13 +190,13 @@ The DOT_BLOB is authenticated on every boot in ODD state to ensure the CAK and L
 - Handles runtime commands
 - Controls fuse burning operations
 - Coordinates with Caliptra_Core for cryptographic operations
-- Manages Ownership_Storage
+- Reads, authenticates, and updates the DOT_BLOB
 
 ### Caliptra_Core
 - Performs cryptographic operations offload(key derivation, HMAC, signature verification)
 - Derives DOT_EFFECTIVE_KEY
 - Authenticates DOT_BLOBs and commands
-- Manages owner public key hash (SET_OWNER_PK_HASH)
+- Installs the selected owner public key hash (`INSTALL_OWNER_PK_HASH`)
 
 ### DOT_FUSE_ARRAY
 - Hardware fuse array
@@ -199,17 +206,9 @@ The DOT_BLOB is authenticated on every boot in ODD state to ensure the CAK and L
 - Written during state transitions
 - One-time programmable (OTP) per bit
 
-### Ownership_Storage
-- Volatile storage for current CAK and LAK (ex, FLOP based register)
-- Content must be retained across at least one MCU reset level; should be retained across as many MCU reset levels as possible
-- Ownership data must be invalidated and/or scrubbed on power cycle
-- Ownership data must not be updatable once marked as valid by a non-Caliptra entity
-
-See [Ownership RAM Recommendations](#ownership-ram-recommendations) for detailed guidance on how this storage should be sized, laid out, and retained across resets.
-
 ### Storage (Flash)
 - Non-volatile external storage
-- Stores DOT_BLOB (with redundancy)
+- Stores the active DOT_BLOB
 - Not assumed to be secure
 
 ### BMC (Baseboard Management Controller)
@@ -226,38 +225,30 @@ See [Ownership RAM Recommendations](#ownership-ram-recommendations) for detailed
 
 #### 1. Uninitialized (EVEN State)
 - DOT_FUSE_ARRAY is in EVEN state
-- No CAK in Ownership_Storage
-- Device boots without owner authentication
-- DOT_BLOB is not authoritative for boot and may contain post-transition data
+- DOT does not provide an active owner
+- ROM installs the fused owner PK hash when it is provisioned
+- An empty DOT_BLOB is permitted; a nonempty blob must authenticate with the next-epoch key
 
-#### 2. Volatile (EVEN State)
-- DOT_FUSE_ARRAY is in EVEN state
-- CAK present in Ownership_Storage
-- Device boots with owner authentication
-- Ownership lost on power cycle
-- DOT_BLOB is not authoritative for boot
-
-#### 3. Locked (ODD State)
+#### 2. Locked (ODD State)
 - DOT_FUSE_ARRAY is in ODD state
-- CAK present in Ownership_Storage (retrieved from DOT_BLOB)
+- Authenticated DOT_BLOB contains a nonzero CAK digest
 - DOT_BLOB authenticated
 - Device boots with owner authentication
 - Ownership persists across power cycles
 - DOT_BLOB present in storage
 
-#### 4. Disabled (ODD State)
+#### 3. Disabled (ODD State)
 - DOT_FUSE_ARRAY is in ODD state
-- LAK present in DOT_BLOB, but no CAK
-- Device boots without code authentication enforcement
+- LAK digest present in DOT_BLOB, but no CAK digest
+- ROM authenticates the DOT_BLOB and installs the fused owner PK hash when it is provisioned
 - Ownership is locked to silicon (via LAK) preventing unauthorized takeover
-- Useful when owner doesn't want code signing but wants to prevent others from claiming ownership
 
-#### 5. Corrupted (ODD State)
+#### 4. Corrupted (ODD State)
 - DOT_FUSE_ARRAY is in ODD state
 - DOT_BLOB is corrupted or missing
-- Device boots into recovery mode (ROM or FMC)
+- Normal firmware boot stops while ROM invokes the platform's configured locked-state recovery policy
 - No CAK available
-- Special recovery or override commands accepted
+- Configured ROM recovery handlers may restore a backup blob or perform a recovery-key override
 
 ### State Transitions
 
@@ -269,8 +260,14 @@ Uninitialized (EVEN, n)
 Locked / Disabled (ODD, n)
     └─ DOT_UNLOCK  → Uninitialized (EVEN, n+1)
 
-Locked / Disabled (n)
-    └─ DOT_ROTATE  → same parity (n+2)
+Locked (ODD, n)
+    └─ DOT_ROTATE  → Locked (ODD, n+2)
+
+Disabled (ODD, n)
+    └─ DOT_ROTATE  → Locked (ODD, n+2)
+
+Uninitialized (EVEN, n)
+    └─ DOT_ROTATE  → EVEN at command completion; stages a boot-time lock
 ```
 
 ---
@@ -313,36 +310,39 @@ skinparam sequence {
 participant Caliptra_MCU
 participant Caliptra_Core
 participant DOT_FUSE_ARRAY
-participant Ownership_Storage
 participant Storage
 
 autonumber
 
-Caliptra_MCU -> Caliptra_MCU : Start up MCU ROM
-Caliptra_MCU -> Caliptra_Core : Start Core
-Caliptra_MCU -> DOT_FUSE_ARRAY : MCU ROM read DOT_FUSE_ARRAY for State (n)
-note across : DOT_FUSE_ARRAY is either in EVEN STATE (not locked, not disabled) or in ODD STATE dot-1(locked or disabled)
-Caliptra_MCU -> Caliptra_Core : MCU ROM calls Core ROM to DERIVE_KEY with DOT_FUSE_ARRAY as input
-alt DOT FUSE is in EVEN STATE
-    Caliptra_Core -> Caliptra_Core : Core-ROM derive DOT_EFFECTIVE_KEY with DOT_ROOT_KEY and DOT_FUSE_ARRAY value (n+1)
-    note across : The derived key represent the key that will be used to seal the next DOT_BLOB
-else DOT FUSE is in ODD STATE
-    Caliptra_Core -> Caliptra_Core : Core-ROM derive DOT_EFFECTIVE_KEY with DOT_ROOT_KEY and DOT_FUSE_ARRAY value (n)
-    note across : The derived key represent the key that is used to authenticate the current DOT_BLOB
-    Caliptra_MCU -> Storage : MCU ROM reads DOT_BLOB from storage
-    note across : In the ODD State, DOT_BLOB must be available from storage
-    Caliptra_MCU -> Caliptra_Core : MCU ROM asks Core-ROM to authenticate DOT_BLOB with DOT_EFFECTIVE_KEY (HMAC function)
-    alt DOT_BLOB is authentic (Contains CAK / LAK)
-        Caliptra_MCU -> Ownership_Storage : MCU ROM programs CAK / LAK from DOT_BLOB into Ownership_Storage
-        note across : This would overwrite existing CAK / LAK from previous volatile install if exist, but that's ok
+Caliptra_MCU -> Caliptra_MCU : Start MCU ROM and initialize Caliptra Core
+Caliptra_MCU -> DOT_FUSE_ARRAY : Read DOT initialization, fuse count, and parity
+Caliptra_MCU -> Storage : Read DOT_BLOB
+alt DOT_BLOB is empty or erased
+    alt DOT initialized and parity is ODD
+        Caliptra_MCU -> Caliptra_MCU : Enter configured locked-state recovery path
+    else
+        Caliptra_MCU -> Caliptra_MCU : Select fused owner PK hash fallback, if provisioned
     end
-    alt DOT_BLOB corruptted
-        Caliptra_MCU -> Caliptra_MCU : MCU ROM boots MCU RT without Stage 2 CAK / LAK indicating DOT recovery mode
-        note across: Recovery-only Runtime gating is deferred; native recovery authorization remains mandatory
-        note across : For more details, Ref "DOT Recovery Mode and FMC Flow Management"
+else DOT_BLOB is present
+    Caliptra_MCU -> Caliptra_Core : Derive DOT_EFFECTIVE_KEY with epoch n (ODD) or n+1 (EVEN)
+    Caliptra_MCU -> Caliptra_Core : Authenticate DOT_BLOB HMAC
+    alt Authentication fails in ODD state
+        Caliptra_MCU -> Caliptra_MCU : Enter configured locked-state recovery path
+    else Authentication fails in EVEN state
+        Caliptra_MCU -> Caliptra_MCU : Fatal DOT boot error
+    else Authentication succeeds
+        opt DOT initialized, parity EVEN, and blob has nonzero CAK and LAK digests
+            Caliptra_MCU -> DOT_FUSE_ARRAY : Burn next bit as pending lock transition
+        end
+        alt Boot-start parity was ODD and CAK digest is nonzero
+            Caliptra_MCU -> Caliptra_MCU : Select DOT_BLOB CAK digest
+        else
+            Caliptra_MCU -> Caliptra_MCU : Select fused owner PK hash fallback, if provisioned
+        end
     end
-    Caliptra_MCU -> Ownership_Storage : MCU ROM reads Ownership_Storage for CAK and calls Core-ROM to SET_OWNER_PK_HASH with CAK as input
-    note across : This is the common path, either volatile or locked CAK might exist (or none)
+end
+opt Selected owner digest is nonzero
+    Caliptra_MCU -> Caliptra_Core : MCU ROM calls INSTALL_OWNER_PK_HASH with selected digest
 end
 Caliptra_MCU -> Caliptra_Core : MCU ROM asks Core-ROM to run RI_DOWNLOAD_FIRMWARE to boot
 Caliptra_MCU -> Caliptra_MCU : MCU ROM resets and jumps to RT
@@ -351,50 +351,48 @@ Caliptra_MCU -> Caliptra_MCU : MCU ROM resets and jumps to RT
 ```
 
 
-1. **MCU ROM Startup**
-   - Caliptra_MCU boots and starts MCU ROM
-   - MCU ROM initializes Caliptra_Core
+This diagram shows the production-lifecycle path when DOT flash is configured
+and the normal `DotThenFuse` owner policy is selected. Non-production lifecycle
+states and the `ForceFuse` policy bypass the DOT blob and use the fused owner.
 
-2. **Read DOT_FUSE_ARRAY State**
-   - MCU ROM reads current DOT_FUSE_ARRAY value (n)
-   - Determines if state is EVEN or ODD
-
-3. **Derive DOT_EFFECTIVE_KEY**
-   - MCU ROM calls Caliptra_Core ROM to derive key
-   - **If EVEN state**: Derive with (n+1) for next DOT_BLOB sealing
-   - **If ODD state**: Derive with (n) for current DOT_BLOB authentication
-
-4. **ODD State Processing**
-   - Read DOT_BLOB from storage
-   - Authenticate DOT_BLOB using HMAC with DOT_EFFECTIVE_KEY
-   - **If authentic**: Extract CAK/LAK and program into Ownership_Storage
-   - **If corrupted**: Boot into DOT recovery mode (recovery flow documented in [later diagram](#dot-2-recovery))
-
-5. **Set Owner Public Key**
-   - Read CAK from Ownership_Storage (if present)
-   - Call Caliptra_Core ROM SET_OWNER_PK_HASH with CAK
-
-6. **Boot Firmware**
-   - Call Caliptra_Core ROM RI_DOWNLOAD_FIRMWARE
-   - MCU ROM resets and jumps to RT (Runtime)
+1. ROM reads the DOT fuses and active blob.
+2. An empty blob falls back to the fused owner unless DOT is initialized in ODD
+    state, where it invokes the configured locked-state recovery policy.
+3. A nonempty blob is authenticated with epoch `n` in ODD state or `n+1` in
+    EVEN state. Authentication failure invokes recovery only in ODD state; it is
+    fatal in EVEN state.
+4. For an authenticated EVEN-state blob containing nonzero CAK and LAK digests,
+    ROM burns the next fuse as its implemented pending-lock transition. Owner
+    selection for that boot still uses the state read before the burn, so the
+    fused owner remains the fallback until the next boot.
+5. For an authenticated ODD-state blob, ROM selects its nonzero CAK digest;
+    otherwise it selects the fused owner PK hash.
+6. ROM sends a nonzero selected digest through `INSTALL_OWNER_PK_HASH`, then
+    continues the normal firmware-load flow.
 
 ### State Determination Logic
 
 ```
-if (DOT_FUSE_ARRAY % 2 == 0) {
-    // EVEN STATE - Unlocked/Uninitialized
-    DOT_EFFECTIVE_KEY = Derive(DOT_ROOT_KEY, n+1)
-    // Ready to seal new DOT_BLOB
+DOT_BLOB = Read_Storage()
+if (DOT_BLOB is empty) {
+    if (DOT_INITIALIZED && n is ODD) Recover_Locked_DOT()
+    OWNER_DIGEST = Read_Fused_Owner_Pk_Hash()
 } else {
-    // ODD STATE - Locked/Enabled
-    DOT_EFFECTIVE_KEY = Derive(DOT_ROOT_KEY, n)
-    DOT_BLOB = Read_Storage()
-    if (Authenticate(DOT_BLOB, DOT_EFFECTIVE_KEY)) {
-        CAK, LAK = Extract(DOT_BLOB)
-        Write_Ownership_Storage(CAK, LAK)
-    } else {
-        Boot_Recovery_Mode()
+    epoch = (n is EVEN) ? n + 1 : n
+    DOT_EFFECTIVE_KEY = DeriveStableKey(IDevID, epoch)
+    if (!Authenticate(DOT_BLOB, DOT_EFFECTIVE_KEY)) {
+        if (n is ODD) Recover_Locked_DOT()
+        else Fatal_DOT_Error()
     }
+    if (DOT_INITIALIZED && n is EVEN && CAK != 0 && LAK != 0) {
+        Burn_Next_DOT_Fuse()
+    }
+    OWNER_DIGEST = (DOT_INITIALIZED && n is ODD && CAK != 0)
+        ? DOT_BLOB.CAK_DIGEST
+        : Read_Fused_Owner_Pk_Hash()
+}
+if (OWNER_DIGEST != 0) {
+    Install_Owner_Pk_Hash(OWNER_DIGEST)
 }
 ```
 
@@ -409,12 +407,12 @@ commands as `AuthorizedCommand (0x12) -> family 0x11 -> DOT FourCC`.
 
 | Command | FourCC | Classification | Core validation |
 | ------- | ------ | -------------- | --------------- |
-| `DOT_LOCK` | `MDLK` | Generic-authorized | Nonzero CAK/LAK hash, EVEN state |
-| `DOT_DISABLE` | `MDDS` | Generic-authorized | Nonzero LAK hash, EVEN state |
+| `DOT_LOCK` | `MDLK` | Generic-authorized | Nonzero CAK digest and LAK digest, EVEN state |
+| `DOT_DISABLE` | `MDDS` | Generic-authorized | Nonzero LAK digest, EVEN state |
 | `DOT_ROTATE` | `MDRT` | Generic-authorized | Current burned count below requested minimum |
 | `GET_DOT_BACKUP_BLOB` | `MDBB` | Generic-authorized | ODD state and valid blob HMAC |
 | `DOT_UNLOCK_CHALLENGE` | `MDUC` | Native | ODD state and valid current blob |
-| `DOT_UNLOCK` | `MDUL` | Native LAK signatures | Stored LAK hash, challenge, and fuse epoch |
+| `DOT_UNLOCK` | `MDUL` | Native LAK signatures | Stored LAK digest, challenge, and fuse epoch |
 | `DOT_STATUS` | `MDST` | Native/read-only | OTP state read |
 | `DOT_RECOVERY` | `MDRC` | Native blob authentication | ODD state and current-epoch blob HMAC |
 | `DOT_OVERRIDE_CHALLENGE` | `DOTW` | Native recovery authority | Keys match fused recovery-key hash |
@@ -492,9 +490,9 @@ cargo xtask runtime-build \
 A platform must not enable these features until its Runtime storage backend
 refers to the same persistent DOT blob storage consumed by ROM.
 
-Recovery-mode gating for Runtime `MDRC`, `DOTW`, and `DOTX` is deferred. Their
-native cryptographic and state checks remain mandatory. Firmware-manifest DOT
-directives and ROM recovery protocols are unchanged.
+Runtime `MDRC`, `DOTW`, and `DOTX` are not gated by a ROM recovery-mode signal.
+Their native blob-HMAC, recovery-key, challenge, and fuse-state checks are
+always enforced.
 
 ### 1. DOT_LOCK
 
@@ -532,7 +530,6 @@ skinparam sequence {
 participant BMC
 participant Caliptra_MCU
 participant Caliptra_Core
-participant Ownership_Storage
 participant Storage
 
 autonumber
@@ -561,14 +558,14 @@ Caliptra_MCU -> BMC : Success; reset required to activate ownership
 @enduml
 ```
 
-**Purpose:** Install CAK and LAK hashes in a DOT_BLOB and lock ownership to silicon.
+**Purpose:** Install a CAK digest and LAK digest in a DOT_BLOB and lock ownership to silicon.
 
 **Preconditions:**
 - DOT_FUSE_ARRAY in EVEN state
-- Nonzero CAK and LAK hashes provided in the command
+- Nonzero CAK digest and LAK digest provided in the command
 
 **Flow:**
-1. BMC obtains `MACC` and issues an authorized `MDLK` request containing CAK and LAK hashes.
+1. BMC obtains `MACC` and issues an authorized `MDLK` request containing a CAK digest and LAK digest.
 2. MCU RT verifies generic command authorization and checks DOT_FUSE_ARRAY state.
    - If ODD state: Return error (already locked)
 3. MCU RT creates and HMAC-seals the ODD-state DOT_BLOB using epoch `(n+1)`.
@@ -577,7 +574,7 @@ Caliptra_MCU -> BMC : Success; reset required to activate ownership
 6. MCU RT returns success with `reset_required = 1`.
 7. **On the subsequent boot**:
     - Device boots in ODD state (n+1)
-    - DOT_BLOB is authenticated and CAK/LAK retrieved
+    - DOT_BLOB is authenticated and its CAK and LAK digests are retrieved
     - Device is now in Locked state
 
 **Result:** Device enters Locked state with ownership persisting across power cycles.
@@ -586,32 +583,34 @@ Caliptra_MCU -> BMC : Success; reset required to activate ownership
 
 Diagram is [above](#dot-5-command-lock).
 
-**Purpose:** Lock DOT mechanism in disabled state directly from uninitialized state, maintaining ownership control without code authentication requirements.
+**Purpose:** Enter ODD state with a nonzero LAK digest but no DOT-supplied CAK.
 
-**Use Case:** When the owner does not want to sign code with CAK but also does not want to leave the system in an uninitialized state where others could take over ownership. This provides a secure "parked" state where:
-- The device remains under the owner's control (via LAK)
-- No code authentication is enforced (no CAK)
-- Unauthorized parties cannot install their own CAK or disable the device
-- The owner can later unlock to return to uninitialized state
+**Use Case:** Park DOT ownership behind the LAK-authenticated unlock flow without
+installing a CAK from the DOT_BLOB. On boot, ROM uses the fused owner PK hash as
+the owner fallback when that fuse is provisioned; if it is zero, no owner hash
+is installed.
 
 **Preconditions:**
 - DOT_FUSE_ARRAY in EVEN state
-- Nonzero LAK hash provided in command
+- Nonzero LAK digest provided in command
 
 **Flow:**
-1. BMC obtains `MACC` and issues an authorized `MDDS` request containing the LAK hash.
+1. BMC obtains `MACC` and issues an authorized `MDDS` request containing the LAK digest.
 2. MCU RT verifies generic command authorization and checks DOT_FUSE_ARRAY state.
    - If ODD state: Return error (already locked or disabled)
-3. MCU RT creates and HMAC-seals an ODD-state DOT_BLOB containing LAK but no CAK.
+3. MCU RT creates and HMAC-seals an ODD-state DOT_BLOB containing the LAK digest but a zero CAK digest.
 4. MCU RT writes and read-back verifies the DOT_BLOB.
 5. MCU RT burns and verifies the next DOT_FUSE_ARRAY bit.
 6. MCU RT returns success with `reset_required = 1`.
 7. **On the subsequent boot**:
     - Device boots in ODD state (n+1)
-    - DOT_BLOB is authenticated and LAK recovered (but no CAK)
+    - DOT_BLOB is authenticated and its LAK digest is recovered, but no CAK digest is active
+    - ROM installs the fused owner PK hash when it is provisioned
     - Device is now in Disabled state
 
-**Result:** Device enters Disabled state - ownership is locked to the silicon (preventing takeover) but no code authentication is active. The owner retains authority to unlock via LAK.priv, which will return the device to Uninitialized state.
+**Result:** Device enters Disabled state. DOT supplies no CAK, and the LAK
+holder can return the device to Uninitialized state by completing the hybrid
+unlock challenge.
 
 ### 3. DOT_UNLOCK_CHALLENGE / DOT_UNLOCK
 
@@ -650,7 +649,6 @@ skinparam sequence {
 participant BMC
 participant Caliptra_MCU
 participant Caliptra_Core
-participant Ownership_Storage
 
 autonumber
 
@@ -661,110 +659,71 @@ alt DOT_FUSE_ARRAY is in EVEN STATE
 end
 
 Caliptra_MCU -> BMC : Return challenge
-note across : Challenge is based on previous DOT_LOCK / DOT_DISABLE command's Unlock_Method
-BMC -> Caliptra_MCU : Signs DOT_UNLOCK command + challenge
-Caliptra_MCU -> Caliptra_Core : Authenticate DOT_UNLOCK with LAK public key from DOT_BLOB
+note across : Challenge is a fresh 48-byte random value
+BMC -> Caliptra_MCU : Signs DOT_UNLOCK challenge transcript with both LAK private keys
+Caliptra_MCU -> Caliptra_Core : Hash supplied LAK public keys, compare with stored LAK digest, and verify both signatures
 note across : ensure the locking entity has proper authority
 alt Authentication Fail
     Caliptra_MCU -> BMC : DOT request invalid
     Caliptra_MCU -> Caliptra_MCU : Abort sequence
 end
-Caliptra_MCU -> Caliptra_MCU : Seal post-burn blob retaining authenticated LAK hash
+Caliptra_MCU -> Caliptra_MCU : Seal post-burn blob retaining authenticated LAK digest
 Caliptra_MCU -> Caliptra_MCU : Write/read-back blob and burn next DOT fuse
 Caliptra_MCU -> BMC : Success; reset required
 
 @enduml
 ```
 
-**Purpose:** Unlock and unbind ownership from silicon, returning to volatile or uninitialized state.
+**Purpose:** Remove the DOT-supplied CAK and return DOT to the Uninitialized state.
 
 **Preconditions:**
 - DOT_FUSE_ARRAY in ODD state (Locked or Disabled)
-- Valid DOT_BLOB in storage (for LAK.pub)
+- Valid DOT_BLOB in storage containing a nonzero LAK digest
 
 **Flow:**
 1. BMC issues DOT_UNLOCK_CHALLENGE
 2. MCU RT checks DOT_FUSE_ARRAY state
    - If EVEN state: Return error (already unlocked)
 3. MCU RT generates and returns challenge
-   - Challenge based on Unlock_Method from previous LOCK/DISABLE
-4. BMC provides signed challenge with LAK.priv
-5. BMC issues DOT_UNLOCK command with signed challenge
+    - The challenge is a fresh 48-byte random value
+4. BMC signs `MDUL(BE) || challenge` with both LAK private keys.
+5. BMC issues `DOT_UNLOCK` with the LAK public keys and both signatures.
 6. MCU RT verifies challenge matches
-7. MCU RT authenticates command using LAK.pub from DOT_BLOB
+7. MCU RT hashes the supplied LAK public keys, compares the result with the LAK digest in the DOT_BLOB, and verifies both signatures.
    - If authentication fails: Return error
-8. MCU RT seals an empty-CAK post-burn blob while retaining the authenticated LAK hash.
+8. MCU RT seals a post-burn blob with a zero CAK digest while retaining the authenticated LAK digest.
 9. MCU RT writes/read-back verifies the blob, burns one fuse bit, and verifies the new count.
 10. MCU RT consumes the challenge and returns success with `reset_required = 1`.
-11. On the subsequent boot, the device is in EVEN state `(n+1)` with no active CAK.
+11. On the subsequent boot, the device is in EVEN state `(n+1)`. DOT supplies no owner, and ROM installs the fused owner PK hash when it is provisioned.
 
 **Result:**
 - Device enters the unlocked/uninitialized EVEN state.
-- The retained LAK hash keeps the post-burn blob well formed and matches firmware-manifest unlock semantics.
+- Runtime retains the HMAC-authenticated LAK digest from the current blob in the post-burn blob.
+
+Firmware-manifest UNLOCK is a separate ROM path authorized by the authenticated
+MCU image. It stores the manifest section's LAK digest and does not perform the
+Runtime LAK challenge flow.
 
 ### 4. DOT_ROTATE
 
-`MDRT` is generic-authorized and carries `min_fuse_count`, CAK, and LAK hashes.
-When the current burned count is below `min_fuse_count`, Runtime burns two fuse
-bits, preserving parity, and reseals the DOT_BLOB with the effective key for the
-resulting state. An ODD result uses the new burned count; an EVEN result uses the
-new burned count plus one. When the threshold is already met, the command
-succeeds without another burn. Runtime requires enough remaining fuse bits to
-complete both burns.
+**Purpose:** Replace the CAK and LAK digests while advancing the fuse count by
+two and preserving parity when the command completes.
 
-### 5. GET_DOT_BACKUP_BLOB
-
-`MDBB` is generic-authorized. It is available only in ODD state. Runtime derives
-the current DOT effective key, validates the active blob version and HMAC, and
-returns the exact 168-byte blob. Corrupt, stale, or EVEN-state blobs are not
-returned.
-
-### 6. DOT_STATUS
-
-`MDST` is read-only and does not use generic authorization. It returns:
-
-```text
-enabled:u8 || locked:u8 || burned:u16_le
-```
-
-`locked` is the parity of the burned fuse count.
-
-### 7. DOT_RECOVERY
-
-`MDRC` accepts a 168-byte backup blob without a generic authorization trailer.
-Runtime requires ODD state and verifies the supplied blob with the current
-device-derived DOT key before writing and read-back verifying it. The HMAC is
-the command's native proof; an invalid backup cannot modify flash.
-
-### 8. DOT_OVERRIDE_CHALLENGE / DOT_OVERRIDE
-
-`DOTW` carries recovery ECC and ML-DSA public keys. Runtime hashes those keys
-using the Caliptra recovery-key convention and compares the result with the
-fused recovery-key hash before returning a fresh challenge.
-
-`DOTX` carries the same keys and hybrid signatures over that challenge. Runtime
-rechecks the fused key hash, verifies ECDSA P-384 and ML-DSA-87, burns one fuse
-bit, and writes an empty blob sealed for the new EVEN epoch. These commands do
-not use generic authorization. Restricting them to a ROM-signaled recovery
-Runtime is deferred to a future hardening change.
-
-The retained LAK hash keeps the post-burn blob well formed and matches firmware-manifest unlock semantics.
-
-### 4. DOT_ROTATE
-
-**Purpose:** Refresh the code authentication and lock authentication key hashes while advancing fuse state, maintaining the current parity (EVEN/ODD) to preserve the ownership state.
-
-**Use Case:** Enables periodic key rotation without losing device ownership or requiring an unlock-relock cycle. Allows updating CAK and LAK hashes to new keys while keeping the device in the same locked/unlocked state.
+**Use Case:** From Locked state, rotate the active CAK and LAK digests without
+an unlock-relock cycle. Because the command always requires a nonzero CAK, a
+rotation from Disabled state produces Locked state. The implementation also
+accepts rotation in EVEN state; the resulting CAK-bearing blob is treated by
+ROM as a pending lock on the next boot.
 
 **Preconditions:**
 - DOT_FUSE_ARRAY in either EVEN or ODD state
 - `min_fuse_count` value provided in command
 - Current burned count is below `min_fuse_count`
-- Nonzero CAK and LAK hashes provided
+- Nonzero CAK digest and LAK digest provided
 - Sufficient remaining fuse bits to complete the rotation
 
 **Flow:**
-1. BMC obtains `MACC` and issues an authorized `MDRT` request containing `min_fuse_count`, new CAK hash, and new LAK hash.
+1. BMC obtains `MACC` and issues an authorized `MDRT` request containing `min_fuse_count`, a new CAK digest, and a new LAK digest.
 2. MCU RT verifies generic command authorization.
 3. MCU RT checks if current burned count is below `min_fuse_count`:
    - If already met: Return success without burning (no-op on threshold)
@@ -773,15 +732,16 @@ The retained LAK hash keeps the post-burn blob well formed and matches firmware-
    - If current state is EVEN (n): Result is EVEN (n+2)
    - If current state is ODD (n): Result is ODD (n+2)
 5. MCU RT derives DOT_EFFECTIVE_KEY for the new epoch.
-6. MCU RT creates and HMAC-seals a new DOT_BLOB with the new CAK/LAK hashes.
+6. MCU RT creates and HMAC-seals a new DOT_BLOB with the new CAK and LAK digests.
 7. MCU RT writes and read-back verifies the DOT_BLOB.
 8. MCU RT returns success with `reset_required = 1`.
 9. **On the subsequent boot**:
-   - Device boots with the same parity (EVEN/ODD) as before
-   - Ownership state (uninitialized/locked/disabled) is unchanged
-   - New CAK/LAK hashes are active
+    - From ODD state, the device remains ODD and becomes Locked with the new CAK and LAK digests.
+    - From EVEN state, ROM authenticates the CAK-bearing blob and burns the next fuse as its implemented boot-time lock transition. The new CAK becomes active on the following boot.
 
-**Result:** Keys are rotated while maintaining device ownership state. Parity and ownership model are preserved.
+**Result:** The command advances the epoch by two. ODD-state rotation preserves
+parity and installs a Locked-state blob; EVEN-state rotation stages a subsequent
+lock.
 
 ### 5. GET_DOT_BACKUP_BLOB
 
@@ -839,8 +799,8 @@ status || DOT_BLOB[168]
 3. MCU RT determines state parity:
    - `locked = burned_count % 2` (0 = EVEN/Uninitialized, 1 = ODD/Locked or Disabled)
 4. MCU RT determines enabled status:
-   - `enabled = 1` if DOT is in Locked state (has valid CAK)
-   - `enabled = 0` if DOT is in Disabled or Uninitialized state
+    - `enabled = 1` when the `dot_initialized` fuse is set
+    - `enabled = 0` when DOT has not been initialized for the device
 5. MCU RT returns status fields to BMC.
 
 **Response Payload:**
@@ -849,16 +809,19 @@ enabled:u8 || locked:u8 || burned:u16_le
 ```
 
 Where:
-- `enabled`: 1 if CAK is installed and active, 0 otherwise
+- `enabled`: logical value of the `dot_initialized` fuse
 - `locked`: 1 if DOT_FUSE_ARRAY is in ODD state, 0 if in EVEN state
 - `burned`: Current burned fuse count (little-endian u16)
 
 **State Mapping:**
 | enabled | locked | State |
 |---------|--------|-------|
-| 0 | 0 | Uninitialized/Volatile |
-| 1 | 1 | Locked |
-| 0 | 1 | Disabled |
+| 0 | 0 | DOT not initialized |
+| 1 | 0 | Uninitialized (EVEN) |
+| 1 | 1 | ODD state (Locked or Disabled) |
+
+`DOT_STATUS` does not distinguish Locked from Disabled; that distinction
+depends on whether the authenticated DOT_BLOB contains a nonzero CAK digest.
 
 **Security Properties:**
 - Read-only operation
@@ -870,10 +833,13 @@ Where:
 
 **Purpose:** Restore a previously backed-up DOT_BLOB to storage when the on-device copy has been corrupted or lost.
 
-**Use Case:** Enables recovery from flash storage corruption. If the active DOT_BLOB becomes corrupted and the device boots into recovery mode, the owner can supply a previously backed-up blob obtained via GET_DOT_BACKUP_BLOB to restore valid ownership state.
+**Use Case:** While Runtime is executing, replace a damaged or stale active
+DOT_BLOB with a previously exported blob before the next boot. An ODD-state
+boot that already cannot authenticate its active blob is handled separately by
+the configured ROM locked-state recovery policy.
 
 **Preconditions:**
-- DOT_FUSE_ARRAY in ODD state (device must be in Locked or Disabled state, or in recovery mode)
+- DOT_FUSE_ARRAY in ODD state (Locked or Disabled)
 - Backup DOT_BLOB must have been obtained via GET_DOT_BACKUP_BLOB from the same epoch
 - Backup BLOB must be exactly 168 bytes
 
@@ -892,11 +858,11 @@ Where:
    - If HMAC validation fails: Return error (blob is invalid, no writes occur)
 5. If HMAC is valid, MCU RT writes the backup BLOB to storage.
 6. MCU RT performs read-back verification to ensure write succeeded.
-7. MCU RT returns success.
+7. MCU RT returns success with `reset_required = 1`.
 8. **On the subsequent boot**:
    - Device boots in ODD state
    - Restored DOT_BLOB is authenticated
-   - CAK/LAK are recovered from the restored blob
+    - The CAK and LAK digests are recovered from the restored blob
    - Device resumes normal operation in Locked or Disabled state
 
 **Request Payload:**
@@ -924,12 +890,13 @@ DOT_BLOB[168]
 **Security Model:**
 - Recovery authorization requires both ECC P-384 and ML-DSA-87 signatures (hybrid cryptography)
 - Recovery keys are provisioned in OTP as a public-key hash during manufacturing
-- Recovery operation is irreversible (forces transition to EVEN state)
-- Recovery resets all DOT state and ownership
+- The recovery fuse burn is irreversible and transitions the device to EVEN state
+- Recovery clears the DOT CAK and LAK while retaining the monotonic fuse history
 
 **DOT_OVERRIDE_CHALLENGE (DOTW) Flow:**
 
 **Preconditions:**
+- DOT_FUSE_ARRAY is in ODD state
 - DOT recovery key hash must be provisioned in OTP
 - No authorization trailer required
 
@@ -940,7 +907,7 @@ DOT_BLOB[168]
 2. MCU RT hashes both keys using Caliptra's recovery-key hash convention.
 3. MCU RT compares the combined hash with the fused recovery-key hash in OTP:
    - If hash does not match: Return error (invalid recovery keys)
-4. MCU RT generates a fresh challenge (random nonce/timestamp).
+4. MCU RT generates a fresh random challenge.
 5. MCU RT returns the challenge to BMC.
 
 **Response:**
@@ -953,7 +920,7 @@ challenge[48]
 **Preconditions:**
 - Must have previously issued DOTW and received valid challenge
 - DOT recovery key hash must match OTP
-- Can be issued in any DOT state (EVEN or ODD)
+- DOT_FUSE_ARRAY remains in the same ODD state used to issue the challenge
 
 **Flow:**
 1. BMC issues a native `DOTX` request containing:
@@ -967,22 +934,20 @@ challenge[48]
    - If signature invalid: Return error
 4. MCU RT verifies ML-DSA-87 signature:
    - If signature invalid: Return error
-5. MCU RT consumes the challenge (prevents reuse).
-6. MCU RT burns one fuse bit, advancing state by 1:
-   - If current state is EVEN (n): Result is ODD (n+1)
-   - If current state is ODD (n): Result is EVEN (n+1)
-7. MCU RT creates and HMAC-seals an empty-CAK blob for the new epoch.
-8. MCU RT writes and read-back verifies the blob.
+5. MCU RT burns one fuse bit, advancing state by 1:
+    - Current state is ODD (n); result is EVEN (n+1)
+6. MCU RT creates and HMAC-seals a blob with zero CAK and LAK digests for the new epoch.
+7. MCU RT writes and read-back verifies the blob.
+8. MCU RT consumes the challenge after the transition commits.
 9. MCU RT returns success with `reset_required = 1`.
 10. **On the subsequent boot**:
-    - Device boots with reversed parity
-    - If was EVEN (uninitialized): Now ODD (but with no CAK in blob)
-    - If was ODD (locked/disabled): Now EVEN (uninitialized)
+    - Device boots in EVEN state (uninitialized)
+    - DOT supplies no owner; ROM installs the fused owner PK hash when it is provisioned
     - Recovery operation is complete
 
 **Request Payload (DOTX):**
 ```
-recovery_ecc_key[48] || recovery_mldsa_key[2592] || ecc_sig[96] || mldsa_sig[4627]
+recovery_ecc_x[48] || recovery_ecc_y[48] || recovery_mldsa_key[2592] || ecc_sig_r[48] || ecc_sig_s[48] || mldsa_sig[4628]
 ```
 
 **Security Properties:**
@@ -991,11 +956,13 @@ recovery_ecc_key[48] || recovery_mldsa_key[2592] || ecc_sig[96] || mldsa_sig[462
 - Challenge prevents replay attacks
 - Single-use challenge prevents bypass via replay
 - Fuse burn is irreversible
-- Timestamps/nonces ensure freshness
+- The one-time random challenge ensures freshness
 - No generic authorization used (native recovery-key authentication only)
 
-**Limitations (Deferred):**
-Recovery-mode gating for `MDRC`, `DOTW`, and `DOTX` is deferred to a future hardening change. Currently, these commands are available in all runtime states. Future versions will restrict them to ROM-signaled recovery runtime to prevent their use during normal operation.
+**Runtime scope:** `MDRC`, `DOTW`, and `DOTX` are available whenever the DOT
+Runtime command service is running. They are not gated by a ROM recovery-mode
+signal; their command-specific cryptographic and fuse-state checks provide the
+authorization boundary.
 
 ---
 
@@ -1045,8 +1012,8 @@ alt LOCK / DISABLE (EVEN to ODD)
     MCU_Runtime -> Storage : Write and read-back verify DOT_BLOB
     MCU_Runtime -> DOT_FUSE_ARRAY : Burn and verify next fuse bit
 else UNLOCK (ODD to EVEN)
-    MCU_Runtime -> Caliptra_Core : Authenticate current LAK challenge response
-    MCU_Runtime -> Caliptra_Core : HMAC empty-CAK post-burn DOT_BLOB
+    MCU_Runtime -> Caliptra_Core : Authenticate current hybrid LAK challenge response against stored LAK digest
+    MCU_Runtime -> Caliptra_Core : HMAC post-burn DOT_BLOB with zero CAK digest
     MCU_Runtime -> Storage : Write and read-back verify DOT_BLOB
     MCU_Runtime -> DOT_FUSE_ARRAY : Burn and verify next fuse bit
 else ROTATE
@@ -1081,9 +1048,8 @@ point:
 - MCU ROM retains its I3C recovery and override path.
 
 Runtime recovery and override commands use the same direct-commit backend as
-the other Runtime commands. Restricting those commands to a ROM-signaled
-recovery Runtime is deferred; their cryptographic and state checks remain
-mandatory.
+the other Runtime commands. They are not gated by a ROM recovery-mode signal;
+their cryptographic and state checks remain mandatory.
 
 ---
 
@@ -1133,7 +1099,7 @@ Caliptra_MCU -> Caliptra_MCU : MCU boots up to RT
 
 group Uninitialized
     note across : DOT_FUSE_ARRAY is in EVEN state and no owner authentication is active
-    BMC -> Caliptra_MCU : Authorized DOT_LOCK with CAK and LAK hashes
+    BMC -> Caliptra_MCU : Authorized DOT_LOCK with CAK digest and LAK digest
     Caliptra_MCU -> Caliptra_Core : Verify generic command authorization
     Caliptra_MCU -> Caliptra_MCU : Creates new DOT_BLOB
     Caliptra_MCU -> Caliptra_Core : HMACs DOT_BLOB
@@ -1151,7 +1117,7 @@ end
 ```
 
 1. Device boots with DOT_FUSE_ARRAY in EVEN state and no owner authentication active.
-2. BMC obtains `MACC` and issues an authorized `DOT_LOCK` with CAK and LAK hashes.
+2. BMC obtains `MACC` and issues an authorized `DOT_LOCK` with a CAK digest and LAK digest.
 3. Runtime verifies generic command authorization and creates the DOT_BLOB.
 4. Runtime seals the blob with the `(n+1)` DOT effective key.
 5. Runtime writes and read-back verifies the blob.
@@ -1202,18 +1168,18 @@ participant DOT_FUSE_ARRAY
 
 Caliptra_MCU -> Caliptra_MCU : MCU boots to runtime
 group Locked
-    note across : DOT_FUSE_ARRAY is in ODD state and the authenticated DOT_BLOB supplies CAK and LAK
+    note across : DOT_FUSE_ARRAY is in ODD state and the authenticated DOT_BLOB supplies CAK and LAK digests
     BMC -> Caliptra_MCU : DOT_UNLOCK_CHALLENGE
     Caliptra_MCU -> BMC : Challenge
     BMC -> Caliptra_MCU : DOT_UNLOCK signed by LAK private keys
     Caliptra_MCU -> Caliptra_Core : Verify challenge and hybrid LAK signatures
-    Caliptra_MCU -> Storage : Write/read-back empty-CAK blob retaining LAK hash
+    Caliptra_MCU -> Storage : Write/read-back blob with zero CAK digest, retaining LAK digest
     Caliptra_MCU -> DOT_FUSE_ARRAY : Runtime burns and verifies next fuse bit
     Caliptra_MCU -> BMC : Success; reset required
 end
 
 group Uninitialized
-    note across : On the next boot, the EVEN state has no active CAK
+    note across : On the next boot, DOT supplies no CAK; ROM may install the fused owner fallback
 end
 
 @enduml
@@ -1222,114 +1188,37 @@ end
 1. Device is in Locked or Disabled state with an ODD fuse count.
 2. BMC issues DOT_UNLOCK_CHALLENGE
 3. MCU RT returns challenge
-4. BMC signs challenge with LAK.priv
-5. BMC issues DOT_UNLOCK command with signed challenge
-6. MCU RT verifies challenge and authenticates with LAK.pub
-7. Runtime seals and read-back verifies an empty-CAK blob for the post-burn epoch while retaining the authenticated LAK hash.
+4. BMC signs the challenge transcript with both LAK private keys.
+5. BMC issues `DOT_UNLOCK` with the LAK public keys and both signatures.
+6. MCU RT compares the supplied public-key digest with the stored LAK digest and verifies both signatures.
+7. Runtime seals and read-back verifies a blob with a zero CAK digest for the post-burn epoch while retaining the authenticated LAK digest.
 8. Runtime burns and verifies DOT_FUSE_ARRAY from ODD `(n)` to EVEN `(n+1)`.
 9. Runtime consumes the challenge and returns success with reset required.
-10. On the subsequent boot, no CAK is active.
+10. On the subsequent boot, DOT supplies no CAK; ROM installs the fused owner PK hash when it is provisioned.
 11. **Result:** The device is Uninitialized in the EVEN state.
 
 ---
 
 ## Recovery Mechanisms
 
-Failure scenario in
-[dot-1-init](#dot-1-init)
-
 <a id="dot-2-recovery"></a>
 
-```plantuml
-@startuml
+When ROM cannot authenticate the DOT_BLOB in ODD state, it does not continue
+the normal firmware boot. It invokes the locked-state recovery policy configured
+by the platform.
 
-title DOT Recovery Mode and FMC Flow Management
+| Implemented path | Entry point | Result |
+|---|---|---|
+| Reset-flow backup | `dot_recovery_reset_flow`, `DotRecoveryPolicy::BackupBlob`, and `dot_recovery_handler` | Restores and re-verifies the active blob, then continues the same cold boot. |
+| Ordered ROM handler chain | `dot_locked_recovery_handlers` when reset coordination is disabled | Tries each configured handler according to its retry policy; the first success triggers a warm reset. |
+| ROM I3C recovery service | `I3cDotLockedRecoveryHandler` with `I3cServicesModes::DOT_RECOVERY` in the ordered chain | Accepts status, blob recovery, and recovery-authority override operations while ROM owns the recovery flow. |
+| ROM MCI mailbox override | `OverrideChallengeRecoveryHandler` with `Mbox0RecoveryTransport` in the ordered chain | Performs the recovery-authority challenge and override flow. The reference emulator wires this path under its `test-dot-recovery` feature. |
+| Reset coordination | `dot_recovery_reset_flow` when local backup recovery does not succeed | Publishes the DOT failure status and halts so the BMC can select fused-owner recovery or regular DOT verification on the next cold boot. |
+| Runtime native commands | `MDRC`, `DOTW`, and `DOTX` | Available when Runtime is already executing; these commands enforce blob HMAC or recovery-key authentication but are not gated by a ROM recovery-mode signal. |
 
-skinparam maxMessageSize 250
-skinparam wrapWidth 700
-skinparam backgroundColor white
-skinparam NoteBackgroundColor #76b900
-skinparam NoteFontSize 14
-skinparam SequenceGroupBodyBackgroundColor #EEEEEE
-skinparam defaultFontName Open Sans
+The sections below describe the command-level recovery and override protocols.
 
-skinparam sequence {
-    ArrowColor #76b900
-    ActorBorderColor #76b900
-    LifeLineBorderColor #000000
-    LifeLineBackgroundColor #76b900
-    GroupHeaderFontsize 15
-    GroupHeaderFontColor #76b900
-    GroupFontSize 15
-    GroupFontColor #76b900
-    ArrowFontSize 15
-    ParticipantBorderColor #76b900
-    ParticipantBackgroundColor #76b900
-    ParticipantFontSize 18
-    ParticipantFontColor black
-    ArrowFontSize 14
-}
-
-participant BMC
-participant Caliptra_MCU
-participant Caliptra_Core
-participant DOT_FUSE_ARRAY
-participant Storage
-
-autonumber
-note across : This diagram follows the "DOT ROM Startup and DOT State Initialization" diagram in the failure case where DOT_BLOB is corrupted
-note across : There are two options for recovery: ROM faciliated or FMC facilitated (have to block regular boot) recovery/override
-alt FMC facilitaed recovery/override Flow
-    Caliptra_MCU -> Caliptra_Core : MCU ROM asks Core-ROM to run RI_DOWNLOAD_FIRMWARE to boot
-    Caliptra_MCU -> Caliptra_MCU : MCU ROM resets and jumps to RT
-    note across : a flag should be passed from MCU ROM to RT to indicate that this is a recovery/override flow so that RT will only accept recovery/override commands and not facilitate normal boot flow
-end
-note across : now assume we are either in ROM or FMC waiting for BMC to issue a recovery/override command
-BMC -> Caliptra_MCU : Check to confirm silicon is in DOT recovery/override mode
-alt BMC has recovery DOT_BLOB for recovery (DOT_RECOVERY)
-    BMC -> Caliptra_MCU : BMC issues DOT_RECOVERY command with DOT_BLOB
-    Caliptra_MCU -> Caliptra_Core : MCU asks Caliptra_Core to authenticate DOT_BLOB with DOT_EFFECTIVE_KEY
-    alt Authentication failed
-        Caliptra_MCU -> Caliptra_MCU: Error and abort sequence
-    end
-    Caliptra_MCU -> Storage : Store authenticated DOT_BLOB to flash
-else BMC does not have recovery DOT_BLOB for recovery (DOT_OVERRIDE)
-    BMC -> Caliptra_MCU : Issues DOT_UNLOCK_CHALLENGE
-    Caliptra_MCU -> BMC : MCU returns challenge
-    BMC -> Caliptra_MCU : BMC signs challenge and issues DOT_OVERRIDE command to force DOT_FUSE_ARRAY increase
-    Caliptra_MCU -> Caliptra_MCU : MCU verifies challenge matches
-    Caliptra_MCU -> Caliptra_Core : Authenticates DOT_OVERRIDE with DOT recovery private keys
-    alt Authentication failed
-        Caliptra_MCU -> Caliptra_MCU: Error and abort sequence
-    end
-    Caliptra_MCU -> DOT_FUSE_ARRAY : MCU burns DOT_FUSE_ARRAY from State (n) to (n+1)
-    note across : this is an ODD to EVEN transition only
-end
-Caliptra_MCU -> Caliptra_MCU : Requests subsystem reset
-note across : The request to reset can be self reset or waiting for BMC to reset
-
-@enduml
-```
-
-**Detection:**
-- Device in ODD state (should have valid DOT_BLOB)
-- DOT_BLOB read from storage
-- HMAC authentication fails
-
-**Recovery Flow:**
-1. MCU ROM detects corrupted DOT_BLOB during initialization
-2. MCU ROM boots MCU RT without CAK/LAK
-3. ROM may indicate DOT recovery mode to Runtime
-4. Recovery-only Runtime gating is deferred; current recovery commands enforce their native cryptographic and state checks
-5. BMC detects silicon in DOT recovery mode
-   - Via boot progress tracking
-   - Via error codes
-   - Via explicit notification
-6. MCU ROM/FMC conduct DOT recovery flow
-   - Option 1: Recovery (BMC or EC has backup DOT_BLOB)
-    - Option 2: Override (DOT recovery authority only)
-
-### Option 1: DOT_RECOVERY Command
+### DOT_RECOVERY Command
 
 <a id="dot-9-recovery-corrupted-blob"></a>
 
@@ -1368,9 +1257,9 @@ participant Caliptra_MCU
 participant Caliptra_Core
 
 group Locked
-    Caliptra_MCU -> Caliptra_MCU : MCU boots to ROM but DOT_BLOB is corrupted, ROM boots up to FMC or RT for DOT recovery
-    note across : DOT_FUSE_ARRAY is in ODD state, Ownership_Storage has no CAK, Device boot up with FMC without CAK in DOT recovery mode
-    note across : Either MCU notify BMC or BMC detects that the silicon is in DOT recovery mode. This is a silicon-specific function, examples can be BMC tracking boot progress/error codes of the silicon boot
+    Caliptra_MCU -> Caliptra_MCU : ROM detects an invalid DOT_BLOB and invokes configured locked-state recovery handlers
+    note across : DOT_FUSE_ARRAY is in ODD state and no owner digest is installed while the DOT_BLOB is invalid
+    note across : ROM retains control; normal firmware boot does not continue until recovery succeeds
     alt BMC / platform has a backup copy of DOT_BLOB
         BMC -> Caliptra_MCU : DOT_RECOVERY
         Caliptra_MCU -> Caliptra_Core : authenticate to ensure DOT_BLOB is valid
@@ -1392,10 +1281,14 @@ note across : DOT_RECOVERY will cause the system to go back to mutable lock stat
 @enduml
 ```
 
-**When:** BMC has a backup copy of the DOT_BLOB
+The restore operation is implemented by Runtime `MDRC`, the ROM I3C recovery
+service, and ROM backup-blob handlers. Each path invokes the same current-epoch
+HMAC validation before replacing the active blob.
+
+**When:** A current-epoch backup copy of the DOT_BLOB is available.
 
 **Flow:**
-1. BMC issues DOT_RECOVERY command with backup DOT_BLOB
+1. The recovery caller or configured handler supplies the backup DOT_BLOB.
 2. MCU authenticates DOT_BLOB with DOT_EFFECTIVE_KEY
    - If authentication fails: Return error and abort
 3. MCU writes authenticated DOT_BLOB to flash
@@ -1404,94 +1297,11 @@ note across : DOT_RECOVERY will cause the system to go back to mutable lock stat
 6. **Result:** Device returns to Locked state with recovered ownership
 
 **Requirements:**
-- BMC must maintain backup DOT_BLOB
+- A backup DOT_BLOB must be available
 - DOT_BLOB must match current DOT_FUSE_ARRAY state
 - Cannot recover if backup is also corrupted
 
-#### Challenge/Response Recovery via MCI Mailbox
-
-An example specific implementation of the DOT_RECOVERY method using the MCI mailbox is provided below.
-
-**When:** The platform provides an external recovery agent (e.g., BMC or host) that controls (or can ask for signatures) using the vendor ECDSA P-384 and MLDSA-87 private keys.
-
-The reference MCU ROM uses MCI mailbox 0 (`mcu_mbox0`) to perform a
-two-transaction challenge/response protocol with the external agent.
-The agent provides public keys and signs the challenge externally; the ROM
-verifies the signatures using Caliptra's `CM_ECDSA384_VERIFY` and
-`CM_MLDSA87_VERIFY` mailbox commands.
-
-**Protocol:**
-
-#### Transaction 1: DOT_RECOVERY_REQUEST
-
-Command Code: `0x444F_5451` ("DOTQ")
-
-*Table: `DOT_RECOVERY_REQUEST` input arguments*
-
-| **Name**        | **Type**     | **Description**                     |
-| --------------- | ------------ | ----------------------------------- |
-| chksum          | u32          | Checksum (Caliptra standard formula)|
-| ecc_pub_key_x   | u8[48]       | ECDSA P-384 public key X coordinate |
-| ecc_pub_key_y   | u8[48]       | ECDSA P-384 public key Y coordinate |
-| mldsa_pub_key   | u8[2592]     | MLDSA-87 public key                 |
-| cak             | u8[48]       | New Code Authentication Key hash    |
-| lak             | u8[48]       | New Lock Authentication Key hash    |
-
-*Table: `DOT_RECOVERY_REQUEST` output arguments*
-
-| **Name**        | **Type**     | **Description**                      |
-| --------------- | ------------ | ------------------------------------ |
-| challenge       | u8[48]       | Random 48-byte challenge for signing |
-
-The ROM computes SHA-384 of the concatenated public keys (ECC X ‖ ECC Y ‖ MLDSA)
-and verifies the hash against the vendor recovery PK hash stored in OTP fuses.
-If the hash matches, the ROM generates a random 48-byte challenge and returns it
-via `DataReady` status.
-
-#### Transaction 2: DOT_CHALLENGE_RESPONSE
-
-Command Code: `0x444F_5452` ("DOTR")
-
-*Table: `DOT_CHALLENGE_RESPONSE` input arguments*
-
-| **Name**        | **Type**     | **Description**                     |
-| --------------- | ------------ | ----------------------------------- |
-| chksum          | u32          | Checksum (Caliptra standard formula)|
-| ecc_sig_r       | u8[48]       | ECDSA P-384 signature R component   |
-| ecc_sig_s       | u8[48]       | ECDSA P-384 signature S component   |
-| mldsa_pub_key   | u8[2592]     | MLDSA-87 public key                 |
-| mldsa_signature | u8[4627]     | MLDSA-87 signature                  |
-| padding         | u8           | Padding for MLDSA signature         |
-
-The ECDSA signature is over `SHA-384(challenge)`. The MLDSA signature is
-over the raw challenge bytes.
-
-The ROM verifies both signatures over the challenge. The ROM
-intentionally does **not** set `CmdComplete` after reading this transaction
-so that the SRAM data remains valid during signature verification (the
-MLDSA pub key and signature are read directly from SRAM in zero-copy mode).
-
-**Flow:**
-1. ROM boots and detects DOT recovery mode (corrupted DOT_BLOB)
-2. ROM polls MCI mbox0 for `DOT_RECOVERY_REQUEST` command
-3. Agent writes pub keys + new DOT blob data → mbox0 SRAM
-4. ROM hashes pub keys and verifies against vendor recovery PK hash in OTP
-5. ROM generates random 48-byte challenge → responds via mbox0 `DataReady`
-6. Agent signs challenge with ECC and MLDSA private keys
-7. Agent writes signatures + MLDSA pub key → mbox0 as `DOT_CHALLENGE_RESPONSE`
-8. ROM verifies ECC signature via `CM_ECDSA384_VERIFY`
-9. ROM verifies MLDSA signature via `CM_MLDSA87_VERIFY`
-10. If both pass: ROM writes new DOT_BLOB and requests subsystem reset
-11. **Result:** Device returns to Locked state with new ownership keys
-
-**Requirements:**
-- External agent must hold vendor ECDSA P-384 and MLDSA-87 private keys
-- Vendor recovery PK hash must be burned in OTP fuses
-- MCI mbox0 must be accessible to the agent
-- Public key hash must match the OTP vendor recovery PK hash
-
-
-### Option 2: DOT_OVERRIDE Command
+### DOT_OVERRIDE Command
 
 **When:** BMC does not have backup DOT_BLOB (catastrophic recovery, RMA to vendor)
 
@@ -1507,7 +1317,7 @@ MLDSA pub key and signature are read directly from SRAM in zero-copy mode).
    - This is an ODD to EVEN transition only
 8. Request subsystem reset
 9. On next boot, device is in EVEN state (Uninitialized)
-10. **Result:** Device unlocked, but ownership lost (factory reset equivalent)
+10. **Result:** DOT is Uninitialized with no DOT-supplied owner; the fused owner fallback is unchanged.
 
 
 ### DOT Recovery PK Hash Format
@@ -1523,13 +1333,6 @@ way and stored in the same byte order, so an integrator can — if they
 choose — provision the same `(ECC P-384, MLDSA-87)` key pair as owner key,
 debug unlock key, and DOT recovery key and reuse one hashing pipeline
 to compute all three fuse values.
-
-> **Implementation status:** the reference MCU ROM currently hashes ECC
-> coordinates in standard SEC1 big-endian byte order and stores the
-> SHA-384 output byte-for-byte in OTP, which differs from the Caliptra
-> convention described below. The format documented here is the
-> **target/aligned** format; aligning the DOT code and integration test
-> with this format is tracked in a separate PR.
 
 #### Hash construction
 
@@ -1549,13 +1352,10 @@ Total input: **2688 bytes** (96 B ECC + 2592 B MLDSA). Output: **48 bytes**
 Byte order matches Caliptra's [Public key hash byte ordering](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#public-key-hash-byte-ordering-dword-reversal)
 exactly:
 
-- **ECC P-384 X/Y coordinates** are in **dword-reversed format**. Take the
-  48-byte standard SEC1 (big-endian) coordinate, group it into 12 four-byte
-  dwords, and reverse the bytes within each dword. Equivalently, this is
-  the in-memory layout of `[u32; 12]` where each `u32` is the standard
-  big-endian dword interpreted as a native (little-endian) `u32` word.
-  These dword-reversed bytes are what travels on the Caliptra mailbox wire
-  (and what `CM_SHA` / `CM_ECDSA384_VERIFY` consume).
+- **ECC P-384 X/Y coordinates** travel over the MCI and I3C recovery
+    protocols in standard SEC1 big-endian byte order. Before hashing, MCU ROM
+    groups each coordinate into 12 four-byte dwords and reverses the bytes
+    within each dword to match Caliptra's image public-key representation.
 - **MLDSA-87 public key** bytes are passed through as raw FIPS 204 bytes,
   with no dword reversal.
 - **SHA-384 output** in OTP is also **dword-reversed**: the 48-byte
@@ -1600,11 +1400,12 @@ Y (SEC1 / openssl output, 48 bytes):
   be14794d 27789964 7735fde8 328afd84 cd4d4aa8 72d40b42
 ```
 
-#### Step 2: Dword-reverse the ECC coordinates
+#### Step 2: Build the ECC hash input
 
-Group each 48-byte coordinate into 12 four-byte dwords and reverse the
-bytes within each dword. These are the bytes that get hashed (and the
-bytes the BMC sends on the mailbox wire for `DOT_OVERRIDE`):
+MCU ROM groups each 48-byte coordinate into 12 four-byte dwords and reverses
+the bytes within each dword before hashing. The BMC sends the Step 1 natural
+SEC1 bytes on the recovery protocol; these are the transformed bytes that ROM
+passes to SHA-384:
 
 ```text
 X (dword-reversed, hashed bytes), first 16 bytes:
@@ -1680,13 +1481,7 @@ otp_bytes = dword_reverse(digest)                  # 48 bytes to write to OTP
   hash that is burned at manufacture and to sign the `DOT_OVERRIDE`
   challenge response at recovery time. There is no separate "key index"
   field — the hash binds both keys together.
-- The reference fuse map allocates exactly one recovery PK hash. If
-    rotation of the DOT recovery key is required in the field, integrators
-  should add multiple `vendor_recovery_pk_hash_{0..N}` slots in a vendor
-  secret partition, plus a `vendor_recovery_pk_hash_valid` revocation
-  bitmask analogous to `CPTRA_CORE_VENDOR_PK_HASH_VALID`. ROM would then
-  pick the first valid slot using the same selection policy as the regular
-  vendor PK hash.
+- The reference fuse map and MCU ROM support one recovery PK hash.
 - A fuse value of all-zero bytes is treated as "not provisioned" by MCU ROM;
   in that case `DOT_OVERRIDE` is permanently disabled for the part.
 
@@ -1695,22 +1490,23 @@ otp_bytes = dword_reverse(digest)                  # 48 bytes to write to OTP
 ```
 Locked (ODD, n) + Corrupted BLOB
     ↓
-Recovery Mode
+ROM locked-state recovery
     ├─→ [DOT_RECOVERY with valid backup] → Locked (ODD, n) [restored]
-    └─→ [DOT_OVERRIDE with DOT recovery key] → Uninitialized (EVEN, n+1) [ownership lost]
+    └─→ [DOT_OVERRIDE with DOT recovery key] → Uninitialized (EVEN, n+1) [DOT CAK/LAK cleared]
 ```
 
 
-### DOT_OVERRIDE via MCI Mailbox (Reference Implementation)
+### DOT_OVERRIDE via MCI Mailbox (Emulator Test Integration)
 
-An example implementation of DOT_OVERRIDE using the MCI mailbox is provided below.
-This is for disaster recovery when no backup blob is available.
+The emulator ROM wires `Mbox0RecoveryTransport` into its locked-state handler
+chain when built with `test-dot-recovery`. This path exercises DOT_OVERRIDE over
+MCI mailbox 0 when no backup blob is available.
 
 **When:** Device is in Locked (ODD) state with a corrupted or missing DOT_BLOB. The BMC
 holds the DOT recovery private keys corresponding to the recovery key hash stored
 in OTP fuses.
 
-The reference MCU ROM uses MCI mailbox 0 (`mcu_mbox0`) to perform a
+This integration uses MCI mailbox 0 (`mcu_mbox0`) to perform a
 two-transaction challenge/response protocol with the BMC.
 The BMC provides the DOT recovery public keys (ECC P-384 + MLDSA-87) and signs
 the challenge with both corresponding private keys; ROM verifies the signatures using
@@ -1722,24 +1518,21 @@ Caliptra's `CM_ECDSA384_VERIFY` and `CM_MLDSA87_VERIFY` commands.
 
 Command Code: `0x444F_5457` ("DOTW")
 
-The `DOT_UNLOCK_CHALLENGE` command is a unified challenge request used for both
-owner unlock and vendor override. The `challenge_type` field indicates
-which operation is requested.
+The MCI recovery transport uses `DOT_UNLOCK_CHALLENGE` to begin vendor
+override. Its `challenge_type` field must request override.
 
 *Table: `DOT_UNLOCK_CHALLENGE` input arguments*
 
 | **Name**        | **Type**     | **Description**                              |
 | --------------- | ------------ | -------------------------------------------- |
 | chksum          | u32          | Checksum (Caliptra standard formula)         |
-| challenge_type  | u32          | `0x01` = UNLOCK (owner), `0x02` = OVERRIDE (vendor) |
+| challenge_type  | u32          | `0x02` = OVERRIDE; other values are rejected |
 | ecc_pub_key_x   | u8[48]       | Public key ECDSA P-384 X coordinate          |
 | ecc_pub_key_y   | u8[48]       | Public key ECDSA P-384 Y coordinate          |
 | mldsa_pub_key   | u8[2592]     | MLDSA-87 public key                          |
 
-For `challenge_type = OVERRIDE`, the public keys are the DOT recovery keys and
-are verified against the recovery key hash in OTP fuses.
-For `challenge_type = UNLOCK`, the public keys are the LAK and are
-verified against the LAK hash in the DOT_BLOB.
+The public keys are the DOT recovery keys and are verified against the recovery
+key hash in OTP fuses.
 
 *Table: `DOT_UNLOCK_CHALLENGE` output arguments*
 
@@ -1747,9 +1540,8 @@ verified against the LAK hash in the DOT_BLOB.
 | --------------- | ------------ | ------------------------------------ |
 | challenge       | u8[48]       | Random 48-byte challenge for signing |
 
-The ROM computes SHA-384 of the provided public keys (ECC X ‖ ECC Y ‖ MLDSA)
-and verifies the hash against the appropriate PK hash (OTP fuses for OVERRIDE,
-DOT_BLOB for UNLOCK).
+The ROM computes the Caliptra-format SHA-384 digest of the provided public keys
+and verifies it against the recovery PK hash in OTP fuses.
 If the hash matches, the ROM generates a random 48-byte challenge and
 returns it via `DataReady` status.
 
@@ -1767,8 +1559,7 @@ Command Code: `0x444F_5458` ("DOTX")
 | ecc_sig_r       | u8[48]       | ECDSA P-384 signature R component   |
 | ecc_sig_s       | u8[48]       | ECDSA P-384 signature S component   |
 | mldsa_pub_key   | u8[2592]     | MLDSA-87 public key                 |
-| mldsa_signature | u8[4627]     | MLDSA-87 signature                  |
-| padding         | u8           | Padding for MLDSA signature         |
+| mldsa_signature | u8[4628]     | Padded MLDSA-87 signature           |
 
 The ROM re-verifies the DOT recovery public-key hash (ECC + MLDSA) against the
 OTP fuses before verifying signatures. The ECDSA signature is over
@@ -1785,7 +1576,7 @@ OTP fuses before verifying signatures. The ECDSA signature is over
 8. ROM re-verifies the DOT recovery key hash against OTP fuses
 9. ROM verifies ECDSA signature via `CM_ECDSA384_VERIFY`
 10. ROM verifies MLDSA signature via `CM_MLDSA87_VERIFY`
-11. If both pass: ROM burns DOT fuse (n→n+1) and writes a new empty DOT_BLOB (no CAK/LAK) HMAC'd with the EVEN-state key
+11. If both pass: ROM burns DOT fuse (n→n+1) and writes a new DOT_BLOB with zero CAK and LAK digests, HMAC'd with the EVEN-state key
 12. ROM triggers warm reset
 13. **Result:** Device transitions to EVEN (Uninitialized) state with a valid DOT_BLOB
 
@@ -1798,110 +1589,13 @@ OTP fuses before verifying signatures. The ECDSA signature is over
 
 ---
 
-## Ownership RAM Recommendations
-
-`Ownership_Storage` (also referred to as *ownership RAM*) is an optional
-platform mechanism for retaining active CAK/LAK material across selected reset
-levels. It is not a transition journal in the reference implementation:
-interactive Runtime commands commit DOT_BLOB and OTP changes directly and do
-not post a desired fuse state for ROM or FMC.
-
-An integrator may also reserve boot-intent fields for a future ROM-signaled DOT
-recovery Runtime. Enforcement of that recovery-only mode is deferred in the
-reference Runtime.
-
-### Retention and Reset Domain
-
-When implemented, ownership RAM should sit in a reset domain that is **retained
-across selected MCU/subsystem resets but cleared when `powergood` drops (power
-cycle)**. Mapping this onto the MCU reset flows (selected by the MCI
-`RESET_REASON` register, see the [Reference ROM Specification](rom.md)):
-
-| Reset / event | `RESET_REASON` | Ownership RAM |
-|---|---|---|
-| Cold boot (first boot after power-good asserted / MCI reset) | none set | **Cleared / invalid** (must be re-derived from DOT_BLOB) |
-| Firmware Boot Reset | `FwBootUpdReset` | **Retained** |
-| Firmware Hitless Update | `FwHitlessUpdReset` | **Retained** |
-| Warm Reset (subsystem reset with `powergood` held) | `WarmReset` | **Retained** |
-| Power cycle / `powergood` de-assert | (next boot is cold) | **Cleared / scrubbed** |
-
-Recommendations:
-
-- Place ownership RAM in MCI sticky/FLOP storage (or equivalent SoC sticky
-  registers) that shares the retention domain of other reset-surviving MCI
-  state, so that warm and firmware resets preserve it while a power-good drop
-  clears it.
-- Retaining it across firmware and warm resets lets an integrator preserve
-    active ownership context without treating it as non-volatile state.
-- On any boot where the hardware cannot guarantee retention (e.g. a cold boot),
-  the contents must be treated as invalid and re-derived from the DOT_BLOB.
-
-### Sizing and Layout
-
-Size the region to hold the largest CAK/LAK material plus control and integrity
-fields. A recommended logical layout:
-
-| Field | Purpose | Writer |
-|---|---|---|
-| `magic` / `version` | Identifies a valid, correctly-versioned ownership RAM block | ROM |
-| `valid` flag | Set once ROM has populated the block this power cycle | ROM |
-| `locked` flag | Set once the block is sealed; further non-Caliptra writes are rejected | ROM |
-| `dot_boot_mode` | Optional normal vs. DOT recovery boot intent | ROM |
-| `CAK` | Current code authentication key in Locked state | ROM (from blob) |
-| `LAK` | Current lock authentication key | ROM (from blob) |
-| `integrity` (CRC/checksum) | Detects corruption of the block | last writer |
-
-Keep the layout fixed and versioned so that ROM and RT agree on the contents
-across firmware updates. Reserve space for future fields.
-
-### Access Control and Locking
-
-- **Ownership data must not be updatable once marked valid by a non-Caliptra
-    entity.** Once ROM seals the block, set the
-  `locked` flag and have the hardware/firmware reject further writes from
-  untrusted AXI users until the next power cycle. This prevents another agent
-  from substituting CAK/LAK after they have been committed.
-- Lock ownership RAM before handing control to less-trusted code or exposing
-  mailbox/interfaces to external entities (mirror the MCI configuration locking
-  performed around `SS_CONFIG_DONE_STICKY` / `SS_CONFIG_DONE` in the ROM).
-- Runtime DOT transitions must not depend on mutating ownership RAM; their
-    authoritative state is the read-back-verified DOT_BLOB and DOT_FUSE_ARRAY.
-
-### Integrity and Scrubbing
-
-- Protect the block with a `magic`/`version` and a CRC/checksum so consumers can
-  distinguish a validly retained block from uninitialized or corrupted RAM. If
-  the integrity check fails, treat the block as invalid and fall back to the
-  DOT_BLOB / fuse state on flash and OTP.
-- **Scrub secrets on power cycle and on transition completion.** CAK/LAK must be
-  zeroized when ownership is lost (power cycle, or `DOT_UNLOCK`/`DOT_OVERRIDE`
-  that drops to Uninitialized). Do not rely solely on the retention domain
-  clearing — explicitly invalidate the `valid` flag and zero secret fields when
-  a flow completes so stale keys are never re-used.
-
-### Using Ownership RAM Across Boot Stages
-
-The intended producer/consumer relationship is narrow:
-
-1. **ROM (boot):** In ODD state, authenticate the DOT_BLOB and optionally
-   publish its CAK/LAK as read-only active ownership context.
-2. **Runtime:** Consume active ownership context if the platform exposes it;
-   Runtime command transitions still validate and commit against flash and OTP.
-3. **ROM → Runtime recovery intent:** A future implementation may publish a
-   recovery-only boot mode. Until that gating is implemented, Runtime recovery
-   commands rely on their native cryptographic and state checks.
-
-On a cold boot or failed integrity check, discard ownership RAM and reconstruct
-authoritative ownership from `DOT_FUSE_ARRAY` and the authenticated DOT_BLOB.
-
----
-
 ## Security Considerations
 
 ### Security Properties
 
 1. **Silicon Binding**
-   - DOT_ROOT_KEY is unique per device, for Caliptra 2.0/2.1, it is up to the integrator to decide how to form this per-device unique key.
+   - The selected Caliptra stable identity root is device-derived. The reference
+    implementation uses the UDS-derived stable IDevID root by default.
    - DOT_BLOBs cannot be authenticated / used between devices of the same model
    - Each device requires its own unique DOT_BLOB
 
@@ -1917,20 +1611,19 @@ authoritative ownership from `DOT_FUSE_ARRAY` and the authenticated DOT_BLOB.
 
 4. **Authenticity**
     - DOT_LOCK, DOT_DISABLE, DOT_ROTATE, and GET_DOT_BACKUP_BLOB require generic command authorization
-   - DOT_UNLOCK requires LAK.priv signature
+    - DOT_UNLOCK requires both LAK signatures and public keys matching the stored LAK digest
     - DOT_RECOVERY requires a current-epoch DOT_BLOB HMAC
     - DOT_OVERRIDE requires recovery-key signatures anchored in fused PK hash
     - All commands that touch fuse state are cryptographically authenticated
 
 5. **Ownership Protection**
-   - Disabled state prevents unauthorized ownership takeover
-   - Owner maintains control via LAK even without CAK enforcement
-   - Uninitialized devices can be claimed by any party, Disabled devices cannot
+    - Generic authorization protects lock, disable, and rotate operations
+    - In Disabled state, the LAK holder can authorize unlock while DOT supplies no CAK
+    - In Uninitialized state, DOT supplies no owner; a lock or disable still requires generic authorization
 
 6. **Minimal Fuse Usage**
     - One bit per parity-changing transition; two bits per rotation
-   - Efficient use of limited fuse resources
-   - Supports many lock/unlock cycles
+    - The 256-bit reference counter supports at most 256 one-bit transitions
 
 ### Threat Model
 
@@ -1944,42 +1637,10 @@ authoritative ownership from `DOT_FUSE_ARRAY` and the authenticated DOT_BLOB.
 
 **Not Protected Against:**
 - Physical attacks on fuses (assumed secure)
-- Compromise of DOT_ROOT_KEY (silicon security boundary)
-- Compromise of LAK.priv (ownership credential)
+- Compromise of the selected Caliptra stable identity root (silicon security boundary)
+- Compromise of both LAK private keys (ownership credentials)
 - Compromise of the DOT recovery private keys
 - Side-channel attacks on cryptographic operations
-
-### Best Practices
-
-1. **LAK Management**
-   - Store LAK.priv securely (HSM, secure enclave)
-   - Control LAK.priv access carefully
-   - Consider key escrow for recovery scenarios
-   - Implement proper key rotation when re-locking
-
-2. **DOT_BLOB Backup**
-   - Maintain redundant backups of DOT_BLOB
-   - Store in multiple locations
-   - Verify backups periodically
-   - Secure backup storage (integrity and availability)
-
-3. **State Transition Management**
-   - Verify DOT_BLOB integrity before DOT_LOCK fuse burn
-   - Ensure storage is reliable
-   - Handle reset failures gracefully
-   - Monitor fuse budget (total available transitions)
-
-4. **Recovery Planning**
-   - Define recovery procedures between device and BMC or EC
-   - Test recovery scenarios
-    - Maintain secure access to the DOT recovery private keys
-   - Document override procedures
-
-5. **Operational Security**
-   - Audit DOT command invocations
-   - Monitor DOT state changes
-   - Alert on recovery mode entries
-   - Track fuse usage over time
 
 ### Fuse Budget Planning
 
@@ -1988,16 +1649,10 @@ LOCK, DISABLE, UNLOCK, and OVERRIDE consume one fuse bit. ROTATE consumes two:
 Uninitialized(0) → Locked(1) → Uninitialized(2) → Locked(3) → ...
 ```
 
-With N fuse bits:
-- Maximum N state transitions
-- Approximately N/2 lock/unlock cycles
-- Plan for expected device lifetime
-- Reserve bits for recovery scenarios
-
-Example with 128-bit fuse array:
-- 128 one-bit state transitions
-- ~64 lock/unlock cycles
-- More than sufficient for most use cases
+The 256-bit reference fuse array permits at most 256 one-bit transitions, or
+128 complete lock/unlock cycles when no bits are consumed by rotations or
+overrides. Each rotation consumes the same fuse budget as one complete
+lock/unlock cycle.
 
 ---
 
@@ -2009,23 +1664,25 @@ Example with 128-bit fuse array:
 |---------|------------------|----------------|-------------|---------|
 | DOT_LOCK | EVEN | Generic authorization | Yes (n→n+1) | Lock ownership to silicon |
 | DOT_DISABLE | EVEN | Generic authorization | Yes (n→n+1) | Disable DOT in locked state |
-| DOT_ROTATE | Threshold | Generic authorization | Yes (n→n+2) | Rotate key epoch while preserving parity |
+| DOT_ROTATE | DOT enabled; below threshold | Generic authorization | Yes (n→n+2) | Replace CAK/LAK digests while preserving parity |
 | GET_DOT_BACKUP_BLOB | ODD | Generic authorization + blob HMAC | No | Export authenticated backup |
 | DOT_UNLOCK_CHALLENGE | ODD | None | No | Request unlock challenge |
-| DOT_UNLOCK | ODD | LAK.priv | Yes (n→n+1) | Unlock ownership from silicon |
+| DOT_UNLOCK | ODD | Both LAK private-key signatures | Yes (n→n+1) | Unlock ownership from silicon |
 | DOT_STATUS | Any | None (read-only) | No | Query initialization, parity, and fuse count |
 | DOT_RECOVERY | ODD | DOT_BLOB HMAC | No | Restore corrupted DOT_BLOB |
 | DOT_OVERRIDE_CHALLENGE | ODD | Fused recovery-key hash | No | Start destructive override |
-| DOT_OVERRIDE | ODD | Fused recovery-key hybrid signatures | Yes (n→n+1) | Force unlock (destructive) |
+| DOT_OVERRIDE | ODD | Fused recovery-key hybrid signatures | Yes (n→n+1) | Clear DOT CAK/LAK and enter EVEN state |
 
 ### State Transition Table
 
 | From State | Command | To State | Fuse Change | Storage Change |
 |------------|---------|----------|-------------|----------------|
-| Volatile (EVEN) | Power Cycle | Uninitialized (EVEN) | No | None |
 | Unlocked (EVEN) | DOT_LOCK | Locked (ODD) | EVEN→ODD | Create DOT_BLOB |
 | Unlocked (EVEN) | DOT_DISABLE | Disabled (ODD) | EVEN→ODD | Create DOT_BLOB (no CAK) |
-| Locked (ODD) | DOT_UNLOCK | Uninitialized (EVEN) | ODD→EVEN | Seal empty-CAK blob retaining LAK hash |
+| Locked (ODD) | DOT_UNLOCK | Uninitialized (EVEN) | ODD→EVEN | Seal blob with zero CAK digest, retaining LAK digest |
+| Locked (ODD) | DOT_ROTATE | Locked (ODD) | n→n+2 | Replace DOT_BLOB with new CAK and LAK digests |
+| Disabled (ODD) | DOT_ROTATE | Locked (ODD) | n→n+2 | Replace DOT_BLOB with nonzero CAK and LAK digests |
+| Uninitialized (EVEN) | DOT_ROTATE | Pending lock | n→n+2, then n→n+3 on boot | Write CAK-bearing blob; ROM performs its blob-driven lock transition |
 | Locked (ODD) | Corrupted BLOB | Recovery (ODD) | No | None |
 | Recovery (ODD) | DOT_RECOVERY | Locked (ODD) | No | Restore DOT_BLOB |
 | Recovery (ODD) | DOT_OVERRIDE | Uninitialized (EVEN) | ODD→EVEN | Seal empty DOT_BLOB |

--- a/docs/src/firmware_format.md
+++ b/docs/src/firmware_format.md
@@ -1,9 +1,8 @@
 # MCU Firmware Format
 
-This document describes optional headers that may be prepended to the MCU
-runtime firmware image. These headers sit **in front of** the firmware's
-reset vector in MCU SRAM and give the ROM a way to act on instructions
-carried by the firmware image itself.
+This document describes optional headers placed after the platform's fixed MCU
+image header and before the runtime firmware reset vector in MCU SRAM. They give
+ROM a way to act on instructions carried by the authenticated firmware image.
 
 All headers described here are **optional**. A firmware image that does
 not include any of them still boots normally; the ROM detects each header
@@ -11,35 +10,30 @@ by its magic value and silently skips any header that is absent.
 
 ## Purpose
 
-The ROM is the trusted component of the MCU. The MCU runtime firmware is
-authenticated against the code-signing keys (via the Caliptra
-SoC manifest) before the ROM jumps to it, which means any bytes that the
-ROM consumes from the start of the firmware image inherit the same
-authorization guarantees as the firmware itself.
+Caliptra authenticates the MCU runtime firmware against the SoC manifest before
+loading it into MCU SRAM. Any optional header prepended to that image is covered
+by the same authenticated image digest.
 
 An integrator may desire that some operations — burning fuses, advancing
 ownership state, and similar one-way platform changes — are performed
 by immutable code. 
 
-Firmware headers give the runtime an **easy, signed, idempotent path** to
-ask the ROM to perform a well-defined set of privileged operations on
-its behalf. The model is:
+Firmware headers provide an authenticated, idempotent path for ROM to perform a
+well-defined set of operations before entering Runtime. The model is:
 
-* The firmware image author (the signer who holds the owner code-signing
-  key) decides which operations need to happen on the next boot.
+* The entity authorized to produce the MCU image decides which operations need
+  to happen on the next boot.
 * Those operations are encoded as a fixed-format header and prepended to
-  the firmware image before signing.
-* The ROM authenticates the whole image as usual, then — before jumping
-  to the firmware — inspects the header, executes the requested
-  operations, and advances the firmware entry offset past the header.
-* Every command is idempotent: if the requested state change has
-  already been applied on a previous boot, the command is a no-op. This
-  makes it safe to leave the header in place across resets and hitless
-  updates.
+  the firmware image before the SoC manifest digest is generated.
+* After Caliptra authenticates and loads the image, ROM inspects the header,
+  executes the requested operations, and advances the firmware entry offset
+  past the header before jumping to Runtime.
+* Each command uses fuse parity or `min_fuse_count` to avoid repeating a
+  completed transition when the same header is processed on a later boot.
+  Interrupted write/burn sequences have the failure behavior described below.
 
-This keeps the set of operations the ROM will perform small, auditable,
-and explicitly authorized, while avoiding the need to implement
-privileged paths in the runtime firmware.
+This keeps the ROM-owned operation set small and auditable while providing an
+authenticated alternative to the Runtime management-command paths.
 
 ## Image Layout
 
@@ -48,11 +42,11 @@ of the MCU image, in front of the firmware's reset vector:
 
 ```
 +-----------------------------------------+ <- MCU_MEMORY_MAP.sram_offset
-| Optional header #1 (e.g. DOT manifest)  |
+| Platform MCU image header               |
++-----------------------------------------+ <- + mcu_image_header_size
+| Firmware manifest DOT section (optional)|
 +-----------------------------------------+
-| Optional header #2 (future)             |
-+-----------------------------------------+
-| ...                                     |
+| MCU Component SVN Manifest (optional)   |
 +-----------------------------------------+
 | MCU runtime firmware (reset vector, ...)|
 +-----------------------------------------+
@@ -74,8 +68,9 @@ older ROMs.
 
 Header processing is gated both at compile time (by a ROM Cargo
 feature) and at runtime (by a field in `RomParameters`), so integrators
-opt in explicitly per platform. A ROM built without the feature pays no
-code-size cost and ignores any such header.
+opt in explicitly per platform. A header-bearing image must be paired with ROM
+support for that header; otherwise ROM does not consume the header or advance
+the firmware entry offset past it.
 
 ## Firmware Manifest DOT Section
 
@@ -105,14 +100,15 @@ offset  size  field          description
 ------  ----  -------------  -------------------------------------------------
  0x00     4   magic          FW_MANIFEST_DOT_MAGIC = 0x444F_5443 (u32).
                               On disk (little-endian): 43 54 4F 44 ("CTOD").
- 0x04     4   checksum       ones-complement of the u32 sum of bytes[8..end]
+ 0x04     4   checksum       ones-complement of the wrapping sum of
+                              little-endian u32 words in bytes[8..end]
  0x08     4   version        format version (must be 1)
  0x0C     4   num_commands   number of valid entries in `commands` (<= 8)
  0x10     4   min_fuse_count ROTATE idempotency threshold (ignored otherwise)
  0x14     8   commands       up to 8 command bytes, executed in order
- 0x1C    48   cak            Code Authentication Key for LOCK/ROTATE (12x u32)
- 0x4C    48   lak            Lock Authentication Key for LOCK/DISABLE (12x u32)
- 0x7C     4   _reserved      must be zero
+ 0x1C    48   cak_digest     SHA-384 digest of the CAK for LOCK/ROTATE (12x u32)
+ 0x4C    48   lak_digest     SHA-384 digest of the LAK public-key set (12x u32)
+ 0x7C     4   _reserved      reserved; included in checksum but not interpreted
 ```
 
 The `checksum` is a ones-complement over every byte after the magic and
@@ -130,14 +126,26 @@ so the header is safe to leave in place across reboots.
 | Value | Name     | Meaning                                                                                 |
 |-------|----------|-----------------------------------------------------------------------------------------|
 | `0`   | NOP      | Padding / no-op.                                                                        |
-| `1`   | LOCK     | Transition from unlocked (EVEN) to locked (ODD), using `cak` and `lak`.                 |
-| `2`   | UNLOCK   | Transition from locked (ODD) to unlocked (EVEN).                                        |
+| `1`   | LOCK     | Transition from unlocked (EVEN) to locked (ODD), using `cak_digest` and `lak_digest`.   |
+| `2`   | UNLOCK   | Transition from ODD to EVEN and write a zero-CAK blob using the section's `lak_digest`. |
 | `3`   | ROTATE   | Burn two DOT fuses to advance the effective key while preserving lock/unlock parity. Idempotency is controlled by `min_fuse_count`: rotation is applied only when the currently burned count is below this threshold. |
-| `4`   | DISABLE  | Ensure the device is in ODD (locked/disabled) state. Equivalent at the fuse level to LOCK, but the associated DOT blob contains no CAK. |
+| `4`   | DISABLE  | Ensure the device is in ODD (locked/disabled) state. Equivalent at the fuse level to LOCK, but the associated DOT blob contains a zero CAK digest. |
 
 Unknown command values cause the ROM to fail the firmware boot with
 `ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR`. Version mismatches are treated
 the same way.
+
+A section containing both LOCK/DISABLE and UNLOCK is rejected before any
+command executes. If `dot_initialized` is clear, the first non-NOP command ends
+section processing without an error or state change. The manifest path writes
+the `cak_digest` and `lak_digest` values as supplied; unlike the corresponding
+Runtime commands, it does not reject zero digests. A zero CAK produces no
+DOT-supplied owner, and a zero LAK prevents the normal LAK unlock flow.
+
+The authenticated MCU image authorizes these directives. Manifest UNLOCK does
+not inspect the current DOT_BLOB's LAK digest or run the Runtime `MDUC`/`MDUL`
+challenge-and-signature protocol; it stores the section's `lak_digest` in the
+post-transition blob.
 
 ### ROM Processing
 
@@ -147,9 +155,9 @@ The header is consumed by the ROM as part of the Firmware Boot Flow
 1. During cold boot, firmware in MCU SRAM is always decrypted by the
    time the Firmware Boot Flow runs, so the ROM can read the header
    in place.
-2. The ROM looks for `FW_MANIFEST_DOT_MAGIC` at `sram_offset`. If the
-   magic is absent, no DOT header processing is done and the firmware
-   entry offset is unchanged.
+2. The ROM looks for `FW_MANIFEST_DOT_MAGIC` at
+  `sram_offset + mcu_image_header_size`. If the magic is absent, no DOT
+  header processing is done and the firmware entry offset is unchanged.
 3. If the magic is present, the ROM verifies the checksum and version,
    then executes the commands in order against the live DOT fuse/blob
    state.
@@ -158,11 +166,10 @@ The header is consumed by the ROM as part of the Firmware Boot Flow
 5. Any error in header validation or command execution is fatal and
    halts the boot.
 
-During the **Hitless Firmware Update Flow**, the ROM performs the same
-manifest detection and command execution as during cold boot — a new
-firmware image delivered via hitless update may carry a different DOT
-header, and its owner-signed commands are applied on this boot rather
-than deferred to the next cold reset.
+During the **Hitless Firmware Update Flow**, ROM performs the same manifest
+detection and command execution as during the firmware-boot path. A new image
+delivered by hitless update can therefore apply its authenticated DOT directives
+on that boot.
 
 ### DOT Blob Updates and Power-Loss Behavior
 
@@ -171,14 +178,16 @@ DOT blob on flash, otherwise the next boot will see fuse state that
 does not match the sealed blob and the part will be unbootable via the
 DOT path. The exact sequence the ROM uses per command is:
 
-* **LOCK / DISABLE** (EVEN → ODD): the ROM first re-seals the DOT blob
-  with the new CAK/LAK (LOCK) or zero CAK + new LAK (DISABLE) against
-  the *current* fuse-derived effective key, writes it to DOT flash,
+* **LOCK / DISABLE** (EVEN → ODD): the ROM first seals the DOT blob
+  with the new CAK digest and LAK digest (LOCK), or a zero CAK digest and
+  new LAK digest (DISABLE), with the target ODD epoch key derived from
+  the current EVEN state, writes it to DOT flash,
   and only then burns the lock fuse. If power is lost between the
   blob write and the fuse burn, the fuses still report "unlocked" on
   the next boot and the command is re-attempted idempotently.
 * **UNLOCK** (ODD → EVEN): the ROM pre-computes the *post-burn* fuse
-  state, seals a new unlock blob against that future effective key,
+  state, seals a zero-CAK blob containing the section's `lak_digest` against
+  that future effective key,
   writes it to DOT flash, and then burns the unlock fuse. If power is
   lost between the blob write and the fuse burn, the already-written
   blob is sealed against a key that the device cannot yet derive, so
@@ -186,44 +195,17 @@ DOT path. The exact sequence the ROM uses per command is:
   must recover via a DOT recovery handler (see [DOT](./dot.md)).
 * **ROTATE**: the ROM burns both rotation fuses first and only then
   re-seals the DOT blob against the rotated effective key. If power
-  is lost after the first fuse burn but before the blob is re-sealed,
-  the next boot will again see a stale blob that no longer matches
-  the current fuse-derived key and must recover via a DOT recovery
-  handler.
+  is lost after a fuse burn but before the blob is re-sealed, the next
+  boot can see a stale blob that no longer matches the current
+  fuse-derived key.
 * **NOP**: nothing is written.
 
-In all cases, the DOT blob is written **before** the irreversible fuse
-burn whenever possible, so that the most common failure window leaves
-the device in the pre-command state. The remaining windows — between
-individual fuse burns inside ROTATE, and between the pre-computed
-UNLOCK blob and its fuse burn — cannot be closed by code alone: once
-fuses are partially burned there is no way to roll back. A power
-interruption in those windows may leave the device in a state that
-requires a DOT recovery flow on the next boot, and in the worst case
-may leave the part unbootable via DOT until such a recovery succeeds.
+The remaining failure windows are between the pre-computed UNLOCK blob write
+and its fuse burn, between the individual ROTATE fuse burns, and between the
+completed ROTATE fuse burns and its blob write. A reset in one of these windows
+can leave a blob that does not authenticate at the current epoch. Current ROM
+invokes the configured locked-state recovery policy for an ODD-state mismatch;
+an EVEN-state mismatch is a fatal DOT boot error.
 
-This risk is inherent to mixing single-shot fuse burns with flash
-updates. It can be reduced — though not fully eliminated — by
-platform-level mitigations outside the scope of this format, for
-example:
-
-* Maintaining redundant backup copies of both the *current* and *next*
-  DOT blob in flash, so that a partially-updated primary copy can
-  always be reconciled against a known-good backup.
-* Using more sophisticated sequence locks backed by fuses (e.g., a
-  small monotonic counter burned in a defined order) so that the ROM
-  can unambiguously determine which step of a multi-step transition
-  was in progress when power was lost, and either roll it forward or
-  fall back to a backup blob.
-
-Integrators who need stronger power-loss guarantees should layer such
-mechanisms on top of the firmware manifest DOT section; the format
-itself intentionally keeps the ROM-side logic minimal.
-
-## Future Headers
-
-Additional headers of the same shape — magic, version, checksum,
-payload — can be added in the same image area (before the firmware
-reset vector). Each new header will define its own magic and be
-independently detected and skipped by the ROM, subject to its own
-compile-time and runtime opt-in gates.
+See [DOT Recovery Mechanisms](./dot.md#recovery-mechanisms) for the implemented
+ROM and Runtime recovery paths.

--- a/docs/src/fuse_api_cmd.md
+++ b/docs/src/fuse_api_cmd.md
@@ -26,24 +26,12 @@ Write fuse values.
 Command Code: `0x4946_5057` ("IFPW")
 
 *Table: `MC_FUSE_WRITE` input arguments*
-<<<<<<< HEAD
-| **Name**   | **Type**       | **Description**               |
-| ---------- | -------------- | ----------------------------- |
-| chksum     |  u32           |                               |
-| partition  |  u32           | Partition number to write to  |
-| entry      |  u32           | Entry to write                |
-| start bit  |  u32           | Starting bit to write to (least significant bit in entry is 0). |
-| length     | u32            | in bits                       |
-| data       | u8[...]        | length/8
-=======
 | **Name**   | **Type**       | **Description**                       |
 | ---------- | -------------- | ------------------------------------- |
 | chksum     |  u32           |                                       |
 | word_addr  |  u32           | Entry to write (word offset)          |
 | data       |  u32           | Word to write                         |
 | mask       |  u32           | Bit-Mask to only write specified bits |
-
->>>>>>> 56fcd2fa ([mcu-mbox] fuse read write lock commands (#1380))
 
 
 *Table: `MC_FUSE_WRITE` output arguments*
@@ -56,7 +44,7 @@ Command Code: `0x4946_5057` ("IFPW")
 Caveats:
 * This command is **idempotent**, so that identical writes will have no effect.
 * Will fail if any of the existing data is 1 but is set to 0 in the input data.
-* Bits masked with `mask` will be ignored
+* Bits cleared in `mask` are ignored
 * Writes to buffered partitions will not take effect until the next reset.
 
 ### MC_FUSE_LOCK_PARTITION

--- a/docs/src/fuses.md
+++ b/docs/src/fuses.md
@@ -6,7 +6,9 @@ The hardware has provisioned the OTP controller with an overall structure that h
 
 As part of the Fuse API, we support defining the vendor-specific fuses and assist in provisioning the Caliptra- and vendor-specific fuses.
 
-In general, the Fuse API gives the SoC an easy way to read and write fuses with bit granularity via MCTP or mailbox commands.
+The Runtime fuse API provides authorized MCU mailbox operations for reading and
+writing OTP and transport-neutral commands for supported provisioning and lock
+operations.
 
 ## Fuse Defining
 
@@ -17,7 +19,7 @@ There are two places where we expand on the standard [OTP memory map](https://gi
 1. Defining how many bits are backed by actual fuses in each field
 2. Defining vendor-specific fields
 
-For an example of (1), the `CPTRA_SS_OWNER_ECC_REVOCATION` is specified as 1 byte (8 bits) in the memory map, but the may only have 4 bits backed by actual fuses in hardware. Our additional fuse map contains a section to define how many bits are available in each field as this information is vendor-specific and hence not present in the standard memory map.
+For an example of (1), the `CPTRA_SS_OWNER_ECC_REVOCATION` is specified as 1 byte (8 bits) in the memory map, but may have only 4 bits backed by actual fuses in hardware. The additional fuse map defines how many bits are available in each field because this information is vendor-specific and is not present in the standard memory map.
 
 For (2), there are two defined partitions, `VENDOR_SECRET_PROD_PARTITION` (520 bits) and `VENDOR_NON_SECRET_PROD_PARTITION` (984 bits) in the standard memory map. In addition, the vendor can choose to provide additional fuses. We provide a way to split these up into specific areas and automatically generate Rust code to manage them.
 
@@ -38,8 +40,6 @@ Here is an example fuse definition file, for example, `vendor_fuses.hjson`:
   non_secret_vendor: [
     {"example_key_revocation": 1}
   ],
-  // TBD how we allow additional fuses outside of these areas, if this is allowed by OTP
-  other_fuses: {},
   // entries to define how many bits are in each field, and potentially other information
   fields: [
     // set specifics on Subsystem fuses
@@ -54,20 +54,25 @@ Here is an example fuse definition file, for example, `vendor_fuses.hjson`:
 
 By default, all bits in each field are assumed to be backed by actual fuse bits unless they have an entry in the `fields` array.
 
-## Fuse definition script
+## Fuse definition generation
 
-We will provide a script, `cargo xtask fuse-autogen`, that can be used to process an `.hjson` file into:
+The implemented generator runs as:
 
-* Firmware definitions and code for the fuses and bits (Rust)
-* Documentation on the fuses and bits (Markdown)
+```shell
+cargo xtask registers-autogen --fuses-hjson <path> --otp-mmap-hjson <path>
+```
 
-The command will use either a `--platform` flag to indicate the file is `platforms/{platform}/fuse_bits.hjson` or a `--file` to specify the file manually.
+Both path options are optional and default to `hw/fuses.hjson` and the
+Caliptra subsystem OTP memory map. The command generates:
 
-This script can optionally generate extra commands for programming specific fuses as well as Rust and C code to access them.
+* Rust fuse definitions in the selected generated-register output
+* The corresponding `fuse_map.md`
 
 ## Fuse Provisioning Commands
 
-The fuse provisioning commands can be used over our [generic command](#mc_fuse_read) interface through MCTP, mailboxes, etc., or through commands in firmware manifest (except read operations).
+MCU Runtime implements generic fuse read, write, and partition-lock operations
+through the MCI mailbox. Supported provisioning and lock operations are also
+exposed through the common SPDM VDM command interface.
 
 The commands are:
 
@@ -77,17 +82,13 @@ The commands are:
 
 ### Authorization
 
-Only authorized SoC users shall call these commands. This can be authorized through the mechanism itself (i.e., a mailbox that only a trusted SoC component has access to) or cryptographically.
+The reference Runtime routes these operations through its generic authorized
+command handler. The requester first obtains a one-use `MACC` challenge and
+then supplies the configured ECC P-384 and ML-DSA-87 public keys plus hybrid
+signatures over the command payload and challenge. See
+[Authorization-Gated Subcommand Wrapper](./caliptra_common_commands.md#authorization-gated-subcommand-wrapper).
 
-Some example cryptographic mechanisms that could be used:
-
-* A certificate provided to MCU during boot, which will be used to validate signatures on each message.
-* An HMAC key imported into Caliptra's cryptographic mailbox during boot, which MCU can use to validate a request. (The key could itself be stored as fuses.)
-* Asymmetric verification public keys imported or accessed during boot, which MCU can use to validate a challenge-response signature on each request. (The public keys or hashes could themselves be stored in fuses or embedded in the firmware directly.)
-
-It will be integrator-defined which authorization mechanism is required, but we provide reference implementations with stubs for source-based and asymmetric signature-based authorization.
-
-These commands reference partition, fuse, and bit numbers that must use the same numbers generated from the [Fuse definition script](#fuse-definition-script).
+These commands reference partition, fuse, and bit numbers that must use the same numbers generated by [Fuse definition generation](#fuse-definition-generation).
 
 ### Limitations
 
@@ -103,55 +104,20 @@ These commands reference partition, fuse, and bit numbers that must use the same
 
 ### Field Entropy Provisioning
 
-Field entropy fuses can only be burned by Caliptra runtime, so the flow for provisioning them is different and any changes in them will **invalidate any OCP Device Ownership Transfer blob** stored on the device. See the [MCU OCP DOT implementation spec](dot.md).
+Field entropy can only be programmed by Caliptra. MCU Runtime exposes the
+authorized `MC_FE_PROG` (`MCFP`) command, which accepts one partition index and
+forwards Caliptra's `FE_PROG` mailbox command. MCU ROM can also program the
+partitions selected by `RomParameters::program_field_entropy` during cold boot;
+that path records `Started` and `Finished` state in `FIELD_ENTROPY_STATE` and
+rejects partial or zeroized slots.
 
-This will be an MCU mailbox API command (or other signal to MCU runtime) to trigger that MCU should use the Caliptra mailbox PROGRAM_FIELD_ENTROPY command. If a mailbox command is used, it must be authorized in the same way as other fuse programming API commands (see [authorization](#Authorization))
-
-If OCP DOT is being used, then the MCU ROM must also update the DOT blob after Caliptra core burns field entropy. **Failure to do so may "brick" a device or require a DOT recovery flow, as the ownership information could be corrupted after provisioning field entropy if the DOT root key is derived from the LDevID CDI.**
-
-The flow will be:
-1. MCU runtime receives a MCU_PROGRAM_FIELD_ENTROPY command through a mailbox or other signal.
-2. If DOT is enabled and the DOT root key is derived from LDevID, we need to store the DOT blob (and re-sign it after FE is updated):
-	1. MCU runtime stores the current DOT blob in non-volatile storage, e.g., SRAM that won't be cleared on reset
-	2. MCU runtime verifies this DOT blob using the current DOT root key.
-	3. MCU runtime indicates that the DOT blob must be checked and re-derived by setting a register or other signal in non-volatile storage, for example, a generic output wire or SRAM.
-	4. Sign the DOT blob copy with a new special DOT root key **derived from IDevID**.
-3. MCU runtime sends to Caliptra's runtime mailbox the PROGRAM_FIELD_ENTROPY command.
-4. MCU runtime waits for a successful response.
-5. MCU runtime initiates a reset.
-6. If DOT is enabled and the DOT root key is derived from LDevID
-	1. MCU ROM checks if we are in a FE programming mode (i.e., from register, input wires, or SRAM contents)
-	2. MCU derives both special DOT root key (from IDevID) and the normal DOT root key (from LDevID)
-	3. MCU ROM verifies the DOT blob copy in non-volatile storage against the special **IDevID** DOT root key.
-	4. MCU ROM copies the DOT blob copy into the standard DOT blob location
-	5. MCU ROM asks Caliptra core signs the DOT blob with the current DOT root key.
-	6. Continue with the normal boot flow
-
-```mermaid
-sequenceDiagram
-  Participant SoC
-
-  Note over MCU,Caliptra: Runtime
-  SoC->>MCU: MCU_PROGRAM_FIELD_ENTROPY
-
-  alt DOT enabled and LDevID DOT key used
-  MCU->>Caliptra: Derive special DOT key
-  MCU->>Caliptra: HMAC DOT blob with special DOT key
-  end
-
-  MCU->>Caliptra: PROGRAM_FIELD_ENTROPY
-  Caliptra->>OTP: (Burn)
-  Caliptra->>MCU: Done
-  MCU->>SoC: Reset subsystem
-
-  Note over MCU,Caliptra: ROM
-  alt DOT enabled and LDevID DOT key used
-  MCU->>Caliptra: Derive DOT normal and special key
-  MCU->>Caliptra: HMAC DOT blob with special key
-  MCU->>MCU: verify HMAC
-  MCU->>Caliptra: HMAC DOT blob with normal key
-  end
-```
+The reference DOT configuration derives its effective key from the stable
+IDevID root, so Field Entropy programming does not invalidate the DOT_BLOB.
+`RomParameters::dot_stable_key_type` can select LDevID for ROM paths, but the
+reference Runtime always derives DOT keys from IDevID and no implementation
+re-HMACs an existing DOT_BLOB when Field Entropy changes. The LDevID override is
+therefore not compatible with the reference Runtime DOT commands or an existing
+IDevID-sealed blob without corresponding platform code changes.
 
 ## Fuse Layout Options
 

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -16,18 +16,22 @@ choices that must be made by an integrator.
 
 ### DOT mode and storage planning
 
-DOT can be deployed in two broad modes:
+The reference implementation supports mutable-locking DOT:
 
 | Mode | Persistent ownership | Fuse use | Required platform storage |
 |---|---|---|---|
-| Volatile DOT | No. Ownership is lost on power cycle. | None beyond optional DOT enablement. | Ownership storage that is retained across the reset level needed by the DOT flow. |
-| Mutable locking DOT | Yes. Ownership is sealed to the device across power cycles. | `dot_fuse_array` bits consumed by lock/unlock/disable/override and rotation transitions. | DOT blob flash storage plus ownership storage handoff between ROM and runtime. |
+| Mutable locking DOT | Yes. Ownership is sealed to the device across power cycles. | `dot_fuse_array` bits consumed by lock/unlock/disable/override and rotation transitions. | Non-volatile DOT blob storage. |
 
 If mutable locking DOT is enabled, the platform must provide non-volatile DOT
 blob storage through `RomParameters::dot_flash`. The DOT blob is not secret, but
 it must be available and authenticated on every ODD-state boot. If the blob is
 missing, erased, corrupt, or HMAC-invalid while the part is in ODD state, ROM
 enters the configured locked-state recovery path or reports a fatal DOT error.
+
+The reference ROM and Runtime DOT paths both derive blob keys from stable
+IDevID. ROM's `dot_stable_key_type` parameter can select another root for
+ROM-only paths, but the reference Runtime remains on IDevID and there is no blob
+migration when the root changes.
 
 Integrators should treat the DOT blob flash layout as a platform-owned recovery
 asset. Keep enough space for the active blob and any backup blob policy your
@@ -53,8 +57,7 @@ transition (ODD → EVEN). Therefore:
 
 | Logical fuse bits | Lock/unlock cycles | Notes |
 |:---------:|:------------------:|-------|
-| 64        | 32                 | Recommended minimum. |
-| 256       | 128                | Default in the reference `hw/fuses.hjson`. |
+| 256       | 128                | Size used by the reference fuse map and MCU implementation. |
 
 The right size depends on how many ownership transfers the part is expected to
 undergo in its lifetime. There is no way to reclaim burned fuse bits — once the
@@ -64,9 +67,7 @@ service events such as unlock, override, and key-rotation flows rather than
 sizing only for the happy-path number of ownership transfers.
 
 The reference implementation burns the next sequential bit and reports a fatal
-DOT error if no bit remains. Platforms that need stronger wear budgeting or
-product-specific lifetime policy should size the field accordingly or provide a
-custom DOT state policy in their platform integration.
+DOT error if no bit remains.
 
 ### DOT blob and transition power-loss policy
 
@@ -74,18 +75,18 @@ The DOT fuse and DOT blob must advance together. A state transition that burns a
 fuse without leaving a matching HMAC-sealed blob can strand the device in a
 state that requires recovery on the next boot.
 
-The ROM-owned firmware manifest DOT section provides an owner-signed,
-idempotent way to request DOT state changes during boot. It is the preferred
-path for field-driven DOT lock, unlock, rotate, and disable operations when the
-platform wants immutable ROM code to perform the fuse burn. See
+The ROM-owned firmware manifest DOT section provides an authenticated,
+idempotent way to request DOT state changes during boot. Its directives are
+covered by the MCU image digest authenticated through the SoC manifest. See
 [Firmware Manifest DOT Section](./firmware_format.md#firmware-manifest-dot-section)
 for the exact header format and power-loss windows.
 
-For platforms that expose runtime DOT commands directly, the runtime must follow
-the same ordering rules: write the DOT blob expected by the post-transition fuse
-state, verify it can be recovered if power is lost, and only then ask ROM or the
-trusted fuse-burning path to advance the fuse. Maintaining redundant active and
-backup DOT blobs is strongly recommended for mutable locking deployments.
+For platforms that expose runtime DOT commands directly, Runtime performs the
+DOT blob and fuse writes itself. It must follow the command-specific ordering:
+write and read-back verify the target blob before the one-bit LOCK, DISABLE, or
+UNLOCK burn; ROTATE burns two bits before sealing the rotated-epoch blob.
+Maintaining redundant active and backup DOT blobs is strongly recommended for
+mutable-locking deployments.
 
 ### Vendor recovery PK hash
 
@@ -114,31 +115,31 @@ policy is compiled into `RomParameters::dot_locked_recovery_handlers`:
 
 | Recovery option | Required platform support | Result |
 |---|---|---|
-| Backup blob recovery | A recovery handler that can read a backup DOT blob sealed for the current fuse count. | Restores the DOT blob and resets without changing DOT fuse state. |
+| Reset-flow backup recovery | `dot_recovery_reset_flow`, `DotRecoveryPolicy::BackupBlob`, and `dot_recovery_handler`. | Restores and re-verifies the active blob, then continues the same cold boot without changing DOT fuse state. |
+| Ordered backup recovery | A `BackupBlobRecoveryHandler` entry in `dot_locked_recovery_handlers`. | Restores the active blob; the handler manager then requests a warm reset. |
 | I3C DOT recovery services | `I3cServicesModes::DOT_RECOVERY` plus an external recovery agent over I3C. | Allows `DOT_STATUS`, `DOT_RECOVERY`, and `DOT_OVERRIDE` commands over ROM I3C services. |
 | DOT recovery reset coordination | `RomParameters::dot_recovery_reset_flow` plus BMC policy for the next boot. | On locked DOT failure, ROM publishes `DEVICE_STATUS_0 = 0x0094_000E` before fatal error. On the subsequent cold boot, BMC writes `DEVICE_RESET.RESET_CTRL = 0x10` to force the fused owner hash, or `0x11` to continue regular DOT verification. |
 
 Integrators may configure more than one locked-state recovery handler; ROM tries
 the configured handlers in order and stops at the first one that succeeds. The
-I3C service path is a ROM recovery protocol and is separate from runtime
-management paths. Runtime-originated recovery or field-management workflows
-should be described by transport: in-band through a SoC-side MCI mailbox agent,
-or out-of-band through SPDM VDM over MCTP/I3C. All DOT I3C service commands are
-available only when the platform explicitly enables the corresponding ROM
-service mode.
+ordered handler chain runs only when `dot_recovery_reset_flow` is disabled; the
+reset-coordination path instead attempts its singular backup handler and then
+reports failure to the BMC. The I3C service path is a ROM recovery protocol and
+is separate from Runtime's in-band MCI mailbox and out-of-band SPDM VDM command
+paths. DOT I3C service commands are available only when the platform enables
+the corresponding ROM service mode.
 
 ### Fuse storage cost summary
 
 | Fuse field | Partition | Size | Encoding | Notes |
 |---|---|:---:|---|---|
-| `dot_initialized` | `VENDOR_NON_SECRET_PROD_PARTITION` | 1 bit (3 bytes with 3x OR duplication) | `LinearOr` | Gates the DOT flow. |
-| `dot_fuse_array` | `VENDOR_TEST_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Must be in a non-ECC partition. Scales linearly with desired lock/unlock cycles. |
+| `dot_initialized` | `VENDOR_NON_SECRET_PROD_PARTITION` | 1 logical bit encoded in 3 raw bits | `LinearOr` | Gates the DOT flow. |
+| `dot_fuse_array` | `VENDOR_TEST_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Must be in a non-ECC partition. |
 | `vendor_recovery_pk_hash` | `VENDOR_NON_SECRET_PROD_PARTITION` | 384 bits (48 bytes) | `Single` | Optional. For `DOT_OVERRIDE` catastrophic recovery. |
 
-If OTP space is constrained, the `dot_fuse_array` can be made smaller — the
-minimum useful size is 2 bits, but this only allows a single lock/unlock cycle
-with no margin. If redundant bit-count encoding (`OneHotLinearOr`) is used,
-multiply the raw bit count by the duplication factor (e.g., 3×).
+The reference MCU implementation reads the full 256-bit `dot_fuse_array` and
+uses 256 as its transition limit; changing that size requires corresponding
+implementation changes.
 
 ### Non-ECC Partition Requirement for Incremental Counters
 
@@ -257,7 +258,7 @@ When adding storage for MCU-owned SVN fuses, integrators should:
 5. Validate update and power-loss behavior: ROM intentionally performs the SVN
     Anti-Rollback flow's anti-rollback and range checks before burning any SVN
     fuse, but the platform must still ensure OTP write, digest, and
-    partition-lock policy are compatible with the planned field workflow.
+    partition-lock policy are compatible with the field workflow below.
 
 ### Field update workflow
 

--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -12,10 +12,11 @@ It can also handle any other custom SoC-specific initialization that needs to ha
 
 ## Boot Flows
 
-There are three main boot flows that needs to execute for its role in the Caliptra subsystem:
+There are four main boot flows for its role in the Caliptra subsystem:
 
 * Cold Boot Flow
-* Firmware Update Flow
+* Firmware Boot Flow
+* Hitless Firmware Update Flow
 * Warm Reset Flow
 
 These are selected based on the MCI `RESET_REASON` register that is set by hardware whenver the MCU is reset.
@@ -41,7 +42,6 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
     * [`FUSE_ECC_REVOCATION`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_ecc_revocation): Vendor ECC key revocation (4 bits)
     * [`FUSE_LMS_REVOCATION`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_lms_revocation): Vendor LMS key revocation (32 bits)
     * [`FUSE_MLDSA_REVOCATION`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_mldsa_revocation): Vendor MLDSA key revocation (4 bits)
-    * [`CPTRA_OWNER_PK_HASH`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.CPTRA_OWNER_PK_HASH): Owner public key hash (384 bits, written only if non-zero, could be overridden by [device ownership transfer](dot.md))
     * [`FUSE_SOC_STEPPING_ID`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_soc_stepping_id): SoC stepping ID (16 bits)
     * [`FUSE_ANTI_ROLLBACK_DISABLE`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_anti_rollback_disable): Anti-rollback disable (1 bit)
     * [`FUSE_IDEVID_CERT_ATTR`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.fuse_idevid_cert_attr): IDevID certificate attributes (768 bits)
@@ -50,7 +50,7 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
     * [`SS_STRAP_GENERIC[0]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_STRAP_GENERIC): OTP DAI idle bit offset (bits\[31:16\]) and OTP status register offset (bits\[15:0\]). The status-register offset is the OTP controller status-register byte offset that Caliptra ROM polls for DAI idle during UDS/FE programming; it is hard-coded in MCU ROM (not provisioned via a fuse) from the integrator's OTP map. See [caliptra-sw#3723](https://github.com/chipsalliance/caliptra-sw/pull/3723).
     * [`SS_STRAP_GENERIC[1]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_STRAP_GENERIC): OTP direct access command register offset
     * [`SS_STRAP_GENERIC[2]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_STRAP_GENERIC): iTRNG health test window size from OTP (bits\[15:0\]) and bypass mode flag (bit\[31\], from ROM parameters)
-    * [`SS_STRAP_GENERIC[3]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_STRAP_GENERIC): Owner manifest min SVN (bits\[7:0\], from the `CPTRA_CORE_OWNER_MANIFEST_MIN_SVN` OTP fuse — upcoming Caliptra requirement). Today bit\[0\] and bit\[1\] of this register are also consumed as platform hardware straps (PK-hash skip-lock and PK-hash rotation, respectively). **Upcoming:** the two PK-hash strap bits will move from `SS_STRAP_GENERIC[3]` to MCI generic input wires (`mci_reg_generic_input_wires[*]`), freeing `SS_STRAP_GENERIC[3]` bits\[7:0\] for the owner manifest min SVN value. The exact MCI input-wire bit assignments will be defined when the change lands; until then the bit layout of `SS_STRAP_GENERIC[3]` is in flux.
+    * [`SS_STRAP_GENERIC[3]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_STRAP_GENERIC): Bit\[0\] is set when the MCU ROM is built with `stable-owner-key`, enabling Caliptra's stable owner key.
     * [`CPTRA_I_TRNG_ENTROPY_CONFIG_0`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.CPTRA_I_TRNG_ENTROPY_CONFIG_0): iTRNG entropy configuration word 0, from OTP `cptra_itrng_entropy_config_0`
     * [`CPTRA_I_TRNG_ENTROPY_CONFIG_1`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.CPTRA_I_TRNG_ENTROPY_CONFIG_1): iTRNG entropy configuration word 1, from OTP `cptra_itrng_entropy_config_1`
     * [MCI] [`PROD_DEBUG_UNLOCK_PK_HASH_REG`](https://chipsalliance.github.io/caliptra-ss/main/regs/?p=soc.mci_top.mci_reg.PROD_DEBUG_UNLOCK_PK_HASH_REG%5B0%5D%5B0%5D) Production debug unlock public key hashes (384 bytes total for 8 key hashes)
@@ -64,19 +64,17 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
 1. Set `SS_CONFIG_DONE_STICKY`, `SS_CONFIG_DONE` registers to lock MCI configuration.
 1. Verify PK hashes and MCU mailbox AXI users after locking (see [Security Configuration](#security-configuration) below).
 1. Poll on Caliptra `FLOW_STATUS` registers for Caliptra to deassert the Ready for Fuses state.
-1. **Determine owner public key hash.** The ROM determines which owner public key hash to write to Caliptra's [`CPTRA_OWNER_PK_HASH`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.CPTRA_OWNER_PK_HASH) register. The source depends on whether [Device Ownership Transfer (DOT)](./dot.md) is configured and the current DOT state:
+1. **Determine and install the owner public key hash.** After Caliptra completes fuse initialization, the MCU ROM selects the owner public key hash and sends it through Caliptra's `INSTALL_OWNER_PK_HASH` mailbox command. The source depends on whether [Device Ownership Transfer (DOT)](./dot.md) is configured and the current DOT state:
     1. **DOT configured and DOT blob present**: The ROM runs the full DOT flow — derives the `DOT_EFFECTIVE_KEY`, verifies the DOT blob's HMAC, and determines the owner from the blob's state:
-        * **Locked state (ODD, blob has CAK)**: The Code Authentication Key (CAK) from the DOT blob is used as the owner PK hash.
-        * **Disabled state (ODD, no CAK)**: The DOT blob is authentic but contains no CAK. The ROM falls back to reading `CPTRA_SS_OWNER_PK_HASH` from OTP fuses.
-        * **EVEN state (Uninitialized/Volatile)**: DOT does not provide a persistent owner. The ROM falls back to reading `CPTRA_SS_OWNER_PK_HASH` from OTP fuses.
+        * **Locked state (ODD, blob has a CAK digest)**: The CAK digest from the DOT blob is installed as the owner PK hash.
+        * **Disabled state (ODD, zero CAK digest)**: The DOT blob is authentic but does not provide an owner. The ROM falls back to reading `CPTRA_SS_OWNER_PK_HASH` from OTP fuses.
+        * **EVEN state (Uninitialized)**: DOT does not provide an owner. The ROM falls back to reading `CPTRA_SS_OWNER_PK_HASH` from OTP fuses.
     1. **DOT blob empty or corrupt in Locked (ODD) state**: The ROM attempts DOT recovery (challenge/response or backup blob, depending on the platform's recovery policy). If recovery fails, this is a fatal error.
     1. **DOT not configured**: The ROM skips DOT entirely and reads the owner PK hash from `CPTRA_SS_OWNER_PK_HASH` in OTP.
 
-    In summary, `CPTRA_SS_OWNER_PK_HASH` in OTP serves as a **fallback** whenever DOT does not provide an owner. When DOT is in the Locked state, the CAK from the DOT blob **supersedes** the fuse value.
+    In summary, `CPTRA_SS_OWNER_PK_HASH` in OTP serves as a **fallback** whenever DOT does not provide an owner. When DOT is in the Locked state, the CAK digest from the DOT blob **supersedes** the fuse value.
 
     > **Note:** Revocation or rotation of the `CPTRA_SS_OWNER_PK_HASH` fuse value is outside the scope of DOT. DOT provides its own key lifecycle (install, lock, unlock, disable) through the DOT blob and fuse array. If an integrator needs to revoke or rotate the fuse-based owner key independently, that must be managed through a separate platform-specific mechanism.
-
-    > **Ownership RAM (optional, not yet implemented):** When DOT is configured, the ROM can use the DOT *ownership RAM* (`Ownership_Storage`) — a volatile, reset-surviving sticky region — to carry the CAK/LAK extracted from the DOT blob into the runtime, to receive a pending fuse-state transition request from the runtime, and to signal a DOT recovery/transition boot (so the runtime accepts only DOT recovery/override commands instead of running the normal boot flow). This region must be retained across MCU/warm/firmware resets but cleared on a power cycle. Using ownership RAM is optional — flash or other sticky registers may be used instead — and these flows are **not currently supported** in the reference ROM/runtime code, the emulator, or the FPGA integration. See [Ownership RAM Recommendations](dot.md#ownership-ram-recommendations) for sizing, layout, retention, locking, and usage guidance.
 
 1. Send the `RI_DOWNLOAD_FIRMWARE` command to Caliptra to start the firmware loading process. Caliptra will:
    1. Follow all of the [steps](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#firmware-processor-stage) in the Caliptra ROM documentation for firmware loading in the ROM cold reset.
@@ -91,7 +89,7 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
       1. MCU issues the `ACTIVATE_FIRMWARE` command to Caliptra (with the `INITIAL_ACTIVATE` flag) to publish `FW_EXEC_CTRL[2]` without triggering the hitless update reset sequence.
    1. Caliptra sets the MCI [`FW_EXEC_CTRL[2]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_GENERIC_FW_EXEC_CTRL%5B0%5D) bit to indicate that MCU firmware is ready
 1. Wait for Caliptra to indicate MCU firmware is ready by polling the firmware ready status.
-1. Stash the MCU ROM and other security-sensitive measurements to Caliptra. (In 2.1 subsystem mode, this should happen after Caliptra runtime is available using CM_SHA_{INIT,UPDATE,FINAL}. In 2.0 or 2.1 core mode, this could potentially happen earlier using the CM_SHA ROM command.)
+1. Stash the MCU ROM and other security-sensitive measurements after Caliptra Runtime is available, using `CM_SHA_{INIT,UPDATE,FINAL}`.
 1. MCU ROM triggers a reset by writing `0x1` to the MCI `RESET_REQUEST` register. This generates a hardware reset of the MCU core while maintaining power. The MCI hardware automatically sets `RESET_REASON` to `FirmwareBootReset`, causing the MCU to restart and enter the Firmware Boot Reset flow, which will jump to the loaded firmware.
 
 ```mermaid
@@ -143,9 +141,10 @@ This flow is used to boot the MCU into the MCU Runtime Firmware following either
 1. Check the MCI `RESET_REASON` register for MCU status (it should be in firmware boot reset mode `FirmwareBootReset`).
 1. Set flow checkpoint to indicate firmware boot flow has started.
 1. Compute the firmware entry offset starting from the MCU image header size.
-1. If the DOT manifests are enabled and `fw_manifest_dot_enabled` is set, look for a firmware-manifest DOT section at the start of MCU SRAM. If found (identified by its magic value):
-    1. Advance the firmware entry offset past the DOT manifest section.
-    1. Process the DOT commands contained in the manifest section (see [DOT documentation](./dot.md)). A fatal error is raised if DOT processing fails.
+1. Process enabled optional firmware headers in fixed order, starting after the MCU image header:
+    1. If `fw-manifest-dot` is built and `fw_manifest_dot_enabled` is set, process a present firmware-manifest DOT section and advance the entry offset. A validation or command error is fatal.
+    1. If `svn-manifest` is built and `svn_manifest_enabled` is set, process a present MCU Component SVN Manifest and advance the entry offset. A validation or anti-rollback error is fatal.
+    1. See [MCU Firmware Format](./firmware_format.md) and [SVN](./svn.md) for the implemented formats.
 1. Validate that firmware is present by checking that the first word at the computed firmware entry point (`sram_offset + firmware_offset`) is non-zero. A fatal error (`ROM_FW_BOOT_INVALID_FIRMWARE`) is raised otherwise.
 1. Set flow milestone to indicate firmware boot flow completion.
 1. Jump directly to runtime firmware at the computed SRAM entry point.
@@ -154,9 +153,9 @@ This flow is used to boot the MCU into the MCU Runtime Firmware following either
 sequenceDiagram
     note right of mcu: check reset reason (FirmwareBootReset)
     note right of mcu: set flow checkpoint
-    alt DOT manifests enabled and DOT section present
-        note right of mcu: advance entry offset past DOT section
-        note right of mcu: process firmware-manifest DOT commands
+    alt enabled optional headers are present
+        note right of mcu: process DOT section, then SVN section
+        note right of mcu: advance entry offset past each present section
     end
     note right of mcu: validate firmware at entry point
     alt firmware valid
@@ -175,7 +174,7 @@ Hitless Update Flow is triggered when MCU runtime FW requests an update of the M
 1. Check the MCI `RESET_REASON` register for reset status (it should be `FirmwareHitlessUpdate`).
 1. Release the Caliptra mailbox by completing the response to the original `ACTIVATE_FIRMWARE` command. This is required because the mailbox is still held by the command that triggered this reset. A fatal error (`ROM_FW_HITLESS_UPDATE_CLEAR_MB_ERROR`) is raised if the mailbox cannot be released.
 1. Wait for Caliptra to indicate that MCU firmware is ready in SRAM (i.e., Caliptra has finished copying the new image).
-1. Compute the firmware entry offset starting from the MCU image header size. If the DOT manifests feature is enabled and `fw_manifest_dot_enabled` is set, and a DOT firmware manifest section is present at the start of SRAM (identified by its magic value), advance the entry offset past that section. Note that unlike the Firmware Boot Flow, the hitless update flow does **not** re-process the DOT manifest commands — it only skips past the section so that the entry point lands on the firmware reset vector.
+1. Starting after the MCU image header, process the enabled optional firmware headers in the same fixed DOT-then-SVN order as the Firmware Boot Flow. Each present header advances the entry offset, and processing errors are fatal.
 1. Jump directly to runtime firmware at the computed SRAM entry point.
 
 ```mermaid
@@ -185,8 +184,9 @@ sequenceDiagram
     loop wait for firmware ready
         mcu->>caliptra: check fw_ready status
     end
-    alt DOT manifest enabled and DOT section present
-        note right of mcu: advance entry offset past DOT section
+    alt enabled optional headers are present
+        note right of mcu: process DOT section, then SVN section
+        note right of mcu: advance entry offset past each present section
     end
     note right of mcu: jump to runtime firmware
 ```
@@ -260,7 +260,7 @@ On any fatal or non-fatal failure, MCU ROM can use the MCI registers `FW_ERROR_F
 
 In addition, SoC-specific failure handling may occur.
 
-There will also be a watchdog timer running to ensure that the MCU is reset if not the ROM flow is not progressing properly.
+The ROM configures watchdog timers so a stalled boot flow causes an MCU reset.
 
 ## Security Configuration
 


### PR DESCRIPTION
## Summary

- remove stale Ownership RAM, Volatile DOT, speculative recovery, and future-design material
- align DOT boot, Runtime, firmware-manifest, recovery, fuse, and owner-fallback behavior with the current MCU implementation
- correct command wire layouts, firmware-header processing, platform integration guidance, and fuse tooling documentation
- resolve stale conflict markers in the included fuse command documentation

## Validation

- `mdbook build docs`
- `git diff --check`
- local Markdown file and anchor validation
- VS Code diagnostics for all changed documentation files