### PR TITLE
emulator/mci: model MCU_LSU_AXI_USER instead of stubbing it

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -153,6 +153,10 @@ pub struct EmulatorArgs {
     #[arg(long)]
     pub soc_manifest: PathBuf,
 
+    /// Value reported by the read-only MCI_REG_MCU_LSU_AXI_USER strap.
+    #[arg(long, value_parser=maybe_hex::<u32>, default_value_t = 0)]
+    pub mcu_lsu_axi_user: u32,
+
     #[arg(long)]
     pub i3c_port: Option<u16>,
 
@@ -924,7 +928,7 @@ impl Emulator {
         let cptra_boot_go = Rc::new(Cell::new(false));
 
         let mci_regs = ext_mci.regs.clone();
-        let mci = Mci::new(
+        let mut mci = Mci::new(
             &clock.clone(),
             ext_mci,
             mci_irq,
@@ -934,6 +938,7 @@ impl Emulator {
             [0, 0],
             cptra_boot_go.clone(),
         );
+        mci.set_mcu_lsu_axi_user(cli.mcu_lsu_axi_user);
 
         let mut auto_root_bus = AutoRootBus::new(
             delegates,

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -350,6 +350,7 @@ pub unsafe extern "C" fn emulator_init(
             config.hw_revision_patch as u64,
         ),
         flash_based_boot: config.flash_based_boot != 0,
+        mcu_lsu_axi_user: 0,
         allow_sideloaded_rom: config.allow_sideloaded_rom != 0,
         // Use provided offset and size override parameters (-1 means use default)
         rom_offset: convert_optional_offset_size(config.rom_offset),

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -47,6 +47,7 @@ fn test_emulator_args_creation() {
         _no_stdin_uart: false,
         allow_sideloaded_rom: false,
         flash_based_boot: false,
+        mcu_lsu_axi_user: 0,
         i3c_port: None,
         device_security_state: DeviceLifecycle::Production as u32,
         test_feature: None,

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -49,6 +49,9 @@ pub struct Mci {
     ext_mci_regs: caliptra_emu_periph::mci::Mci,
     generated: MciGenerated,
 
+    /// Value reported by the read-only MCU LSU AXI USER strap.
+    mcu_lsu_axi_user: u32,
+
     timer: Timer,
     op_wdt_timer1_expired_action: Option<ActionHandle>,
     op_wdt_timer2_expired_action: Option<ActionHandle>,
@@ -107,6 +110,7 @@ impl Mci {
         Self {
             ext_mci_regs,
             generated,
+            mcu_lsu_axi_user: 0,
 
             timer: Timer::new(clock),
             op_wdt_timer1_expired_action: None,
@@ -186,9 +190,20 @@ impl Mci {
     }
 }
 
+impl Mci {
+    /// Set the value reported by the read-only MCU LSU AXI USER strap.
+    pub fn set_mcu_lsu_axi_user(&mut self, value: u32) {
+        self.mcu_lsu_axi_user = value;
+    }
+}
+
 impl MciPeripheral for Mci {
     fn generated(&mut self) -> Option<&mut MciGenerated> {
         Some(&mut self.generated)
+    }
+
+    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+        self.mcu_lsu_axi_user
     }
 
     fn write_mci_reg_cptra_boot_go(


### PR DESCRIPTION
### Problem

`MCI_REG_MCU_LSU_AXI_USER` is a read-only strap carrying the AXI USER ID the MCU
presents on its LSU port. `Mci` never implemented the accessor, so reads fall
through to the generated stub:

```
[EMU] Non-functional register stub: read mci::mci_reg_mcu_lsu_axi_user
```

and return `0` unconditionally. Firmware that reads the strap back — for example
to program matching AXI USER filters and then verify them — cannot be exercised
in the emulator.

### Change

Store the strap value in `Mci`, return it from `read_mci_reg_mcu_lsu_axi_user`,
and allow it to be set via a new `--mcu-lsu-axi-user` option.

The register is read-only in the RDL (there is no generated
`write_mci_reg_mcu_lsu_axi_user`), so a read accessor backed by a settable field
is sufficient and cannot drift from a write path.

### Compatibility

The option defaults to `0`, which is exactly what the stub returned, so the
value observed by firmware is unchanged unless the option is passed. The only
other difference is that the stub warning no longer prints.

### Validation

- `cargo test -p caliptra-mcu-emulator-periph` — 86 passed
- `cargo check`, `cargo clippy --all-targets` (no new warnings), `cargo fmt --check`
