### PR TITLE
emulator: add --pc-coverage to log unique MCU program counters

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -50,6 +50,7 @@ use clap_num::maybe_hex;
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, IsTerminal, Read, Write};
 use std::ops::Range;
@@ -151,6 +152,11 @@ pub struct EmulatorArgs {
 
     #[arg(long)]
     pub soc_manifest: PathBuf,
+
+    /// Log unique MCU program counters to `pc.log` in the log directory,
+    /// one PC per line in first-seen order.
+    #[arg(long, default_value_t = false)]
+    pub pc_coverage: bool,
 
     #[arg(long)]
     pub i3c_port: Option<u16>,
@@ -305,6 +311,8 @@ pub struct Emulator {
     pub bmc: Option<Bmc>,
     pub timer: Timer,
     pub trace_file: Option<File>,
+    pub coverage_file: Option<File>,
+    pub coverage_seen: HashSet<u32>,
     pub stdin_uart: Option<Arc<Mutex<Option<u8>>>>,
     pub sram_range: Range<u32>,
     #[allow(dead_code)]
@@ -1139,6 +1147,12 @@ impl Emulator {
             None
         };
 
+        let pc_coverage_trace = if cli.pc_coverage {
+            Some(args_log_dir.join("pc.log"))
+        } else {
+            None
+        };
+
         let sram_range = mcu_root_bus_offsets.ram_offset
             ..mcu_root_bus_offsets.ram_offset + mcu_root_bus_offsets.ram_size;
 
@@ -1148,6 +1162,7 @@ impl Emulator {
             cpu,
             caliptra_cpu,
             instr_trace,
+            pc_coverage_trace,
             stdin_uart,
             bmc,
             sram_range,
@@ -1169,6 +1184,7 @@ impl Emulator {
         mcu_cpu: Cpu<AutoRootBus>,
         caliptra_cpu: Cpu<CaliptraMainRootBus>,
         trace_path: Option<PathBuf>,
+        coverage_path: Option<PathBuf>,
         stdin_uart: Option<Arc<Mutex<Option<u8>>>>,
         bmc: Option<Bmc>,
         sram_range: Range<u32>,
@@ -1198,6 +1214,7 @@ impl Emulator {
 
         let timer = Timer::new(&mcu_cpu.clock.clone());
         let trace_file = trace_path.map(|path| File::create(path).unwrap());
+        let coverage_file = coverage_path.map(|path| File::create(path).unwrap());
 
         Self {
             mcu_cpu,
@@ -1205,6 +1222,8 @@ impl Emulator {
             bmc,
             timer,
             trace_file,
+            coverage_file,
+            coverage_seen: HashSet::new(),
             stdin_uart,
             sram_range,
             clock,
@@ -1256,15 +1275,25 @@ impl Emulator {
         // mid-step clock value.
         let _step_guard = self.step_lock.lock().unwrap();
 
-        let action = if let Some(ref mut trace_file) = self.trace_file {
-            let trace_fn: &mut dyn FnMut(u32, RvInstr) = &mut |pc, instr| match instr {
-                RvInstr::Instr32(instr32) => {
-                    let _ = writeln!(trace_file, "{}", disassemble(pc, instr32));
-                    println!("{{mcu cpu}}      {}", disassemble(pc, instr32));
-                }
-                RvInstr::Instr16(instr16) => {
-                    let _ = writeln!(trace_file, "{}", disassemble(pc, instr16 as u32));
-                    println!("{{mcu cpu}}      {}", disassemble(pc, instr16 as u32));
+        let action = if self.trace_file.is_some() || self.coverage_file.is_some() {
+            let mut trace_file = self.trace_file.as_mut();
+            let mut coverage_file = self.coverage_file.as_mut();
+            let coverage_seen = &mut self.coverage_seen;
+
+            let trace_fn: &mut dyn FnMut(u32, RvInstr) = &mut |pc, instr| {
+                write_unique_pc_coverage_entry(coverage_file.as_deref_mut(), coverage_seen, pc);
+
+                if let Some(file) = trace_file.as_mut() {
+                    match instr {
+                        RvInstr::Instr32(instr32) => {
+                            let _ = writeln!(file, "{}", disassemble(pc, instr32));
+                            println!("{{mcu cpu}}      {}", disassemble(pc, instr32));
+                        }
+                        RvInstr::Instr16(instr16) => {
+                            let _ = writeln!(file, "{}", disassemble(pc, instr16 as u32));
+                            println!("{{mcu cpu}}      {}", disassemble(pc, instr16 as u32));
+                        }
+                    }
                 }
             };
             self.mcu_cpu.step(Some(trace_fn))
@@ -1314,6 +1343,18 @@ impl Emulator {
     /// Get the current program counter (PC) of the MCU CPU
     pub fn get_pc(&self) -> u32 {
         self.mcu_cpu.read_pc()
+    }
+}
+
+fn write_unique_pc_coverage_entry(
+    coverage_file: Option<&mut File>,
+    coverage_seen: &mut HashSet<u32>,
+    pc: u32,
+) {
+    if let Some(file) = coverage_file {
+        if coverage_seen.insert(pc) {
+            let _ = writeln!(file, "0x{:08x}", pc);
+        }
     }
 }
 

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -350,6 +350,7 @@ pub unsafe extern "C" fn emulator_init(
             config.hw_revision_patch as u64,
         ),
         flash_based_boot: config.flash_based_boot != 0,
+        pc_coverage: false,
         allow_sideloaded_rom: config.allow_sideloaded_rom != 0,
         // Use provided offset and size override parameters (-1 means use default)
         rom_offset: convert_optional_offset_size(config.rom_offset),

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -47,6 +47,7 @@ fn test_emulator_args_creation() {
         _no_stdin_uart: false,
         allow_sideloaded_rom: false,
         flash_based_boot: false,
+        pc_coverage: false,
         i3c_port: None,
         device_security_state: DeviceLifecycle::Production as u32,
         test_feature: None,


### PR DESCRIPTION
### What this adds

An opt-in `--pc-coverage` flag that records every distinct MCU program counter
to `pc.log` in the log directory, one PC per line in first-seen order.

This gives a cheap coverage signal for ROM and runtime firmware — which blocks
were reached on a given run — without standing up an external tracer or
instrumenting the firmware build.

### Implementation

`--trace-instr` already installs a per-instruction step callback, so the
coverage hook reuses it rather than adding a second one:

- the callback is installed when **either** option is set
- the existing tracing logic is nested inside it unchanged, so disassembly
  output is byte-for-byte identical
- dedup is a `HashSet<u32>`; only first-seen PCs are written

The two features are fully independent — either, both, or neither can be
enabled. With neither set the callback is not installed at all, so the hot
stepping path is exactly as it is today.

### Validation

- `cargo test -p caliptra-mcu-emulator-periph -p caliptra-mcu-emulator-caliptra`
- `cargo check`, `cargo clippy --all-targets` (no new warnings), `cargo fmt --check`
