### PR TITLE
spdm: keep serving when the IDevID cert is not provisioned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.109",
 ]
 
 [[package]]

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -10,9 +10,9 @@
 //!
 //! Caliptra generates the IDevID *keypair* and a self-signed CSR, but never the
 //! IDevID *certificate* — that is issued externally and provisioned into OTP.
-//! Both the ECC-384 (partition 1) and ML-DSA-87 (partition 2) IDevID certs are
-//! read here and prepended to their respective Caliptra cert chains via the
-//! `POPULATE_IDEV_*_CERT` mailbox commands.
+//! When provisioned, the ECC-384 (partition 1) and ML-DSA-87 (partition 2) IDevID
+//! certs are read here and prepended to their respective Caliptra cert chains via
+//! the `POPULATE_IDEV_*_CERT` mailbox commands.
 
 mod slot0_endorsements;
 
@@ -28,7 +28,7 @@ use caliptra_mcu_spdm_pal::cert::store::SharedCertStore;
 #[allow(unused_imports)]
 use core::fmt::Write as _;
 use mcu_caliptra_api::{
-    is_der_cert_header, mldsa87_cert_der_len, populate_idev_ecc384_cert,
+    ecc384_cert_der_len, mldsa87_cert_der_len, populate_idev_ecc384_cert,
     populate_idev_mldsa87_cert, ApiAlloc,
 };
 use mcu_error::McuResult;
@@ -143,12 +143,12 @@ async fn yield_now() {
     YieldNow(false).await
 }
 
-/// One-time Caliptra setup: read the IDevID certs from OTP and install them.
+/// One-time Caliptra setup: read the IDevID ECC-384 cert from OTP and install it.
 ///
-/// Only the ECC-384 install runs here; its failure fails cert-store init, which
-/// leaves slot 0 unprovisioned but no longer stops the responders from serving.
-/// The ML-DSA-87 install is best-effort and lives in its own task.
-pub async fn populate_idev<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
+/// Returns `false` when partition 1 holds no cert, so the caller can leave slot 0
+/// unprovisioned rather than endorsing a chain with no IDevID in it. The
+/// ML-DSA-87 install is best-effort and lives in its own task.
+pub async fn populate_idev<A: ApiAlloc>(alloc: &A) -> McuResult<bool> {
     populate_idev_from_otp(alloc).await
 }
 
@@ -172,20 +172,28 @@ pub async fn populate_idev_mldsa<A: ApiAlloc>(alloc: &A) {
     }
 }
 
-/// Configure endorsement chains on the shared cert store, for all 3 slots.
+/// Configure endorsement chains on the shared cert store.
 ///
