### PR TITLE
emulator/lc_ctrl: reload lifecycle state from OTP on update reset

### DIFF
--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -334,6 +334,14 @@ impl caliptra_mcu_emulator_registers_generated::lc::LcPeripheral for LcCtrl {
         self.reload_from_otp();
     }
 
+    fn update_reset(&mut self) {
+        // UpdateReset is the action the MCI schedules for warm resets.
+        // Reload lifecycle state from OTP so the new committed state
+        // (e.g. SCRAP after a MANUF→SCRAP transition) is visible to
+        // firmware on the next boot.
+        self.reload_from_otp();
+    }
+
     fn read_status(&mut self) -> ReadWriteRegister<u32, lc_ctrl::bits::Status::Register> {
         ReadWriteRegister::new(self.status.reg.get())
     }


### PR DESCRIPTION
### Problem

`LcCtrl` implements `warm_reset` by reloading its lifecycle state from OTP:

```rust
fn warm_reset(&mut self) {
    self.reload_from_otp();
}
```

but it has no `update_reset` implementation, so it falls through to the default
no-op. `UpdateReset` is the action the MCI schedules for warm resets, which
means a lifecycle state that was committed to OTP just before the reset is not
picked up: after the reset the controller keeps serving the *pre-transition*
state, and firmware reads a stale `LC_STATE`.

This is observable for any transition that is committed and then followed by a
reset — e.g. `MANUF` -> `SCRAP`, where firmware expects to boot into `SCRAP`
but still sees `MANUF`.

### Fix

Implement `update_reset` the same way as `warm_reset`. Both are reset entry
points into the same controller and both need the OTP-backed state re-read.

### Validation

- `cargo check -p caliptra-mcu-emulator-periph`
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt --check`

Extracted from a larger downstream commit; the unrelated DCCM-clearing half of
that commit is intentionally **not** included here, as it encodes SoC-specific
reset semantics rather than generic emulator behaviour.
