### PR TITLE
emulator/caliptra: gate the REQ_IDEVID_CSR clear on subsystem mode

### DIFF
--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -164,6 +164,9 @@ pub fn start_caliptra(
     // in active mode, we don't update firmware here, as MCU will trigger it
     let upload_update_fw = UploadUpdateFwCb::new(|_| {});
 
+    // In subsystem mode the MCU owns clearing REQ_IDEVID_CSR.
+    let subsystem_mode = true;
+
     let bus_args = CaliptraRootBusArgs {
         clock: clock.clone(),
         pic: pic.clone(),
@@ -183,10 +186,15 @@ pub fn start_caliptra(
                 u32,
                 DebugManufService::Register,
             >| {
-                download_idev_id_csr(mailbox, log_dir.clone(), cptra_dbg_manuf_service_reg);
+                download_idev_id_csr(
+                    mailbox,
+                    log_dir.clone(),
+                    cptra_dbg_manuf_service_reg,
+                    subsystem_mode,
+                );
             },
         ),
-        subsystem_mode: true,
+        subsystem_mode,
         use_mcu_recovery_interface: args_use_mcu_recovery_interface,
         debug_intent: args.debug_intent,
         prod_dbg_unlock_keypairs: args.prod_dbg_unlock_keypairs.clone(),
@@ -259,6 +267,7 @@ fn download_idev_id_csr(
     mailbox: &mut MailboxInternal,
     path: Rc<PathBuf>,
     cptra_dbg_manuf_service_reg: &mut InMemoryRegister<u32, DebugManufService::Register>,
+    subsystem_mode: bool,
 ) {
     let mut path = path.to_path_buf();
     path.push("caliptra_ldevid_cert.der");
@@ -287,6 +296,10 @@ fn download_idev_id_csr(
     // Complete the mailbox command.
     soc_mbox.status().write(|w| w.status(|w| w.cmd_complete()));
 
-    // Clear the Idevid CSR requested bit.
-    cptra_dbg_manuf_service_reg.modify(DebugManufService::REQ_IDEVID_CSR::CLEAR);
+    if !subsystem_mode {
+        // Standalone mode: callback acts as SoC side and clears REQ_IDEVID_CSR.
+        cptra_dbg_manuf_service_reg.modify(DebugManufService::REQ_IDEVID_CSR::CLEAR);
+    }
+    // Subsystem mode: MCU polls idevid_csr_ready then clears REQ_IDEVID_CSR.
+    // Clearing here can race ROM and lose the ready indication.
 }


### PR DESCRIPTION
### Problem

`download_idev_id_csr` is registered as the IDEVID CSR download callback. It
stands in for the SoC: it drains the mailbox, writes the CSR out, completes the
command, and then unconditionally clears the request bit:

```rust
soc_mbox.status().write(|w| w.status(|w| w.cmd_complete()));

// Clear the Idevid CSR requested bit.
cptra_dbg_manuf_service_reg.modify(DebugManufService::REQ_IDEVID_CSR::CLEAR);
```

In **subsystem** mode that last step is wrong, because the MCU owns the
handshake there: it polls `CPTRA_FLOW_STATUS.idevid_csr_ready` and clears
`REQ_IDEVID_CSR` itself once it has consumed the CSR.

Clearing the bit from the callback races the ROM's flow-status update. If the
callback wins, the ready indication is torn down before the MCU ever observes
it, and the MCU polling loop never sees `idevid_csr_ready` assert.

In **standalone** mode the callback genuinely is the SoC, so clearing there is
correct and must be preserved.

### Fix

Thread the existing `subsystem_mode` value into the callback and gate the clear
on it. Standalone behaviour is byte-for-byte unchanged; subsystem mode now
leaves the request bit for the MCU.

The literal `true` that was previously passed inline to
`CaliptraRootBusArgs::subsystem_mode` is hoisted into a named local so both
uses stay in sync.

### Validation

- `cargo check -p caliptra-mcu-emulator-caliptra`
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt --check`
