### PR TITLE
emulator/caliptra: model the SS_SOC_DBG_UNLOCK_LEVEL[0] strap

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -152,6 +152,12 @@ pub struct EmulatorArgs {
     #[arg(long)]
     pub soc_manifest: PathBuf,
 
+    /// Models the SoC strap `SS_SOC_DBG_UNLOCK_LEVEL[0]` at reset deassertion.
+    /// Combined with debug intent to decide whether the Caliptra security state
+    /// is latched as Production or honours the requested device lifecycle.
+    #[arg(long, default_value_t = false)]
+    pub ss_soc_dbg_unlock_level0: bool,
+
     #[arg(long)]
     pub i3c_port: Option<u16>,
 
@@ -438,6 +444,7 @@ impl Emulator {
         let use_mcu_recovery_interface = is_flash_based_boot;
 
         let (mut caliptra_cpu, soc_to_caliptra, _, ext_mci) = start_caliptra(&StartCaliptraArgs {
+            ss_soc_dbg_unlock_level0: cli.ss_soc_dbg_unlock_level0,
             rom: BytesOrPath::Path(cli.caliptra_rom),
             device_lifecycle: device_lifecycle_str,
             req_idevid_csr,

--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -62,6 +62,10 @@ impl BytesOrPath {
 
 #[derive(Default)]
 pub struct StartCaliptraArgs<'a> {
+    /// Models the SoC strap `SS_SOC_DBG_UNLOCK_LEVEL[0]` sampled at reset
+    /// deassertion. Combined with `debug_intent` to decide whether the security
+    /// state is latched as Production or honours the requested lifecycle.
+    pub ss_soc_dbg_unlock_level0: bool,
     pub rom: BytesOrPath,
     pub req_idevid_csr: Option<bool>,
     pub device_lifecycle: Option<String>,
@@ -137,22 +141,13 @@ pub fn start_caliptra(
         ))?,
     };
 
-    // If debug intent is not set or unlock level 0 is not set, then the security state
-    // should be latched as production.
-    // In the emulator, we don't easily have access to the register state before Caliptra starts.
-    // However, we can simulate the latching logic by defaulting to Production unless
-    // specifically overridden by a mechanism that represents "unlocked".
-
-    // For now, we follow the RTL logic: it is unlocked if (debug_intent AND SS_SOC_DBG_UNLOCK_LEVEL[0])
-    // OR ss_dbg_manuf_enable.
-    // Since we don't have registers yet, we'll assume it's locked unless debug_intent is set
-    // AND some other condition we can pass in.
-    // But the user said "if the debug_intent and SS_SOC_DBG_UNLOCK_LEVEL are not set ... report the correct security state"
-    // This implies that if they ARE set, it should NOT be Production.
-
-    // Since we are at reset deassertion, SS_SOC_DBG_UNLOCK_LEVEL is 0.
-    // So it should ALWAYS be locked at reset deassertion.
-    let is_unlocked = false;
+    // RTL latches the security state at reset deassertion:
+    //   unlocked = (debug_intent AND SS_SOC_DBG_UNLOCK_LEVEL[0]) OR ss_dbg_manuf_enable
+    // When not unlocked, the lifecycle is forced to Production regardless of the
+    // requested value. The emulator has no strap/register state at this point, so
+    // the strap is supplied by the caller. `ss_dbg_manuf_enable` is not modelled
+    // yet; callers needing it should add a separate strap.
+    let is_unlocked = args.debug_intent && args.ss_soc_dbg_unlock_level0;
 
     if !is_unlocked {
         security_state.set_device_lifecycle(DeviceLifecycle::Production);

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -350,6 +350,7 @@ pub unsafe extern "C" fn emulator_init(
             config.hw_revision_patch as u64,
         ),
         flash_based_boot: config.flash_based_boot != 0,
+        ss_soc_dbg_unlock_level0: false,
         allow_sideloaded_rom: config.allow_sideloaded_rom != 0,
         // Use provided offset and size override parameters (-1 means use default)
         rom_offset: convert_optional_offset_size(config.rom_offset),

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -47,6 +47,7 @@ fn test_emulator_args_creation() {
         _no_stdin_uart: false,
         allow_sideloaded_rom: false,
         flash_based_boot: false,
+        ss_soc_dbg_unlock_level0: false,
         i3c_port: None,
         device_security_state: DeviceLifecycle::Production as u32,
         test_feature: None,

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -111,6 +111,10 @@ pub fn new(init_params: InitParams) -> Result<DefaultHwModel> {
 }
 
 pub struct InitParams<'a> {
+    /// Models the SoC strap `SS_SOC_DBG_UNLOCK_LEVEL[0]` at reset deassertion.
+    /// Combined with `debug_intent` to decide whether the Caliptra security state
+    /// is latched as Production or honours the requested device lifecycle.
+    pub ss_soc_dbg_unlock_level0: bool,
     /// Fuse settings
     pub fuses: Fuses,
     /// The contents of the Caliptra ROM
@@ -264,6 +268,7 @@ impl Default for InitParams<'_> {
                 Box::new(RandomEtrngResponses::new_from_stdrng())
             };
         Self {
+            ss_soc_dbg_unlock_level0: false,
             fuses: Default::default(),
             caliptra_rom: Default::default(),
             caliptra_firmware: Default::default(),

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -331,6 +331,7 @@ impl McuHwModel for ModelEmulated {
 
         let (mut caliptra_cpu, soc_to_caliptra, soc_to_caliptra_bus, ext_mci) =
             start_caliptra(&StartCaliptraArgs {
+                ss_soc_dbg_unlock_level0: params.ss_soc_dbg_unlock_level0,
                 rom: BytesOrPath::Bytes(params.caliptra_rom.to_vec()),
                 device_lifecycle,
                 req_idevid_csr,


### PR DESCRIPTION
### Problem

At reset deassertion the RTL latches the Caliptra security state as

```
unlocked = (debug_intent AND SS_SOC_DBG_UNLOCK_LEVEL[0]) OR ss_dbg_manuf_enable
```

and forces the device lifecycle to Production when not unlocked.

`start_caliptra` hardcoded the result:

```rust
// Since we are at reset deassertion, SS_SOC_DBG_UNLOCK_LEVEL is 0.
// So it should ALWAYS be locked at reset deassertion.
let is_unlocked = false;
```

so the requested device lifecycle is *always* overridden to Production and a
debug-unlocked boot cannot be modelled at all. The comment block above it
already recorded the intended formula and described the hardcode as a stand-in
for the strap the emulator did not have.

### Change

Add the strap as an explicit argument on `StartCaliptraArgs` / `InitParams` and
apply the documented formula. `ss_dbg_manuf_enable` is still not modelled, so
the OR term is omitted and that is called out in the comment rather than left
implicit.

### Compatibility

The new field defaults to `false`. With `debug_intent && false` the result is
`is_unlocked == false` — identical to the hardcoded value — so behaviour is
unchanged for every existing caller unless the new `--ss-soc-dbg-unlock-level0`
flag is passed.

### Validation

- `cargo test -p caliptra-mcu-emulator-periph -p caliptra-mcu-emulator-caliptra`
- `cargo check` across `emulator-app`, `emulator-caliptra`, `hw-model`
- `cargo clippy --all-targets` (no new warnings), `cargo fmt --check`
