### PR TITLE
emulator: honor the --rom-size override when validating the ROM image

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -450,8 +450,13 @@ impl Emulator {
         .expect("Failed to start Caliptra CPU");
 
         let rom_buffer = read_binary(args_rom, 0)?;
-        if rom_buffer.len() > ROM_SIZE as usize {
-            println!("ROM File Size must not exceed {} bytes", ROM_SIZE);
+        // Honor the `--rom-size` override when validating the ROM image. The
+        // compile-time `ROM_SIZE` is only the default; the configured size
+        // (e.g. from the CaliptraMCU model's `/emulator/rom_size`) governs how
+        // large a ROM the emulator can load.
+        let effective_rom_size = cli.rom_size.unwrap_or(ROM_SIZE);
+        if rom_buffer.len() > effective_rom_size as usize {
+            println!("ROM File Size must not exceed {} bytes", effective_rom_size);
             exit(-1);
         }
         println!(


### PR DESCRIPTION
### Problem

The emulator already honours `--rom-size` when sizing the bus:

```rust
if let Some(rom_size) = cli.rom_size {
    mcu_root_bus_offsets.rom_size = rom_size;
}
```

but the ROM *image loader* a few dozen lines later still validated against the
compile-time constant:

```rust
if rom_buffer.len() > ROM_SIZE as usize {
    println!("ROM File Size must not exceed {} bytes", ROM_SIZE);
    exit(-1);
}
```

So a ROM larger than the default 64 KiB is rejected with a misleading message
even though `--rom-size` was raised and the bus region is large enough to hold
it. The override is effectively inoperative for its main use case.

### Fix

Validate against the effective size, and report that same value in the error:

```rust
let effective_rom_size = cli.rom_size.unwrap_or(ROM_SIZE);
if rom_buffer.len() > effective_rom_size as usize { ... }
```

Default behaviour is unchanged when `--rom-size` is not passed.

### Validation

- `cargo check -p caliptra-mcu-emulator`
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt --check`
