### PR TITLE
emulator/i3c: avoid cloning the whole recovery image on every FIFO read

### DIFF
--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -873,13 +873,19 @@ impl I3cPeripheral for I3c {
         }
 
         let address: usize = address.try_into().unwrap();
-        let range = address..(address + 4);
-        let data = &self.indirect_fifo_data.clone()[range];
+        // Read the 4-byte word directly from the FIFO backing store. Avoid
+        // cloning the entire (up to ~200 KB) image Vec on every word read,
+        // which was O(image_size) per access and O(image_size^2) overall.
+        let word = u32::from_le_bytes(
+            self.indirect_fifo_data[address..address + 4]
+                .try_into()
+                .unwrap(),
+        );
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2
             .reg
             .set(read_index + 1);
 
-        u32::from_le_bytes(data.try_into().unwrap())
+        word
     }
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(


### PR DESCRIPTION
### Problem

`read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data` cloned the entire
`indirect_fifo_data` `Vec` on **every** 4-byte FIFO read:

```rust
let range = address..(address + 4);
let data = &self.indirect_fifo_data.clone()[range];
```

`indirect_fifo_data` holds the whole recovery firmware image, so this is
O(image_size) per word read and O(image_size²) over a full transfer. For a
197 KB image that is roughly 9.7 GB of `memcpy` and ~49k heap allocations,
and it dominates the recovery-image transfer phase of MCU ROM boot.

The clone was not there for correctness of the data — it was only sidestepping
the borrow conflict with the `&mut self` use of the status register a few lines
later.

### Fix

Read the 4-byte word out of the backing store *before* mutating the status
register, and return the already-decoded `u32`. No clone, no allocation,
identical observable behaviour.

### Validation

- `cargo check -p caliptra-mcu-emulator-periph`
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt --check`
