### PR TITLE
ocp-lock: support and verify ML-DSA signatures from DPE for EKP reports

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -2136,6 +2136,7 @@ pub struct GetOcpLockEpochKeyReportReq {
     /// SEK state (0=Unused, 1=Programmed, 2=Sanitized)
     pub sek_state: u16,
     pub reserved: u16,
+    pub algorithm: EndorsementAlgorithm,
 }
 impl Request for GetOcpLockEpochKeyReportReq {
     const ID: CommandId = CommandId::MC_GET_OCP_LOCK_EPOCH_KEY_REPORT;
@@ -2146,13 +2147,13 @@ impl Request for GetOcpLockEpochKeyReportReq {
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetOcpLockEpochKeyReportResp {
     pub hdr: MailboxRespHeaderVarSize,
-    pub data: [u8; MAX_RESP_DATA_SIZE],
+    pub data: [u8; MAX_ENDORSEMENT_CERT_SIZE],
 }
 impl Default for GetOcpLockEpochKeyReportResp {
     fn default() -> Self {
         Self {
             hdr: MailboxRespHeaderVarSize::default(),
-            data: [0u8; MAX_RESP_DATA_SIZE],
+            data: [0u8; MAX_ENDORSEMENT_CERT_SIZE],
         }
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -18,7 +18,7 @@ use caliptra_mcu_config::version::get_mcu_runtime_version;
 use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
 #[cfg(feature = "ocp-lock")]
 use caliptra_mcu_libapi_caliptra::ocp_lock::{
-    EndorsementAlgorithm, HpkeHandle, OcpLock, OcpLockEnumerateHpkeHandlesResp,
+    HpkeHandle, OcpLock, OcpLockEnumerateHpkeHandlesResp,
 };
 #[cfg(feature = "ocp-lock")]
 use caliptra_mcu_libapi_caliptra::signer::CaliptraDpeSigner;
@@ -513,11 +513,15 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         &self,
         nonce: &[u8; 32],
         sek_state: caliptra_mcu_mbox_common::messages::SekState,
+        algorithm: MboxEndorsementAlgorithm,
         report_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize> {
+        let algo = algorithm
+            .try_into()
+            .map_err(|_| CaliptraCompletionCode::InvalidParameter)?;
         let mailbox = Mailbox::new();
         let ocp_lock = OcpLock::new(&mailbox, &crate::ocp_lock_config::APP_RUNTIME_CONFIG);
-        let signer = CaliptraDpeSigner::new(&mailbox);
+        let signer = CaliptraDpeSigner::with_algorithm(&mailbox, algo);
 
         let len = ocp_lock
             .get_ocp_lock_epoch_key_report(nonce, sek_state, &signer, report_buf)

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -529,9 +529,10 @@ pub trait CaliptraCmdHandler {
         &self,
         nonce: &[u8; 32],
         sek_state: SekState,
+        algorithm: EndorsementAlgorithm,
         report_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize> {
-        let _ = (nonce, sek_state, report_buf);
+        let _ = (nonce, sek_state, algorithm, report_buf);
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
 

--- a/runtime/userspace/api/caliptra-libapi/src/ocp_lock.rs
+++ b/runtime/userspace/api/caliptra-libapi/src/ocp_lock.rs
@@ -722,15 +722,18 @@ impl<'a> OcpLock<'a> {
         )
         .await?;
 
-        let mut signature = [0u8; 96];
-        signer
-            .sign(Self::EKP_DPE_LABEL, &digest, &mut signature)
-            .await?;
+        let sig_len = signer.signature_size();
+        if report_buf.len() < sig_len {
+            return Err(CaliptraApiError::InvalidArgBufferTooSmall);
+        }
+        let (out_buf, sig_buf) = report_buf.split_at_mut(report_buf.len() - sig_len);
 
-        let mut report_encoder = CborEncoder::new(report_buf);
+        signer.sign(Self::EKP_DPE_LABEL, &digest, sig_buf).await?;
+
+        let mut report_encoder = CborEncoder::new(out_buf);
         EkpEvidence::assemble_cose_sign1(
             &evidence_buf[..evidence_len],
-            &signature,
+            sig_buf,
             &mut report_encoder,
         )?;
 

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -1031,36 +1031,31 @@ impl<'a, H: CaliptraCmdHandler, A: CommandAuthorizer, Alloc: McuMboxScratch>
         let sek_state = caliptra_mcu_mbox_common::messages::SekState::try_from(req.sek_state)
             .map_err(|_| errors::INVALID_PARAMS)?;
 
-        let mut data = [0u8; MAX_RESP_DATA_SIZE];
+        let (resp, _) = GetOcpLockEpochKeyReportResp::mut_from_prefix(resp_buf)
+            .map_err(|_| errors::INVALID_PARAMS)?;
+        *resp = GetOcpLockEpochKeyReportResp::default();
+
         let ret = self
             .non_crypto_cmds_handler
-            .get_ocp_lock_epoch_key_report(&req.nonce, sek_state, &mut data)
+            .get_ocp_lock_epoch_key_report(&req.nonce, sek_state, req.algorithm, &mut resp.data)
             .await;
 
         let (mbox_cmd_status, data_len) = match ret {
-            Ok(len) if len <= MAX_RESP_DATA_SIZE => (MbxCmdStatus::Complete, len),
+            Ok(len) => (MbxCmdStatus::Complete, len.min(resp.data.len())),
             _ => (MbxCmdStatus::Failure, 0),
         };
 
-        let resp = if mbox_cmd_status == MbxCmdStatus::Complete {
-            GetOcpLockEpochKeyReportResp {
-                hdr: MailboxRespHeaderVarSize {
-                    data_len: data_len as u32,
-                    ..Default::default()
-                },
-                data,
-            }
+        if mbox_cmd_status == MbxCmdStatus::Complete {
+            resp.hdr = MailboxRespHeaderVarSize {
+                data_len: data_len as u32,
+                ..Default::default()
+            };
         } else {
-            GetOcpLockEpochKeyReportResp::default()
-        };
+            *resp = GetOcpLockEpochKeyReportResp::default();
+        }
 
-        let resp_bytes = resp
-            .as_bytes_partial()
-            .map_err(|_| errors::MCU_MBOX_COMMON)?;
-
-        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
-
-        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
+        let partial_len = resp.partial_len().map_err(|_| errors::MCU_MBOX_COMMON)?;
+        Ok((&mut resp_buf[..partial_len], mbox_cmd_status))
     }
 
     async fn handle_get_auth_cmd_challenge<'r>(
@@ -1732,6 +1727,10 @@ fn response_buffer_size<H: CaliptraCmdHandler>(cmd: u32) -> usize {
         #[cfg(feature = "ocp-lock")]
         c if c == CommandId::MC_OCP_LOCK_ENUMERATE_HPKE_HANDLES => {
             size_of::<OcpLockEnumerateHpkeHandlesResp>()
+        }
+        #[cfg(feature = "ocp-lock")]
+        c if c == CommandId::MC_GET_OCP_LOCK_EPOCH_KEY_REPORT => {
+            size_of::<GetOcpLockEpochKeyReportResp>()
         }
         c if c == CommandId::MC_DPE_SIGNER_CONTEXT_CERT => size_of::<DpeSignerContextCertResp>(),
         c if c == CommandId::MC_GET_DPE_CERTIFICATE_CHAIN => {

--- a/tests/integration/src/test_ekp.rs
+++ b/tests/integration/src/test_ekp.rs
@@ -55,6 +55,7 @@ mod test {
     struct EkpReport {
         protected_hdr: Vec<u8>,
         payload: Vec<u8>,
+        tbs_digest: [u8; 48],
         signature: Vec<u8>,
         map_label: String,
         version: String,
@@ -98,6 +99,16 @@ mod test {
 
         // Signature byte string
         let signature = outer_decoder.bytes().expect("parse signature").to_vec();
+
+        // Reconstruct COSE_Sign1 Sig_structure: ["Signature1", protected_hdr, external_aad, payload]
+        let mut sig_struct_buf = Vec::new();
+        let mut encoder = minicbor::Encoder::new(&mut sig_struct_buf);
+        encoder.array(4).unwrap();
+        encoder.str("Signature1").unwrap();
+        encoder.bytes(&protected_hdr).unwrap();
+        encoder.bytes(&[]).unwrap();
+        encoder.bytes(payload).unwrap();
+        let tbs_digest: [u8; 48] = Sha384::digest(&sig_struct_buf).into();
 
         // Decode EKP evidence map from payload
         let mut payload_decoder = Decoder::new(payload);
@@ -185,6 +196,7 @@ mod test {
         EkpReport {
             protected_hdr,
             payload: payload.to_vec(),
+            tbs_digest,
             signature,
             map_label,
             version,
@@ -198,31 +210,7 @@ mod test {
         }
     }
 
-    fn verify_ekp_report(
-        report: &EkpReport,
-        expected_nonce: &[u8; 32],
-        expected_ekp_allowed: bool,
-        expected_max_sanitizations: u16,
-        expected_remaining_sanitizations: u16,
-        expected_active_hek_state: u16,
-        expected_sek_state: u16,
-        expected_hek_state_list: &[u16],
-        algo: EndorsementAlgorithm,
-        dpe_cert_der: &[u8],
-    ) {
-        assert_eq!(report.protected_hdr, &[0xA0]);
-
-        // Reconstruct COSE_Sign1 Sig_structure: ["Signature1", protected_hdr, external_aad, payload]
-        let mut sig_struct_buf = Vec::new();
-        let mut encoder = minicbor::Encoder::new(&mut sig_struct_buf);
-        encoder.array(4).unwrap();
-        encoder.str("Signature1").unwrap();
-        encoder.bytes(&report.protected_hdr).unwrap();
-        encoder.bytes(&[]).unwrap();
-        encoder.bytes(&report.payload).unwrap();
-
-        let tbs_digest: [u8; 48] = Sha384::digest(&sig_struct_buf).into();
-
+    fn verify_dpe_signature(report: &EkpReport, algo: EndorsementAlgorithm, dpe_cert_der: &[u8]) {
         match algo {
             EndorsementAlgorithm::ECDSA_384 => {
                 assert_eq!(report.signature.len(), 96);
@@ -237,7 +225,7 @@ mod test {
                 let s = openssl::bn::BigNum::from_slice(&report.signature[48..96]).unwrap();
                 let sig = openssl::ecdsa::EcdsaSig::from_private_components(r, s).unwrap();
                 assert!(
-                    sig.verify(&tbs_digest, &dpe_ec_key).unwrap(),
+                    sig.verify(&report.tbs_digest, &dpe_ec_key).unwrap(),
                     "EKP report signature must be validly signed by DPE signer context ECDSA public key"
                 );
             }
@@ -270,12 +258,29 @@ mod test {
                     .try_into()
                     .expect("ML-DSA-87 signature length mismatch");
                 assert!(
-                    mldsa_verifying_key.verify(&tbs_digest, &mldsa_sig, &[]),
+                    mldsa_verifying_key.verify(&report.tbs_digest, &mldsa_sig, &[]),
                     "EKP report signature must be validly signed by DPE signer context ML-DSA public key"
                 );
             }
             _ => panic!("Unsupported endorsement algorithm: {:?}", algo),
         }
+    }
+
+    fn verify_ekp_report(
+        report: &EkpReport,
+        expected_nonce: &[u8; 32],
+        expected_ekp_allowed: bool,
+        expected_max_sanitizations: u16,
+        expected_remaining_sanitizations: u16,
+        expected_active_hek_state: u16,
+        expected_sek_state: u16,
+        expected_hek_state_list: &[u16],
+        algo: EndorsementAlgorithm,
+        dpe_cert_der: &[u8],
+    ) {
+        assert_eq!(report.protected_hdr, &[0xA0]);
+
+        verify_dpe_signature(report, algo, dpe_cert_der);
 
         assert_eq!(report.map_label, MAP_LABEL_VAL);
         assert_eq!(report.version, VERSION_VAL);
@@ -345,39 +350,47 @@ mod test {
 
     #[test]
     fn test_ekp_attested_report_with_perma_bit_set() {
-        let algo = EndorsementAlgorithm::MLDSA_87;
-        let (data, nonce, dpe_cert_der) = run_ekp_report_test(true, algo);
-        let report = parse_ekp_report(&data);
-        verify_ekp_report(
-            &report,
-            &nonce,
-            false,
-            8,
-            0,
-            4,
-            1,
-            &[4, 4, 4, 4, 4, 4, 4, 4],
-            algo,
-            &dpe_cert_der,
-        );
+        for algo in [
+            EndorsementAlgorithm::ECDSA_384,
+            EndorsementAlgorithm::MLDSA_87,
+        ] {
+            let (data, nonce, dpe_cert_der) = run_ekp_report_test(true, algo);
+            let report = parse_ekp_report(&data);
+            verify_ekp_report(
+                &report,
+                &nonce,
+                false,
+                8,
+                0,
+                4,
+                1,
+                &[4, 4, 4, 4, 4, 4, 4, 4],
+                algo,
+                &dpe_cert_der,
+            );
+        }
     }
 
     #[test]
     fn test_ekp_attested_report_without_perma_bit_set() {
-        let algo = EndorsementAlgorithm::MLDSA_87;
-        let (data, nonce, dpe_cert_der) = run_ekp_report_test(false, algo);
-        let report = parse_ekp_report(&data);
-        verify_ekp_report(
-            &report,
-            &nonce,
-            false,
-            8,
-            6,
-            1,
-            1,
-            &[5, 1, 0, 5, 1, 0, 0, 1],
-            algo,
-            &dpe_cert_der,
-        );
+        for algo in [
+            EndorsementAlgorithm::ECDSA_384,
+            EndorsementAlgorithm::MLDSA_87,
+        ] {
+            let (data, nonce, dpe_cert_der) = run_ekp_report_test(false, algo);
+            let report = parse_ekp_report(&data);
+            verify_ekp_report(
+                &report,
+                &nonce,
+                false,
+                8,
+                6,
+                1,
+                1,
+                &[5, 1, 0, 5, 1, 0, 0, 1],
+                algo,
+                &dpe_cert_der,
+            );
+        }
     }
 }

--- a/tests/integration/src/test_ekp.rs
+++ b/tests/integration/src/test_ekp.rs
@@ -2,19 +2,19 @@
 
 #[cfg(all(test, not(feature = "fpga_realtime")))]
 mod test {
-    use crate::test::{
-        mailbox_execute_with_timeout, start_runtime_hw_model, TestParams, TEST_LOCK,
-    };
+    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
     use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_mbox_common::messages::{
-        DpeSignerContextCertReq, GetOcpLockEpochKeyReportReq, MailboxReqHeader,
-        MailboxRespHeaderVarSize, McuMailboxReq, SekState,
+        DpeSignerContextCertReq, EndorsementAlgorithm, GetOcpLockEpochKeyReportReq,
+        MailboxReqHeader, SekState,
     };
     use caliptra_mcu_romtime::McuBootMilestones;
+    use fips204::traits::{SerDes, Verifier as MldsaVerifier};
     use minicbor::data::Type;
     use minicbor::Decoder;
-    use std::mem::size_of;
-    use zerocopy::FromBytes;
+    use sha2::{Digest, Sha384};
+    use x509_parser::nom::Parser;
+    use x509_parser::prelude::X509CertificateParser;
 
     const MAP_LABEL_CLAIM: u64 = 0;
     const VERSION_CLAIM: u64 = 1;
@@ -54,6 +54,7 @@ mod test {
     #[derive(Debug, PartialEq, Eq)]
     struct EkpReport {
         protected_hdr: Vec<u8>,
+        payload: Vec<u8>,
         signature: Vec<u8>,
         map_label: String,
         version: String,
@@ -183,6 +184,7 @@ mod test {
 
         EkpReport {
             protected_hdr,
+            payload: payload.to_vec(),
             signature,
             map_label,
             version,
@@ -205,9 +207,75 @@ mod test {
         expected_active_hek_state: u16,
         expected_sek_state: u16,
         expected_hek_state_list: &[u16],
+        algo: EndorsementAlgorithm,
+        dpe_cert_der: &[u8],
     ) {
         assert_eq!(report.protected_hdr, &[0xA0]);
-        assert_eq!(report.signature.len(), 96);
+
+        // Reconstruct COSE_Sign1 Sig_structure: ["Signature1", protected_hdr, external_aad, payload]
+        let mut sig_struct_buf = Vec::new();
+        let mut encoder = minicbor::Encoder::new(&mut sig_struct_buf);
+        encoder.array(4).unwrap();
+        encoder.str("Signature1").unwrap();
+        encoder.bytes(&report.protected_hdr).unwrap();
+        encoder.bytes(&[]).unwrap();
+        encoder.bytes(&report.payload).unwrap();
+
+        let tbs_digest: [u8; 48] = Sha384::digest(&sig_struct_buf).into();
+
+        match algo {
+            EndorsementAlgorithm::ECDSA_384 => {
+                assert_eq!(report.signature.len(), 96);
+                let dpe_cert = openssl::x509::X509::from_der(dpe_cert_der)
+                    .expect("Failed to parse DPE signer context certificate");
+                let dpe_ec_key = dpe_cert
+                    .public_key()
+                    .expect("DPE cert public key")
+                    .ec_key()
+                    .expect("DPE cert EC key");
+                let r = openssl::bn::BigNum::from_slice(&report.signature[..48]).unwrap();
+                let s = openssl::bn::BigNum::from_slice(&report.signature[48..96]).unwrap();
+                let sig = openssl::ecdsa::EcdsaSig::from_private_components(r, s).unwrap();
+                assert!(
+                    sig.verify(&tbs_digest, &dpe_ec_key).unwrap(),
+                    "EKP report signature must be validly signed by DPE signer context ECDSA public key"
+                );
+            }
+            EndorsementAlgorithm::MLDSA_87 => {
+                assert_eq!(report.signature.len(), 4627);
+                let mut dpe_parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+                let (_, parsed_dpe_cert) = dpe_parser
+                    .parse(dpe_cert_der)
+                    .expect("Failed to parse ML-DSA DPE signer context certificate");
+                let dpe_mldsa_pubkey_bytes = &parsed_dpe_cert
+                    .tbs_certificate
+                    .public_key()
+                    .subject_public_key
+                    .data;
+                assert_eq!(
+                    dpe_mldsa_pubkey_bytes.len(),
+                    2592,
+                    "ML-DSA-87 public key must be 2592 bytes"
+                );
+                let dpe_mldsa_pubkey_arr: [u8; 2592] = dpe_mldsa_pubkey_bytes
+                    .as_ref()
+                    .try_into()
+                    .expect("Invalid ML-DSA-87 public key size");
+                let mldsa_verifying_key =
+                    fips204::ml_dsa_87::PublicKey::try_from_bytes(dpe_mldsa_pubkey_arr)
+                        .expect("Failed to construct ML-DSA-87 PublicKey");
+                let mldsa_sig: [u8; 4627] = report
+                    .signature
+                    .as_slice()
+                    .try_into()
+                    .expect("ML-DSA-87 signature length mismatch");
+                assert!(
+                    mldsa_verifying_key.verify(&tbs_digest, &mldsa_sig, &[]),
+                    "EKP report signature must be validly signed by DPE signer context ML-DSA public key"
+                );
+            }
+            _ => panic!("Unsupported endorsement algorithm: {:?}", algo),
+        }
 
         assert_eq!(report.map_label, MAP_LABEL_VAL);
         assert_eq!(report.version, VERSION_VAL);
@@ -223,7 +291,10 @@ mod test {
         assert_eq!(report.hek_state_list, expected_hek_state_list);
     }
 
-    fn run_ekp_report_test(set_perma: bool) -> (Vec<u8>, [u8; 32]) {
+    fn run_ekp_report_test(
+        set_perma: bool,
+        algo: EndorsementAlgorithm,
+    ) -> (Vec<u8>, [u8; 32], Vec<u8>) {
         let _lock = TEST_LOCK.lock().unwrap();
         let otp = setup_ekp_test_otp(set_perma);
 
@@ -243,42 +314,39 @@ mod test {
         });
 
         // Initialize DPE signer by retrieving the signer context certificate
-        let dpe_req = DpeSignerContextCertReq::default();
-        let _dpe_resp = hw
+        let dpe_req = DpeSignerContextCertReq {
+            algorithm: algo,
+            ..Default::default()
+        };
+        let dpe_resp = hw
             .mailbox_execute_req(dpe_req)
             .expect("DPE signer context cert request failed");
+        let dpe_cert_len = dpe_resp.hdr.data_len as usize;
+        let dpe_cert_der = dpe_resp.cert_data[..dpe_cert_len].to_vec();
 
         let nonce = [0xAAu8; 32];
         let sek_state = SekState::Programmed;
 
-        let mut req = McuMailboxReq::GetOcpLockEpochKeyReport(GetOcpLockEpochKeyReportReq {
+        let req = GetOcpLockEpochKeyReportReq {
             hdr: MailboxReqHeader::default(),
             nonce,
             sek_state: sek_state as u16,
             reserved: 0,
-        });
-        req.populate_chksum().expect("populate_chksum");
-        let cmd = req.cmd_code().0;
-        let payload = req.as_bytes().expect("as_bytes").to_vec();
+            algorithm: algo,
+        };
+        let resp = hw
+            .mailbox_execute_req(req)
+            .expect("GetOcpLockEpochKeyReport mailbox command failed");
+        let data_len = resp.hdr.data_len as usize;
+        let data = resp.data[..data_len].to_vec();
 
-        let resp_bytes = mailbox_execute_with_timeout(&mut hw, cmd, &payload)
-            .expect("GetOcpLockEpochKeyReport mailbox command failed")
-            .unwrap_or_default();
-
-        const HDR_LEN: usize = size_of::<MailboxRespHeaderVarSize>();
-        assert!(resp_bytes.len() >= HDR_LEN);
-
-        let hdr = MailboxRespHeaderVarSize::read_from_bytes(&resp_bytes[..HDR_LEN])
-            .expect("parse response header");
-        let data_len = hdr.data_len as usize;
-        let data = resp_bytes[HDR_LEN..HDR_LEN + data_len].to_vec();
-
-        (data, nonce)
+        (data, nonce, dpe_cert_der)
     }
 
     #[test]
     fn test_ekp_attested_report_with_perma_bit_set() {
-        let (data, nonce) = run_ekp_report_test(true);
+        let algo = EndorsementAlgorithm::MLDSA_87;
+        let (data, nonce, dpe_cert_der) = run_ekp_report_test(true, algo);
         let report = parse_ekp_report(&data);
         verify_ekp_report(
             &report,
@@ -289,12 +357,15 @@ mod test {
             4,
             1,
             &[4, 4, 4, 4, 4, 4, 4, 4],
+            algo,
+            &dpe_cert_der,
         );
     }
 
     #[test]
     fn test_ekp_attested_report_without_perma_bit_set() {
-        let (data, nonce) = run_ekp_report_test(false);
+        let algo = EndorsementAlgorithm::MLDSA_87;
+        let (data, nonce, dpe_cert_der) = run_ekp_report_test(false, algo);
         let report = parse_ekp_report(&data);
         verify_ekp_report(
             &report,
@@ -305,6 +376,8 @@ mod test {
             1,
             1,
             &[5, 1, 0, 5, 1, 0, 0, 1],
+            algo,
+            &dpe_cert_der,
         );
     }
 }


### PR DESCRIPTION
- Add algorithm field to GetOcpLockEpochKeyReportReq to select EndorsementAlgorithm.
- Expand GetOcpLockEpochKeyReportResp data buffer to MAX_ENDORSEMENT_CERT_SIZE to fit ML-DSA-87 signatures.
- Update CaliptraCmdHandler trait and cmd_interface to forward algorithm and zero-copy write into resp_buf.
- Update CaliptraCmdBackend in user-app to initialize CaliptraDpeSigner::with_algorithm.
- Dynamically size signature buffer in ocp_lock.rs without heap allocations.
- Refactor run_ekp_report_test and verify_ekp_report in test_ekp.rs to accept EndorsementAlgorithm, and verify COSE_Sign1 Sig_structure signatures against DPE signer public keys (ECDSA and ML-DSA).
- Update existing EKP integration tests to verify ML-DSA signatures from the DPE signer.