-/// Called once from spdm_task before spawning responders. Slot 0 failure is
-/// fatal. Slots 1-2 stay unprovisioned if flash is empty (they'll be
-/// provisioned via SET_CERTIFICATE).
-pub async fn setup_endorsements<A: ApiAlloc>(store: &SharedCertStore, alloc: &A) -> McuResult<()> {
+/// `idev_installed` gates slot 0: endorsing it without an IDevID would advertise
+/// the slot as provisioned while serving a chain whose Root CA makes no statement
+/// about this device. Left `Empty` instead, so the SPDM slot masks report it
+/// absent. Slots 1-2 stay unprovisioned if flash is empty (they'll be provisioned
+/// via SET_CERTIFICATE).
+pub async fn setup_endorsements<A: ApiAlloc>(
+    store: &SharedCertStore,
+    alloc: &A,
+    idev_installed: bool,
+) -> McuResult<()> {
     // Slot 0 (Vendor): ReadOnly endorsement with static Root CA.
     // Retry on mailbox busy (SHA calls during root cert hashing).
-    retry_on_mailbox_busy!(store.set_endorsement_chain(
-        alloc,
-        VENDOR_STORE_SLOT,
-        slot0_endorsements::SLOT0_ECC_ROOT_CERT_CHAIN,
-        0, // key_pair_id
-    ))?;
+    if idev_installed {
+        retry_on_mailbox_busy!(store.set_endorsement_chain(
+            alloc,
+            VENDOR_STORE_SLOT,
+            slot0_endorsements::SLOT0_ECC_ROOT_CERT_CHAIN,
+            0, // key_pair_id
+        ))?;
+    }
 
     // Slots 1-2 (Owner/Tenant): Managed endorsement, initially empty or loaded
     // from the cert-store flash partition. This remains test-only until a
@@ -217,39 +225,47 @@ pub async fn setup_endorsements<A: ApiAlloc>(store: &SharedCertStore, alloc: &A)
 
 /// Read the IDevID ECC-384 cert from OTP and install it into Caliptra.
 ///
-/// Skips the install when partition 1 is unprovisioned. Nothing downstream
-/// parses the DER, so submitting an erased partition would splice 547 bytes of
-/// `0xFF` into the attestation chain and still report success.
-async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
-    let mut cert_buf = [0u8; ECC_DEVID_CERT_SIZE];
+/// Submits the cert's own DER length, not the partition size: nothing downstream
+/// parses the DER — not Caliptra's `POPULATE_IDEV_ECC384_CERT` handler either —
+/// so an erased or short partition would otherwise splice `0xFF` fill into the
+/// attestation chain and still report success.
+async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<bool> {
     let otp = ExternalOtp::<DefaultSyscalls>::new();
 
-    if !otp_holds_der_cert(&otp, OTP_IDEVID_ECC_PARTITION).await? {
+    let Some(cert_size) = cert_der_len(&otp, OTP_IDEVID_ECC_PARTITION, ecc384_cert_der_len).await?
+    else {
         let mut cw = Console::<DefaultSyscalls>::writer();
         crate::log_warn!(cw, "SPDM: no ECC-384 IDevID cert in OTP; skipping install");
-        return Ok(());
-    }
+        return Ok(false);
+    };
 
-    // Same word-at-a-time read as the ML-DSA path; 547 is not a word multiple,
-    // so the final word contributes 3 bytes.
-    read_otp_range(&otp, OTP_IDEVID_ECC_PARTITION, &mut cert_buf).await?;
+    // Staged in scratch rather than a stack buffer: this runs inside an embassy
+    // task future, where a 1 KiB frame is expensive.
+    let mut cert = alloc.alloc(cert_size)?;
+    read_otp_range(&otp, OTP_IDEVID_ECC_PARTITION, &mut cert).await?;
 
-    retry_on_mailbox_busy!(populate_idev_ecc384_cert(alloc, &cert_buf))
+    retry_on_mailbox_busy!(populate_idev_ecc384_cert(alloc, &cert))?;
+    Ok(true)
 }
 
-/// Whether an OTP partition holds a DER certificate rather than erased fill.
+/// Length of the cert in an OTP partition, or `None` if it holds no usable cert.
 ///
-/// Header policy lives in api-lite so it is covered by host unit tests;
-/// user-app itself is excluded from `cargo test` (xtask/src/test.rs).
-async fn otp_holds_der_cert(
+/// `len_policy` is the per-algorithm bound from `mcu-caliptra-api`, where it is
+/// covered by host unit tests; user-app is excluded from `cargo test`
+/// (xtask/src/test.rs).
+async fn cert_der_len(
     otp: &ExternalOtp<DefaultSyscalls>,
     partition_id: u32,
-) -> McuResult<bool> {
+    len_policy: fn(u32, usize) -> Option<usize>,
+) -> McuResult<Option<usize>> {
     let word = otp
         .read(partition_id, 0)
         .await
         .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
-    Ok(is_der_cert_header(word))
+    let partition_size = otp
+        .partition_size(partition_id)
+        .map_err(|_| mcu_error::codes::INTERNAL_BUG)? as usize;
+    Ok(len_policy(word, partition_size))
 }
 
 /// Read the IDevID ML-DSA-87 cert from OTP and install it into Caliptra.
@@ -269,7 +285,9 @@ async fn populate_idev_mldsa_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
     // Submit the cert's own DER length, not the whole partition: a production
     // cert shorter than its partition would otherwise splice the 0xFF fill into
     // the chain.
-    let Some(cert_size) = mldsa_cert_der_len(&otp).await? else {
+    let Some(cert_size) =
+        cert_der_len(&otp, OTP_IDEVID_MLDSA_PARTITION, mldsa87_cert_der_len).await?
+    else {
         // No cert provisioned — leave the MLDSA chain as Caliptra built it. Say
         // so: this is the branch that decides a device ships without a PQC
         // IDevID, so the log has to distinguish it from a successful install.
@@ -290,29 +308,6 @@ async fn populate_idev_mldsa_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
         populate_idev_mldsa87_cert(alloc, &cert),
         MLDSA_INSTALL_MAX_ATTEMPTS
     )
-}
-
-/// Determine the ML-DSA-87 IDevID cert length from its own DER header.
-///
-/// A certificate is an ASN.1 SEQUENCE: tag `0x30`, then a long-form length.
-/// `0x82` (2 length bytes) is the only form these certs can take: the ML-DSA-87
-/// signature alone exceeds 4 KiB, so the body is always in `128..=65535`.
-///
-/// Returns `Ok(None)` for anything that is not a cert this device can install —
-/// erased OTP, a truncated header, or a length that overruns the partition.
-/// All of those mean "no usable PQC cert provisioned", which the caller skips;
-/// none of them should be able to take down the ECC chain.
-async fn mldsa_cert_der_len(otp: &ExternalOtp<DefaultSyscalls>) -> McuResult<Option<usize>> {
-    let word = otp
-        .read(OTP_IDEVID_MLDSA_PARTITION, 0)
-        .await
-        .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
-    let partition_size = otp
-        .partition_size(OTP_IDEVID_MLDSA_PARTITION)
-        .map_err(|_| mcu_error::codes::INTERNAL_BUG)? as usize;
-    // Length policy lives in api-lite so it is covered by host unit tests;
-    // user-app itself is excluded from `cargo test` (xtask/src/test.rs).
-    Ok(mldsa87_cert_der_len(word, partition_size))
 }
 
 /// Read `out.len()` bytes from the start of an OTP partition.

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -28,7 +28,8 @@ use caliptra_mcu_spdm_pal::cert::store::SharedCertStore;
 #[allow(unused_imports)]
 use core::fmt::Write as _;
 use mcu_caliptra_api::{
-    mldsa87_cert_der_len, populate_idev_ecc384_cert, populate_idev_mldsa87_cert, ApiAlloc,
+    is_der_cert_header, mldsa87_cert_der_len, populate_idev_ecc384_cert,
+    populate_idev_mldsa87_cert, ApiAlloc,
 };
 use mcu_error::McuResult;
 
@@ -144,9 +145,9 @@ async fn yield_now() {
 
 /// One-time Caliptra setup: read the IDevID certs from OTP and install them.
 ///
-/// Only the ECC-384 install runs here, and its failure aborts cert-store init.
-/// The ML-DSA-87 install is best-effort and lives in its own task so a
-/// PQC-provisioning defect cannot take down the ECC chain.
+/// Only the ECC-384 install runs here; its failure fails cert-store init, which
+/// leaves slot 0 unprovisioned but no longer stops the responders from serving.
+/// The ML-DSA-87 install is best-effort and lives in its own task.
 pub async fn populate_idev<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
     populate_idev_from_otp(alloc).await
 }
@@ -215,15 +216,40 @@ pub async fn setup_endorsements<A: ApiAlloc>(store: &SharedCertStore, alloc: &A)
 }
 
 /// Read the IDevID ECC-384 cert from OTP and install it into Caliptra.
+///
+/// Skips the install when partition 1 is unprovisioned. Nothing downstream
+/// parses the DER, so submitting an erased partition would splice 547 bytes of
+/// `0xFF` into the attestation chain and still report success.
 async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
     let mut cert_buf = [0u8; ECC_DEVID_CERT_SIZE];
     let otp = ExternalOtp::<DefaultSyscalls>::new();
+
+    if !otp_holds_der_cert(&otp, OTP_IDEVID_ECC_PARTITION).await? {
+        let mut cw = Console::<DefaultSyscalls>::writer();
+        crate::log_warn!(cw, "SPDM: no ECC-384 IDevID cert in OTP; skipping install");
+        return Ok(());
+    }
 
     // Same word-at-a-time read as the ML-DSA path; 547 is not a word multiple,
     // so the final word contributes 3 bytes.
     read_otp_range(&otp, OTP_IDEVID_ECC_PARTITION, &mut cert_buf).await?;
 
     retry_on_mailbox_busy!(populate_idev_ecc384_cert(alloc, &cert_buf))
+}
+
+/// Whether an OTP partition holds a DER certificate rather than erased fill.
+///
+/// Header policy lives in api-lite so it is covered by host unit tests;
+/// user-app itself is excluded from `cargo test` (xtask/src/test.rs).
+async fn otp_holds_der_cert(
+    otp: &ExternalOtp<DefaultSyscalls>,
+    partition_id: u32,
+) -> McuResult<bool> {
+    let word = otp
+        .read(partition_id, 0)
+        .await
+        .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
+    Ok(is_der_cert_header(word))
 }
 
 /// Read the IDevID ML-DSA-87 cert from OTP and install it into Caliptra.

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -195,8 +195,13 @@ pub async fn setup_endorsements<A: ApiAlloc>(
     // Slots 1-2 (Owner/Tenant): Managed endorsement, initially empty or loaded
     // from the cert-store flash partition. This remains test-only until a
     // production authorization/key-binding policy exists.
+    //
+    // Also gated on `idev_installed`: a managed slot serves the DPE chain with a
+    // fixed two-cert prefix skipped (Caliptra's IDevID and LDevID). Without the
+    // IDevID install that chain is one cert shorter, so the skip would drop the
+    // FMC alias too and serve a chain with a broken issuer link.
     #[cfg(feature = "test-mctp-spdm-set-certificate")]
-    {
+    if idev_installed {
         store
             .set_managed_endorsement(
                 1,

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -40,9 +40,6 @@ const OWNER_SPDM_SLOT: u8 = 2;
 #[cfg(feature = "test-mctp-spdm-set-certificate")]
 const TENANT_SPDM_SLOT: u8 = 3;
 
-/// IDevID ECC cert size in OTP partition 1.
-const ECC_DEVID_CERT_SIZE: usize = 547;
-
 /// OTP partition ID for the IDevID ECC certificate.
 const OTP_IDEVID_ECC_PARTITION: u32 = 0x01;
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -341,13 +341,14 @@ async fn spdm_mctp_responder() {
         unsafe { MCTP_ALLOC_CELL.init_once(scratch_ptr, MCTP_SPDM_SCRATCH_SIZE) };
 
     {
+        // Serve anyway: returning here would skip `stack.run()` and the device
+        // would look hung. Slot 0 stays Empty, so it is reported absent.
         if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::log_error!(
                 cw,
-                "SPDM_MCTP: cert store init failed: 0x{}",
+                "SPDM_MCTP: cert store init failed, serving without slot 0: 0x{}",
                 crate::Hex32(u32::from(e))
             );
-            return;
         }
     }
 
@@ -415,13 +416,13 @@ async fn spdm_doe_responder() {
         unsafe { DOE_ALLOC_CELL.init_once(scratch_ptr, DOE_SPDM_SCRATCH_SIZE) };
 
     {
+        // Serve anyway — same reasoning as the MCTP responder above.
         if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::log_error!(
                 cw,
-                "SPDM_DOE: cert store init failed: 0x{}",
+                "SPDM_DOE: cert store init failed, serving without slot 0: 0x{}",
                 crate::Hex32(u32::from(e))
             );
-            return;
         }
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -205,12 +205,15 @@ async fn ensure_cert_store_init<A: mcu_caliptra_api::ApiAlloc>(
     match state {
         0 => {
             CERT_STORE_STATE.store(1, Ordering::Release);
-            if let Err(e) = cert_store::populate_idev(alloc).await {
-                CERT_STORE_STATE.store(0, Ordering::Release);
-                CERT_STORE_INIT.sender().send(false);
-                return Err(e);
-            }
-            let r = cert_store::setup_endorsements(&CERT_STORE, alloc).await;
+            let idev_installed = match cert_store::populate_idev(alloc).await {
+                Ok(installed) => installed,
+                Err(e) => {
+                    CERT_STORE_STATE.store(0, Ordering::Release);
+                    CERT_STORE_INIT.sender().send(false);
+                    return Err(e);
+                }
+            };
+            let r = cert_store::setup_endorsements(&CERT_STORE, alloc, idev_installed).await;
             CERT_STORE_STATE.store(if r.is_ok() { 2 } else { 0 }, Ordering::Release);
             CERT_STORE_INIT.sender().send(r.is_ok());
             r
@@ -341,8 +344,8 @@ async fn spdm_mctp_responder() {
         unsafe { MCTP_ALLOC_CELL.init_once(scratch_ptr, MCTP_SPDM_SCRATCH_SIZE) };
 
     {
-        // Serve anyway: returning here would skip `stack.run()` and the device
-        // would look hung. Slot 0 stays Empty, so it is reported absent.
+        // Serve anyway: returning would skip `stack.run()`, so nothing would
+        // answer GET_VERSION and the device would look hung, not degraded.
         if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::log_error!(
                 cw,
@@ -416,7 +419,7 @@ async fn spdm_doe_responder() {
         unsafe { DOE_ALLOC_CELL.init_once(scratch_ptr, DOE_SPDM_SCRATCH_SIZE) };
 
     {
-        // Serve anyway — same reasoning as the MCTP responder above.
+        // Serve anyway: a missing slot 0 must degrade, not hang the transport.
         if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::log_error!(
                 cw,

--- a/runtime/userspace/api/caliptra-api/src/cert.rs
+++ b/runtime/userspace/api/caliptra-api/src/cert.rs
@@ -17,8 +17,9 @@ use crate::ApiAlloc;
 /// Caliptra command ID for `POPULATE_IDEV_ECC384_CERT`.
 const CMD_POPULATE_IDEV_ECC384_CERT: u32 = 0x4944_4550; // "IDEP"
 
-/// Maximum IDevID cert size accepted by Caliptra.
-const POPULATE_IDEV_MAX_CERT_SIZE: usize = 1024;
+/// Maximum IDevID ECC-384 cert size accepted by Caliptra
+/// (`PopulateIdevEcc384CertReq::MAX_CERT_SIZE`).
+pub const POPULATE_IDEV_ECC384_MAX_CERT_SIZE: usize = 1024;
 
 /// Fixed-size head of a `POPULATE_IDEV_*_CERT` request:
 /// `MailboxReqHeader.chksum(4) | cert_size(4)`, followed on the wire by exactly
@@ -65,19 +66,21 @@ const _: () = assert!(
         == offset_of!(PopulateIdevCertReqHeader, cert_size)
 );
 const _: () = assert!(offset_of!(PopulateIdevEcc384CertReq, cert) == PREFIX_LEN);
-const _: () = assert!(POPULATE_IDEV_MAX_CERT_SIZE == PopulateIdevEcc384CertReq::MAX_CERT_SIZE);
 const _: () =
-    assert!(PREFIX_LEN + POPULATE_IDEV_MAX_CERT_SIZE == size_of::<PopulateIdevEcc384CertReq>());
+    assert!(POPULATE_IDEV_ECC384_MAX_CERT_SIZE == PopulateIdevEcc384CertReq::MAX_CERT_SIZE);
+const _: () = assert!(
+    PREFIX_LEN + POPULATE_IDEV_ECC384_MAX_CERT_SIZE == size_of::<PopulateIdevEcc384CertReq>()
+);
 
 /// Populate the signed IDevID ECC-384 certificate into Caliptra via
 /// the `POPULATE_IDEV_ECC384_CERT` mailbox command.
 #[inline(never)]
 pub async fn populate_idev_ecc384_cert<A: ApiAlloc>(alloc: &A, cert: &[u8]) -> McuResult<()> {
-    if cert.is_empty() || cert.len() > POPULATE_IDEV_MAX_CERT_SIZE {
+    if cert.is_empty() || cert.len() > POPULATE_IDEV_ECC384_MAX_CERT_SIZE {
         return Err(INVARIANT);
     }
 
-    let req_len = PREFIX_LEN + POPULATE_IDEV_MAX_CERT_SIZE;
+    let req_len = PREFIX_LEN + POPULATE_IDEV_ECC384_MAX_CERT_SIZE;
     let mut req = alloc.alloc(req_len)?;
     req.fill(0);
 
@@ -100,35 +103,25 @@ pub async fn populate_idev_ecc384_cert<A: ApiAlloc>(alloc: &A, cert: &[u8]) -> M
 /// (`PopulateIdevMldsa87CertReq::MAX_CERT_SIZE`).
 pub const POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE: usize = 8192;
 
-/// Whether an OTP partition's first word looks like a DER certificate header.
-///
-/// Provisioning check for the fixed-size ECC path, which has no length to
-/// derive: both IDevID certs exceed 127 bytes, so `30 82` is the only header
-/// they can carry, and an erased partition reads `0xFF` and fails it.
-///
-/// `header_word` is the first 4 bytes of the partition, little-endian.
-pub fn is_der_cert_header(header_word: u32) -> bool {
-    let b = header_word.to_le_bytes();
-    b[0] == 0x30 && b[1] == 0x82
-}
-
-/// Length of an ML-DSA-87 IDevID certificate held in an OTP partition, decided
-/// from the partition's first word and its size.
+/// Length of an IDevID certificate held in an OTP partition, decided from the
+/// partition's first word.
 ///
 /// A certificate is an ASN.1 SEQUENCE: tag `0x30` then a long-form length.
-/// `0x82` (2 length bytes) is the only form these certs can take — an
-/// ML-DSA-87 signature alone exceeds 4 KiB, so the body is always in
-/// `128..=65535`, and Caliptra's 8192-byte cap rules out `0x83`.
+/// `0x82` (2 length bytes) is the only form these certs can take — both exceed
+/// 127 bytes, and Caliptra's 8192-byte cap rules out `0x83`.
 ///
 /// Returns `None` for anything not installable: erased OTP (which reads back
-/// `0xFF`), a non-SEQUENCE tag, a zero body, or a length that overruns either
-/// the partition or Caliptra's cap. Bounding by the *partition* matters because
-/// an OTP read clamps a straddling word to the partition end and pads with
-/// `0xFF`, so an over-long length would silently splice fill bytes into the
-/// attestation chain.
+/// `0xFF`), a non-SEQUENCE tag, a zero body, or a length overrunning the
+/// partition or `max_cert_size`. Bounding by the *partition* matters because an
+/// OTP read clamps a straddling word to the partition end and pads with `0xFF`,
+/// so an over-long length would splice fill into the attestation chain.
 ///
 /// `header_word` is the first 4 bytes of the partition, little-endian.
-pub fn mldsa87_cert_der_len(header_word: u32, partition_size: usize) -> Option<usize> {
+pub fn cert_der_len(
+    header_word: u32,
+    partition_size: usize,
+    max_cert_size: usize,
+) -> Option<usize> {
     let b = header_word.to_le_bytes();
     if b[0] != 0x30 || b[1] != 0x82 {
         return None;
@@ -139,10 +132,28 @@ pub fn mldsa87_cert_der_len(header_word: u32, partition_size: usize) -> Option<u
     }
     // 4 header bytes (tag + 0x82 + 2 length bytes) precede the body.
     let total = body_len + 4;
-    if total > partition_size || total > POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE {
+    if total > partition_size || total > max_cert_size {
         return None;
     }
     Some(total)
+}
+
+/// [`cert_der_len`] with Caliptra's ECC-384 cap applied.
+pub fn ecc384_cert_der_len(header_word: u32, partition_size: usize) -> Option<usize> {
+    cert_der_len(
+        header_word,
+        partition_size,
+        POPULATE_IDEV_ECC384_MAX_CERT_SIZE,
+    )
+}
+
+/// [`cert_der_len`] with Caliptra's ML-DSA-87 cap applied.
+pub fn mldsa87_cert_der_len(header_word: u32, partition_size: usize) -> Option<usize> {
+    cert_der_len(
+        header_word,
+        partition_size,
+        POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE,
+    )
 }
 
 /// Populate the signed IDevID ML-DSA-87 certificate into Caliptra via the
@@ -361,34 +372,32 @@ mod tests {
         assert!(mldsa87_cert_len_ok(POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE));
     }
 
+    /// The ECC-384 cap and partition bound, which decide whether an erased or
+    /// short partition reaches Caliptra.
+    #[test]
+    fn ecc384_cert_der_len_cases() {
+        // The emulator fixture: 30 82 02 1f -> 0x021f + 4 = 547.
+        let good = u32::from_le_bytes([0x30, 0x82, 0x02, 0x1f]);
+        assert_eq!(ecc384_cert_der_len(good, 547), Some(547));
+        // Erased OTP - the case that matters.
+        assert_eq!(ecc384_cert_der_len(u32::MAX, 547), None);
+        assert_eq!(ecc384_cert_der_len(0, 547), None);
+        // A cert one byte longer than its partition would splice 0xFF fill.
+        assert_eq!(ecc384_cert_der_len(good, 546), None);
+        // Past Caliptra's 1024-byte ECC cap even though the partition allows it.
+        let over_cap = u32::from_le_bytes([0x30, 0x82, 0x04, 0x00]); // 1024 + 4
+        assert_eq!(ecc384_cert_der_len(over_cap, 2048), None);
+        // Exactly the cap is accepted.
+        let at_cap = u32::from_le_bytes([0x30, 0x82, 0x03, 0xfc]); // 1020 + 4
+        assert_eq!(
+            ecc384_cert_der_len(at_cap, 2048),
+            Some(POPULATE_IDEV_ECC384_MAX_CERT_SIZE)
+        );
+    }
+
     /// Every accept/reject path of the DER length discovery. The reject cases
     /// are what keep an unprovisioned or malformed partition from splicing
     /// `0xFF` fill into the ML-DSA attestation chain.
-    #[test]
-    /// The ECC path submits a fixed 547 bytes with no length to validate, so
-    /// this predicate is the only thing standing between an erased partition and
-    /// 547 bytes of `0xFF` spliced into the attestation chain.
-    #[test]
-    fn is_der_cert_header_cases() {
-        // Erased OTP - the case that matters.
-        assert!(!is_der_cert_header(u32::MAX));
-        assert!(!is_der_cert_header(0));
-        // Real headers: the emulator ECC fixture (30 82 02 19) and ML-DSA one.
-        assert!(is_der_cert_header(u32::from_le_bytes([
-            0x30, 0x82, 0x02, 0x19
-        ])));
-        assert!(is_der_cert_header(u32::from_le_bytes([
-            0x30, 0x82, 0x1e, 0x39
-        ])));
-        // Wrong tag (SET, not SEQUENCE) and short-form length.
-        assert!(!is_der_cert_header(u32::from_le_bytes([
-            0x31, 0x82, 0x02, 0x19
-        ])));
-        assert!(!is_der_cert_header(u32::from_le_bytes([
-            0x30, 0x81, 0x7f, 0x00
-        ])));
-    }
-
     #[test]
     fn mldsa87_cert_der_len_cases() {
         // `30 82 1e 39` -> body 0x1e39 (7737) + 4 = 7741, the emulator fixture.

--- a/runtime/userspace/api/caliptra-api/src/cert.rs
+++ b/runtime/userspace/api/caliptra-api/src/cert.rs
@@ -100,6 +100,18 @@ pub async fn populate_idev_ecc384_cert<A: ApiAlloc>(alloc: &A, cert: &[u8]) -> M
 /// (`PopulateIdevMldsa87CertReq::MAX_CERT_SIZE`).
 pub const POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE: usize = 8192;
 
+/// Whether an OTP partition's first word looks like a DER certificate header.
+///
+/// Provisioning check for the fixed-size ECC path, which has no length to
+/// derive: both IDevID certs exceed 127 bytes, so `30 82` is the only header
+/// they can carry, and an erased partition reads `0xFF` and fails it.
+///
+/// `header_word` is the first 4 bytes of the partition, little-endian.
+pub fn is_der_cert_header(header_word: u32) -> bool {
+    let b = header_word.to_le_bytes();
+    b[0] == 0x30 && b[1] == 0x82
+}
+
 /// Length of an ML-DSA-87 IDevID certificate held in an OTP partition, decided
 /// from the partition's first word and its size.
 ///
@@ -352,6 +364,31 @@ mod tests {
     /// Every accept/reject path of the DER length discovery. The reject cases
     /// are what keep an unprovisioned or malformed partition from splicing
     /// `0xFF` fill into the ML-DSA attestation chain.
+    #[test]
+    /// The ECC path submits a fixed 547 bytes with no length to validate, so
+    /// this predicate is the only thing standing between an erased partition and
+    /// 547 bytes of `0xFF` spliced into the attestation chain.
+    #[test]
+    fn is_der_cert_header_cases() {
+        // Erased OTP - the case that matters.
+        assert!(!is_der_cert_header(u32::MAX));
+        assert!(!is_der_cert_header(0));
+        // Real headers: the emulator ECC fixture (30 82 02 19) and ML-DSA one.
+        assert!(is_der_cert_header(u32::from_le_bytes([
+            0x30, 0x82, 0x02, 0x19
+        ])));
+        assert!(is_der_cert_header(u32::from_le_bytes([
+            0x30, 0x82, 0x1e, 0x39
+        ])));
+        // Wrong tag (SET, not SEQUENCE) and short-form length.
+        assert!(!is_der_cert_header(u32::from_le_bytes([
+            0x31, 0x82, 0x02, 0x19
+        ])));
+        assert!(!is_der_cert_header(u32::from_le_bytes([
+            0x30, 0x81, 0x7f, 0x00
+        ])));
+    }
+
     #[test]
     fn mldsa87_cert_der_len_cases() {
         // `30 82 1e 39` -> body 0x1e39 (7737) + 4 = 7741, the emulator fixture.

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -90,9 +90,9 @@ pub use auth_stash::{
 pub use capabilities::{core_capabilities, CORE_CAPABILITIES_SIZE};
 #[cfg(feature = "mailbox-io")]
 pub use cert::{
-    get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384, is_der_cert_header,
-    mldsa87_cert_der_len, populate_idev_ecc384_cert, populate_idev_mldsa87_cert,
-    POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE,
+    cert_der_len, ecc384_cert_der_len, get_attested_csr_ecc384, get_attested_csr_mldsa87,
+    get_idev_csr_ecc384, mldsa87_cert_der_len, populate_idev_ecc384_cert,
+    populate_idev_mldsa87_cert, POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE,
 };
 #[cfg(feature = "mailbox-io")]
 pub use debug_unlock::{

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -90,8 +90,9 @@ pub use auth_stash::{
 pub use capabilities::{core_capabilities, CORE_CAPABILITIES_SIZE};
 #[cfg(feature = "mailbox-io")]
 pub use cert::{
-    get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384, mldsa87_cert_der_len,
-    populate_idev_ecc384_cert, populate_idev_mldsa87_cert, POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE,
+    get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384, is_der_cert_header,
+    mldsa87_cert_der_len, populate_idev_ecc384_cert, populate_idev_mldsa87_cert,
+    POPULATE_IDEV_MLDSA87_MAX_CERT_SIZE,
 };
 #[cfg(feature = "mailbox-io")]
 pub use debug_unlock::{


### PR DESCRIPTION
Fixes #2034

An unprovisioned IDevID slot 0 currently has two bad outcomes.

**Cert-store init failure took down every SPDM transport.** Both responders returned before reaching `stack.run()`, the only place SPDM requests are handled, so nothing answered `GET_VERSION` on any path — the device looked hung rather than degraded. The failure is also shared: the first caller resets `CERT_STORE_STATE` and broadcasts `false`, so one failure fans out to every waiter. Now it logs and keeps serving.

Slot 0 is left genuinely unprovisioned in that case. `populate_idev` reports whether it installed a cert, and slot 0's endorsement is skipped when it did not — because `SlotEndorsement::ReadOnly` makes `is_provisioned()` return `true` (`spdm-lib/pal/src/cert/endorsement.rs:165`), so endorsing it anyway would advertise the slot as provisioned while serving a chain whose Root CA makes no statement about this device. Left `Empty`, the SPDM slot masks report it absent, cert-dependent commands fail with a clean error, and VCA still works.

**An erased OTP partition was installed as a certificate.** The ECC path submitted a fixed 547 bytes and nothing downstream parses the DER — not this code, and not Caliptra's `POPULATE_IDEV_ECC384_CERT` handler — so an erased partition reading back `0xFF` was spliced into the attestation chain while init reported success. It only surfaced as a chain-validation failure at the remote verifier.

Both paths now share `cert_der_len(header_word, partition_size, max_cert_size)` and submit the cert's own DER length, bounded by the partition and by Caliptra's per-algorithm cap. That also covers a *short* or partly-programmed cert, not just a fully erased partition. The ECC cert is staged in scratch rather than a 1 KiB stack buffer, matching the ML-DSA path. Length policy lives in `mcu-caliptra-api` so it is covered by host unit tests; user-app is excluded from `cargo test`.

### Testing
- `cargo test -p mcu-caliptra-api` — 38 pass, including new `ecc384_cert_der_len_cases` (cap, partition bound, erased-OTP)
- `cargo clippy --all-targets -- -D warnings` clean; `cargo check` clean for the riscv `spdm` build
- `test_mctp_spdm_responder_conformance` on the emulator — **659 pass / 0 fail**, unchanged from before this series

### Not covered
Every emulator fixture programs both OTP partitions unconditionally (`tests/integration/src/lib.rs:1389`), so no integration test exercises the unprovisioned path. Adding one needs a `TestParams` field to pass `None`; happy to do it here or as a follow-up.
