### PR TITLE
xtask/registers: dedupe generated read arms as writes already are

### DIFF
--- a/xtask/src/registers.rs
+++ b/xtask/src/registers.rs
@@ -844,6 +844,7 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
             ranges_with_writer.insert((start, end));
         }
     });
+    let mut emitted_read_ranges: HashSet<(u64, u64)> = HashSet::new();
     let mut emitted_write_ranges: HashSet<(u64, u64)> = HashSet::new();
     registers.iter().for_each(|(offset, base_name, r)| {
         // skip as this register is not defined yet
@@ -875,7 +876,7 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
         let b = hex_literal(end);
         assert_eq!(r.ty.width, RegisterWidth::_32);
         if has_single_32_bit_field(&r.ty) {
-            if r.ty.fields[0].ty.can_read() {
+            if r.ty.fields[0].ty.can_read() && emitted_read_ranges.insert((start, end)) {
                 if r.is_array() {
                     if start == 0 {
                         read_tokens.extend(quote! {
@@ -925,7 +926,7 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
                 });
             }
         } else {
-            if r.can_read() {
+            if r.can_read() && emitted_read_ranges.insert((start, end)) {
                 if r.is_array() {
                     if offset + r.offset == 0 {
                         read_tokens.extend(quote! {


### PR DESCRIPTION
### Problem

`emu_make_peripheral_bus_impl` already guards the **write** arms against
duplicate address ranges:

```rust
let mut emitted_write_ranges: HashSet<(u64, u64)> = HashSet::new();
...
if r.ty.fields[0].ty.can_write() {
    if emitted_write_ranges.insert((start, end)) { ... }
```

The **read** side has no equivalent. Any RDL that yields two registers covering
the same range therefore emits two identical `#a..#b =>` arms in the generated
`Bus::read`. The second is unreachable, so one of the two registers is silently
shadowed — and the failure mode is a generated-code surprise rather than a
generator error.

### Change

Add the symmetric `emitted_read_ranges` guard to the two existing read
conditions — 3 lines, restoring read/write symmetry rather than introducing a
new pattern.

### Scope

Generator hardening, and I want to be upfront about that: the RDL currently
in-tree contains no overlapping ranges, so this changes nothing today. I
verified that rather than assuming it — `cargo xtask registers-autogen`
reproduces the committed output **byte-for-byte** with this change applied.

I'm sending it because the current behaviour degrades silently, and because the
asymmetry with the write path looks like an oversight rather than a decision. If
you'd prefer the generator hard-error on a duplicate range instead of skipping
it, that's a small change and arguably the better contract — happy to switch.

### Validation

- `cargo xtask registers-autogen` — generated output unchanged
- `cargo xtask clippy` (workspace, all ROM variants) — clean
- `cargo check --workspace --all-targets` — 0 errors
- `cargo fmt --all --check`, `header-check`, `cargo-lock` — clean
