### PR TITLE
Removing the no_default_features flag in size history

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -116,7 +116,6 @@ fn build_runtime(target_dir: &Path) -> Result<PathBuf> {
             platform: Some("fpga"),
             features: Some("release"),
             profile: Some("release"),
-            no_default_features: true,
             target_dir: Some(target_dir.to_path_buf()),
             ..Default::default()
         });


### PR DESCRIPTION
The no_default_features flag has been incorrectly set in the size-history, resulting in some features being removed when doing size calculations. 