### PR TITLE
[kernel] fix partial-word truncation in mailbox response copying

### DIFF
--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -548,9 +548,14 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         match driver.finish_mailbox_resp(self.resp_min_size.get(), self.resp_size.get()) {
             Ok(resp_option) => {
                 if let Some(mut resp) = resp_option {
+                    let out_len = output.len();
                     for (i, word) in (&mut resp).enumerate() {
-                        if let Some(out) = output.get(i * 4..((i + 1) * 4)) {
-                            out.copy_from_slice(&word.to_le_bytes());
+                        let start = i * 4;
+                        if start < out_len {
+                            let end = (start + 4).min(out_len);
+                            if let Some(out) = output.get(start..end) {
+                                out.copy_from_slice(&word.to_le_bytes()[..end - start]);
+                            }
                         }
                     }
                     resp.verify_checksum().map(|_| resp.len())


### PR DESCRIPTION
When copying 32-bit mailbox response words into a userspace process slice, copy_from_mailbox indexed full 4-byte ranges. If the userspace slice length was not a multiple of 4, the slice access for the trailing partial word returned None, silently dropping the final 1-3 bytes of the payload.

Turns out this was an edge case I hit when trying to retrieve the MLDSA cert chain, but only in GET_DIGESTS and not GET_CERTIFICATE, as MCU fetches the cert chain with different offsets between the two