### PR TITLE
emulator/otp: truncate the fuse JSON file after rewinding

### DIFF
--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -416,7 +416,9 @@ impl Otp {
         let state = self.get_state();
         if let Some(file) = &mut self.file {
             file.rewind()?;
-            serde_json::to_writer(file, &state)?;
+            serde_json::to_writer(&mut *file, &state)?;
+            let pos = file.stream_position()?; // Get current position
+            file.set_len(pos)?; // Truncate to actual content size
         }
         Ok(())
     }


### PR DESCRIPTION
### Problem

`Otp::save_to_file` rewinds the backing fuse file and re-serializes the OTP
state, but never truncates it:

```rust
file.rewind()?;
serde_json::to_writer(file, &state)?;
```

If the new serialization is shorter than what was previously on disk, the
leftover tail bytes of the old content survive past the closing brace. The
resulting file is not valid JSON and fails to parse the next time the emulator
loads the fuse file.

This is reachable whenever a state transition shrinks the serialized form —
for example when a partition's populated content becomes shorter, or when the
fuse file is inherited from a run with a larger state.

### Fix

Reborrow the file so it stays usable after the write, then truncate to the
current stream position:

```rust
serde_json::to_writer(&mut *file, &state)?;
let pos = file.stream_position()?;
file.set_len(pos)?;
```

### Validation

- `cargo check -p caliptra-mcu-emulator-periph`
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt --check`
