### PR TITLE
spdm: separate streamed and buffered message limits

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
@@ -5,10 +5,11 @@ use caliptra_mcu_scratch_alloc::{BitmapAllocator, StaticBitmapAllocatorCell, BIT
 use core::ptr::NonNull;
 use mcu_caliptra_api::{
     cm_hmac, cm_import, dpe_certify_key_pubkey, dpe_sign_ecc_p384, ecdh_finish, ecdh_generate,
-    ecdsa_verify, hash_all, hkdf_expand, hkdf_extract, rng_generate, sha_finish, sha_init,
-    sha_update, spdm_aes_gcm_decrypt, spdm_aes_gcm_encrypt, CmKeyUsage, HashAlgo, HkdfSalt,
+    ecdsa_verify, hash_all, hkdf_expand, hkdf_extract, mldsa87_compute_mu, mldsa87_compute_tr,
+    rng_generate, sha_finish, sha_init, sha_update, spdm_aes_gcm_decrypt, spdm_aes_gcm_encrypt,
+    CmKeyUsage, HashAlgo, HkdfSalt, CERTIFY_KEY_MLDSA87_PUBKEY_SIZE,
     CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, DPE_LABEL_LEN,
-    DPE_P384_SIGNATURE_SIZE, SHA_CONTEXT_SIZE,
+    DPE_MLDSA87_MU_SIZE, DPE_P384_SIGNATURE_SIZE, MLDSA87_TR_SIZE, SHA_CONTEXT_SIZE,
 };
 
 const CRYPTO_SCRATCH_SIZE: usize = 16 * 1024;
@@ -45,7 +46,50 @@ pub async fn test_caliptra_sha(alloc: &BitmapAllocator) {
     ];
     test_sha(alloc, DATA, HashAlgo::Sha384, &SHA384).await;
     test_sha(alloc, DATA, HashAlgo::Sha512, &SHA512).await;
+    test_mldsa87_message_representative(alloc).await;
     println!("SHA test completed successfully");
+}
+
+async fn test_mldsa87_message_representative(alloc: &BitmapAllocator) {
+    const RAW_PUBLIC_KEY: [u8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE] =
+        [0xa5; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE];
+    const CONTEXT: &[u8] = b"Caliptra EAT";
+    const MESSAGE_COMPONENT: [u8; 32] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f,
+    ];
+    const EXPECTED_TR: [u8; MLDSA87_TR_SIZE] = [
+        0x86, 0x5a, 0xcd, 0x16, 0xa5, 0xe1, 0x9e, 0x9c, 0x6b, 0x52, 0x52, 0x60, 0x83, 0xcf, 0x3d,
+        0xfb, 0xcc, 0x59, 0x6c, 0x2b, 0xe3, 0xc3, 0x85, 0xa2, 0x56, 0x99, 0x39, 0x9c, 0x91, 0x82,
+        0xff, 0x98, 0x5b, 0x89, 0xfc, 0x3c, 0xc6, 0x5f, 0x18, 0xa3, 0xda, 0x1a, 0x16, 0xac, 0x3f,
+        0xa1, 0xba, 0x54, 0x3c, 0x57, 0xe0, 0xb8, 0x72, 0xda, 0x2b, 0xa5, 0xa6, 0x8d, 0x6a, 0xd7,
+        0xad, 0x37, 0xac, 0x5e,
+    ];
+    const EXPECTED_MU: [u8; DPE_MLDSA87_MU_SIZE] = [
+        0x7a, 0x5c, 0xb5, 0x0b, 0xe8, 0xf4, 0x65, 0xde, 0xa1, 0xb6, 0xb4, 0xf4, 0xef, 0x6f, 0x38,
+        0x1f, 0x69, 0x3b, 0x31, 0xc1, 0xb7, 0x15, 0x72, 0x4f, 0xed, 0x29, 0xa9, 0x39, 0x3a, 0xf0,
+        0xf4, 0x24, 0x02, 0xd3, 0xe0, 0x0a, 0x4f, 0x2e, 0x1b, 0x35, 0x50, 0x0e, 0x4c, 0x73, 0x32,
+        0xa8, 0x12, 0x39, 0x96, 0x94, 0xff, 0x38, 0xec, 0x06, 0x52, 0xba, 0x16, 0x2a, 0x6c, 0x87,
+        0xca, 0xa0, 0xee, 0xca,
+    ];
+
+    let mut tr = [0u8; MLDSA87_TR_SIZE];
+    mldsa87_compute_tr(alloc, &RAW_PUBLIC_KEY, &mut tr)
+        .await
+        .unwrap_or_else(|_| test_exit(1));
+    if tr != EXPECTED_TR {
+        test_exit(1);
+    }
+
+    let message_parts: [&[u8]; 3] = [b"Signature1", &MESSAGE_COMPONENT, b"payload"];
+    let mut mu = [0u8; DPE_MLDSA87_MU_SIZE];
+    mldsa87_compute_mu(alloc, &tr, CONTEXT, &message_parts, &mut mu)
+        .await
+        .unwrap_or_else(|_| test_exit(1));
+    if mu != EXPECTED_MU {
+        test_exit(1);
+    }
 }
 
 async fn test_sha(alloc: &BitmapAllocator, data: &[u8], algo: HashAlgo, expected: &[u8]) {

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -82,7 +82,10 @@ all-features = [
   "userspace-log",
   "mctp-vdm-service",
 ]
-spdm = ["mcu-mbox-service"]
+spdm = [
+  "mcu-mbox-service",
+  "caliptra-mcu-spdm-stack/generic-large-request",
+]
 streaming-boot = []
 flash-boot = []
 firmware-update = []
@@ -94,7 +97,6 @@ dot-mci-mailbox = [
 dot-spdm-vdm = [
   "spdm",
   "caliptra-mcu-spdm-vdm-handler/device-ownership-transfer",
-  "caliptra-mcu-spdm-stack/generic-large-request",
 ]
 # Test-only mock command handler for integration-test device identity responses.
 mcu-mbox-test-handlers = ["mcu-mbox-service"]

--- a/platforms/emulator/runtime/userspace/apps/user/src/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/cert_store/mod.rs
@@ -70,9 +70,15 @@ struct CertStoreBootScratchSlot([u8; BITMAP_SLOT_SIZE]);
 static CERT_STORE: SharedCertStore = SharedCertStore::new();
 
 #[cfg(feature = "test-mctp-spdm-set-certificate")]
-const MANAGED_SLOT_COUNT: usize = 2;
+const MANAGED_ENDORSEMENT_SLOTS: &[(usize, u8)] = &[(1, OWNER_SPDM_SLOT), (2, TENANT_SPDM_SLOT)];
 #[cfg(feature = "test-mctp-spdm-set-certificate")]
-const MANAGED_SLOT_REGION_SIZE: usize = CERT_STORE_PARTITION.size / MANAGED_SLOT_COUNT;
+const MANAGED_SLOT_COUNT: usize = MANAGED_ENDORSEMENT_SLOTS.len();
+#[cfg(feature = "test-mctp-spdm-set-certificate")]
+const MANAGED_SLOT_REGION_SIZE: usize = {
+    assert!(MANAGED_SLOT_COUNT != 0);
+    assert!(CERT_STORE_PARTITION.size % MANAGED_SLOT_COUNT == 0);
+    CERT_STORE_PARTITION.size / MANAGED_SLOT_COUNT
+};
 
 /// Initialize Caliptra identity chains before any SPDM or MCU-mailbox task can
 /// contend for the mailbox, then configure SPDM endorsements when enabled.
@@ -145,24 +151,19 @@ async fn setup_endorsements<A: ApiAlloc>(store: &SharedCertStore, alloc: &A) -> 
     // production authorization/key-binding policy exists.
     #[cfg(feature = "test-mctp-spdm-set-certificate")]
     {
-        store
-            .set_managed_endorsement(
-                1,
-                OWNER_SPDM_SLOT,
-                CERT_STORE_PARTITION.driver_num,
-                0,
-                MANAGED_SLOT_REGION_SIZE,
-            )
-            .await?;
-        store
-            .set_managed_endorsement(
-                2,
-                TENANT_SPDM_SLOT,
-                CERT_STORE_PARTITION.driver_num,
-                MANAGED_SLOT_REGION_SIZE,
-                MANAGED_SLOT_REGION_SIZE,
-            )
-            .await?;
+        for (region, (store_slot, spdm_slot)) in
+            MANAGED_ENDORSEMENT_SLOTS.iter().copied().enumerate()
+        {
+            store
+                .set_managed_endorsement(
+                    store_slot,
+                    spdm_slot,
+                    CERT_STORE_PARTITION.driver_num,
+                    region * MANAGED_SLOT_REGION_SIZE,
+                    MANAGED_SLOT_REGION_SIZE,
+                )
+                .await?;
+        }
     }
 
     Ok(())

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -142,19 +142,17 @@ impl SpdmVdmBackend for AppVdmBackend {
         }
     }
 
-    async fn handle_request<Alloc, Io>(
+    fn handle_request<Alloc, Io>(
         &self,
         req: &[u8],
         rsp: VdmResponseBuffer<'_, Alloc, Io>,
-    ) -> McuResult<VdmResponse>
+    ) -> impl core::future::Future<Output = McuResult<VdmResponse>>
     where
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,
     {
-        match &self.0 {
-            Some(backend) => backend.handle_request(req, rsp).await,
-            None => Err(mcu_error::codes::NOT_IMPLEMENTED),
-        }
+        // The stack calls handle_request only after match_id succeeds.
+        self.0.as_ref().unwrap().handle_request(req, rsp)
     }
 }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -36,56 +36,93 @@ use core::fmt::Write as _;
 use core::ptr::NonNull;
 use embassy_executor::Spawner;
 
-/// Largest single in-flight SPDM message (request or response) this responder
-/// supports.
+/// Scratch-backed limit for large messages retained in full.
 ///
-/// This is a contract, not a measurement: it is advertised verbatim as
-/// `MaxSPDMmsgSize` in `CAPABILITIES`, so each responder scratch pool must be
-/// able to satisfy it. Raising this requires raising both scratch pools; the
-/// assertions below enforce that.
-///
-/// Sized to cover both directions, because `MaxSPDMmsgSize` caps every SPDM
-/// message and the `CHUNK_SEND` admission check compares against it before the
-/// streaming path is reached:
-///
-/// * Responses — the largest evidence this build can emit (an ML-DSA-87 PCR
-///   quote is 6388 bytes) plus SPDM and vendor-defined framing.
-/// * Requests — the production debug unlock token (7504 bytes of ML-DSA-87 key
-///   and signature material) plus framing. This one is streamed into the
-///   Caliptra mailbox and never occupies the scratch pool, but declaring a
-///   smaller `MaxSPDMmsgSize` would have the responder reject it outright.
-///
-/// The assertions below check both against what the build actually enables, so
-/// turning on a larger generator or a larger inbound command fails the build
-/// rather than failing at runtime.
-const MAX_SPDM_MSG_SIZE: usize = {
+/// It contributes to `MaxSPDMmsgSize` only when buffered large requests are
+/// enabled. Raising it requires larger scratch pools.
+const MAX_BUFFERED_SPDM_MSG_SIZE: usize = {
     let declared = 8 * 1024;
     assert!(
         declared
             >= caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::large_response_capacity::<
                 crate::caliptra_cmd_handler::CaliptraCmdBackend,
             >(),
-        "MaxSPDMmsgSize is smaller than the largest Caliptra VDM response this build can \
-         produce; raise MAX_SPDM_MSG_SIZE (and both scratch pools with it) or disable an \
-         evidence generator"
-    );
-    assert!(
-        declared >= MAX_STREAMED_VDM_REQUEST_LEN,
-        "MaxSPDMmsgSize is smaller than the largest Caliptra VDM request this build must \
-         accept (the debug unlock token); raise MAX_SPDM_MSG_SIZE and both scratch pools with it"
+        "SPDM scratch capacity is smaller than the largest buffered VDM response; raise \
+         MAX_BUFFERED_SPDM_MSG_SIZE and both responder scratch pools"
     );
     declared
 };
 
-/// Largest streamed Caliptra VDM request this responder must accept.
+/// Endpoint-wide logical request limit advertised as `MaxSPDMmsgSize`.
 ///
-/// The production debug unlock token dominates every other inbound request: it
-/// carries an ML-DSA-87 public key and signature. It is streamed into the
-/// Caliptra mailbox and never occupies the scratch pool, so it costs no memory
-/// here, but [`MAX_SPDM_MSG_SIZE`] must still admit it.
+/// This is the maximum across buffered and streamed inbound request paths.
+const MAX_INBOUND_SPDM_REQUEST_SIZE: usize = {
+    let mut required = MAX_TRANSPORT_MTU;
+    if MAX_BUFFERED_SPDM_REQUEST_LEN > required {
+        required = MAX_BUFFERED_SPDM_REQUEST_LEN;
+    }
+    if MAX_STREAMED_SPDM_REQUEST_LEN > required {
+        required = MAX_STREAMED_SPDM_REQUEST_LEN;
+    }
+    required
+};
+
+/// Maximum across scratch-backed request handlers. Add new buffered request
+/// limits to this block.
+const MAX_BUFFERED_SPDM_REQUEST_LEN: usize = {
+    let mut required = 0;
+    if MAX_BUFFERED_VDM_REQUEST_LEN > required {
+        required = MAX_BUFFERED_VDM_REQUEST_LEN;
+    }
+    required
+};
+
+/// Logical request ceiling for generic VDM CHUNK_SEND reassembly.
+///
+/// Caliptra `AuthorizedCommand` requests are retained here in full before VDM
+/// dispatch. Streamed debug-unlock and SET_CERTIFICATE requests bypass this
+/// buffer. Raise this together with both SPDM scratch pools when a buffered
+/// request grows, or add a streaming handler instead.
+const MAX_BUFFERED_VDM_REQUEST_LEN: usize = MAX_BUFFERED_SPDM_MSG_SIZE;
+const _: () = assert!(
+    MAX_BUFFERED_VDM_REQUEST_LEN
+        >= caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::
+            MAX_AUTHORIZED_COMMAND_SPDM_REQUEST_LEN,
+    "buffered SPDM request capacity is smaller than an AuthorizedCommand request"
+);
+
+/// Maximum across streaming request handlers. Add new streamed request limits
+/// to this block.
+const MAX_STREAMED_SPDM_REQUEST_LEN: usize = {
+    #[cfg(feature = "test-mctp-spdm-set-certificate")]
+    {
+        if MAX_STREAMED_SET_CERTIFICATE_REQUEST_LEN > MAX_STREAMED_VDM_REQUEST_LEN {
+            MAX_STREAMED_SET_CERTIFICATE_REQUEST_LEN
+        } else {
+            MAX_STREAMED_VDM_REQUEST_LEN
+        }
+    }
+
+    #[cfg(not(feature = "test-mctp-spdm-set-certificate"))]
+    {
+        MAX_STREAMED_VDM_REQUEST_LEN
+    }
+};
+
+/// Maximum logical size of the streamed debug-unlock VDM request.
 const MAX_STREAMED_VDM_REQUEST_LEN: usize =
-    caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::LARGE_REQUEST_FRAMING_LEN
+    caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::SPDM_REQUEST_FRAMING_LEN
         + core::mem::size_of::<mcu_caliptra_api::mailbox::ProductionAuthDebugUnlockToken>();
+
+/// Maximum streamed SET_CERTIFICATE request for a CertChain.
+///
+/// This limit is tunable based on the integrator's requirements.
+#[cfg(feature = "test-mctp-spdm-set-certificate")]
+const MAX_STANDARD_CERT_CHAIN_LEN: usize = u16::MAX as usize;
+#[cfg(feature = "test-mctp-spdm-set-certificate")]
+const MAX_STREAMED_SET_CERTIFICATE_REQUEST_LEN: usize = caliptra_mcu_spdm_codec::SpdmMsgHdrPdu::SIZE
+    + caliptra_mcu_spdm_codec::SetCertificateReqBody::SIZE
+    + MAX_STANDARD_CERT_CHAIN_LEN;
 
 /// Conservative upper bound on transport MTU. The real MTU is a runtime
 /// transport property, so the budget uses a declared ceiling instead.
@@ -110,14 +147,14 @@ const TRANSIENT_MAILBOX_PEAK: usize = 2560;
 /// The receive buffer is not counted: it is shrunk to the actual frame length
 /// immediately after receive, and the request that triggers a large response
 /// is always a single small frame.
-const LARGE_MSG_PATH_PEAK: usize = MAX_SPDM_MSG_SIZE + MAX_TRANSPORT_MTU;
+const LARGE_MSG_PATH_PEAK: usize = MAX_BUFFERED_SPDM_MSG_SIZE + MAX_TRANSPORT_MTU;
 
 /// Peak concurrent allocation on the certificate / secure-session path: the
 /// mailbox working set plus the secured-message plaintext and ciphertext
 /// staging buffers.
 const CRYPTO_PATH_PEAK: usize = TRANSIENT_MAILBOX_PEAK + 2 * MAX_TRANSPORT_MTU;
 
-/// Minimum scratch pool that can satisfy [`MAX_SPDM_MSG_SIZE`].
+/// Minimum scratch pool that can satisfy [`MAX_BUFFERED_SPDM_MSG_SIZE`].
 ///
 /// The two request paths are mutually exclusive: a single request either
 /// builds a large chunked response or runs the certificate/crypto path, never
@@ -142,7 +179,7 @@ const MCTP_SPDM_SCRATCH_SIZE: usize = {
     let declared = 12 * 1024;
     assert!(
         declared >= required_scratch(),
-        "MCTP SPDM scratch pool is too small for the configured MAX_SPDM_MSG_SIZE"
+        "MCTP SPDM scratch pool is too small for MAX_BUFFERED_SPDM_MSG_SIZE"
     );
     declared
 };
@@ -151,7 +188,7 @@ const DOE_SPDM_SCRATCH_SIZE: usize = {
     let declared = 12 * 1024;
     assert!(
         declared >= required_scratch(),
-        "DOE SPDM scratch pool is too small for the configured MAX_SPDM_MSG_SIZE"
+        "DOE SPDM scratch pool is too small for MAX_BUFFERED_SPDM_MSG_SIZE"
     );
     declared
 };
@@ -223,7 +260,8 @@ async fn spdm_mctp_responder() {
             allocator,
             crate::cert_store::shared(),
             measurement_provider(),
-            MAX_SPDM_MSG_SIZE,
+            MAX_INBOUND_SPDM_REQUEST_SIZE,
+            MAX_BUFFERED_SPDM_MSG_SIZE,
         )
     };
     // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
@@ -282,7 +320,8 @@ async fn spdm_doe_responder() {
             allocator,
             crate::cert_store::shared(),
             measurement_provider(),
-            MAX_SPDM_MSG_SIZE,
+            MAX_INBOUND_SPDM_REQUEST_SIZE,
+            MAX_BUFFERED_SPDM_MSG_SIZE,
         )
     };
     #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]

--- a/runtime/userspace/api/caliptra-api/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api/src/dpe.rs
@@ -14,7 +14,7 @@ use core::{
     mem::{offset_of, size_of},
     ops::Deref,
 };
-use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
+use mcu_error::codes::{INTERNAL_BUG, INVARIANT, NOT_IMPLEMENTED};
 use mcu_error::McuResult;
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -80,6 +80,42 @@ pub const DPE_MAX_LEAF_CERT_SIZE: usize = 12 * 1024;
 /// few bitmap-allocator slots.
 pub const DPE_MAX_CHUNK_SIZE: usize = 1024;
 
+/// External `mu` width consumed by DPE ML-DSA-87 `Sign`.
+pub const DPE_MLDSA87_MU_SIZE: usize = 64;
+
+/// ML-DSA-87 signature width returned by DPE `Sign`.
+pub const DPE_MLDSA87_SIGNATURE_SIZE: usize = 4627;
+
+/// SHA-384 digest width consumed by DPE P-384 `Sign`.
+pub const DPE_P384_DIGEST_SIZE: usize = 48;
+
+/// Typed input to DPE-backed attestation signing.
+///
+/// Caliptra 2.0 accepts a raw ML-DSA message, while Caliptra 2.1 accepts an
+/// externally computed `mu`. These forms are intentionally distinct because
+/// they do not have identical context or message-size semantics.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SigningInput<'a> {
+    /// SHA-384 digest for ECDSA P-384.
+    EccP384Digest(&'a [u8; DPE_P384_DIGEST_SIZE]),
+    /// Raw ML-DSA-87 message accepted by the Caliptra 2.0 DPE interface.
+    ///
+    /// The 2.0 form uses an implicit empty FIPS 204 context and limits the
+    /// message to 1024 bytes.
+    Mldsa87RawMessage(&'a [u8]),
+    /// External ML-DSA-87 `mu` accepted by the Caliptra 2.1 DPE interface.
+    Mldsa87ExternalMu(&'a [u8; DPE_MLDSA87_MU_SIZE]),
+}
+
+impl SigningInput<'_> {
+    /// DPE profile required by this signing input.
+    pub const fn profile(&self) -> DpeProfile {
+        match self {
+            Self::EccP384Digest(_) => DpeProfile::P384Sha384,
+            Self::Mldsa87RawMessage(_) | Self::Mldsa87ExternalMu(_) => DpeProfile::Mldsa87,
+        }
+    }
+}
 // ---------------------------------------------------------------------------
 // Slim wire types
 // ---------------------------------------------------------------------------
@@ -132,7 +168,17 @@ struct SignP384Cmd {
     handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
     label: [u8; DPE_LABEL_LEN],
     flags: U32,
-    digest: [u8; DPE_LABEL_LEN], // same size as hash (48)
+    digest: [u8; DPE_P384_DIGEST_SIZE],
+}
+
+/// `dpe::commands::SignMldsa87Cmd`.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct SignMldsa87Cmd {
+    handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    label: [u8; DPE_LABEL_LEN],
+    flags: U32,
+    mu: [u8; DPE_MLDSA87_MU_SIZE],
 }
 
 /// `dpe::commands::DeriveContextCmd`.
@@ -166,6 +212,16 @@ struct SignP384RespBody {
     _new_context_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
     sig_r: [u8; 48],
     sig_s: [u8; 48],
+}
+
+/// `dpe::response::SignMlDsaResp`.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct SignMldsa87RespBody {
+    _resp_hdr: [u8; 12],
+    new_context_handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    signature: [u8; DPE_MLDSA87_SIGNATURE_SIZE],
+    padding: [u8; 1],
 }
 
 /// ECC P-384 signature size (r + s, 48 bytes each).
@@ -283,6 +339,13 @@ const GET_CERT_CHAIN_DPE_PAYLOAD_LEN: u32 =
 const SIGN_REQ_LEN: usize =
     size_of::<InvokeDpeReqPrefix>() + size_of::<DpeCommandHdr>() + size_of::<SignP384Cmd>();
 const SIGN_DPE_PAYLOAD_LEN: u32 = (size_of::<DpeCommandHdr>() + size_of::<SignP384Cmd>()) as u32;
+const SIGN_MLDSA87_REQ_LEN: usize = size_of::<InvokeDpeMldsa87ReqPrefix>()
+    + size_of::<DpeCommandHdr>()
+    + size_of::<SignMldsa87Cmd>();
+const SIGN_MLDSA87_DPE_PAYLOAD_LEN: u32 =
+    (size_of::<DpeCommandHdr>() + size_of::<SignMldsa87Cmd>()) as u32;
+const SIGN_MLDSA87_RESP_LEN: usize =
+    size_of::<InvokeDpeRespPrefix>() + size_of::<SignMldsa87RespBody>();
 const DERIVE_CONTEXT_REQ_LEN: usize =
     size_of::<InvokeDpeReqPrefix>() + size_of::<DpeCommandHdr>() + size_of::<DeriveContextCmd>();
 const DERIVE_CONTEXT_MLDSA87_REQ_LEN: usize = size_of::<InvokeDpeMldsa87ReqPrefix>()
@@ -360,6 +423,11 @@ const _: () = assert!(size_of::<DpeCommandHdr>() == 12);
 const _: () = assert!(size_of::<GetCertChainCmd>() == 8);
 const _: () = assert!(size_of::<SignP384Cmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 48);
 const _: () = assert!(size_of::<SignP384RespBody>() == 12 + DPE_CONTEXT_HANDLE_SIZE + 48 + 48);
+const _: () = assert!(size_of::<SignMldsa87Cmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 64);
+const _: () = assert!(
+    size_of::<SignMldsa87RespBody>()
+        == 12 + DPE_CONTEXT_HANDLE_SIZE + DPE_MLDSA87_SIGNATURE_SIZE + 1
+);
 const _: () =
     assert!(size_of::<DeriveContextCmd>() == DPE_CONTEXT_HANDLE_SIZE + 48 + 4 + 4 + 4 + 4);
 const _: () =
@@ -380,6 +448,9 @@ const _: () = assert!(size_of::<DpeResponseHdr>() == 12);
 const _: () = assert!(GET_CERT_CHAIN_REQ_P384_LEN == 28);
 const _: () = assert!(GET_CERT_CHAIN_REQ_MLDSA87_LEN == 44);
 const _: () = assert!(SIGN_REQ_LEN == 8 + 12 + 116);
+const _: () = assert!(SIGN_MLDSA87_REQ_LEN == 24 + 12 + 132);
+const _: () = assert!(SIGN_MLDSA87_RESP_LEN == 12 + 12 + 16 + 4627 + 1);
+const _: () = assert!(SIGN_MLDSA87_RESP_LEN <= caliptra_api::mailbox::MAILBOX_SIZE);
 const _: () = assert!(DERIVE_CONTEXT_REQ_LEN == 8 + 12 + 80);
 const _: () = assert!(DERIVE_CONTEXT_MLDSA87_REQ_LEN == 24 + 12 + 80);
 const _: () = assert!(UPDATE_CONTEXT_MEASUREMENT_REQ_LEN == 8 + 12 + 76);
@@ -970,6 +1041,43 @@ pub async fn dpe_certify_key_pubkey<A: ApiAlloc>(
     Ok(chunk.next_handle)
 }
 
+/// Return the raw 2,592-byte ML-DSA-87 public key emitted by DPE
+/// `CertifyKey`, along with the rotated context handle.
+#[inline(never)]
+pub async fn dpe_certify_key_mldsa87_pubkey<A: ApiAlloc>(
+    alloc: &A,
+    handle: Option<&DpeContextHandle>,
+    label: &[u8; DPE_LABEL_LEN],
+    public_key: &mut [u8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE],
+) -> McuResult<DpeContextHandle> {
+    let chunk = certify_key_chunks_response(
+        alloc,
+        DpeProfile::Mldsa87,
+        label,
+        dpe_handle_or_default(handle),
+        0,
+        CERTIFY_KEY_MLDSA87_RESP_PREFIX_LEN,
+    )
+    .await?;
+    parse_certify_key_mldsa87_pubkey(chunk.chunk()?, public_key)?;
+    Ok(chunk.next_handle)
+}
+
+fn parse_certify_key_mldsa87_pubkey(
+    response: &[u8],
+    public_key: &mut [u8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE],
+) -> McuResult<()> {
+    validate_certify_key_prefix(response, DpeProfile::Mldsa87)?;
+    copy_bytes(
+        public_key,
+        internal_slice(
+            response,
+            CERTIFY_KEY_RESP_PUBKEY_X_OFF,
+            CERTIFY_KEY_MLDSA87_PUBKEY_SIZE,
+        )?,
+    )
+}
+
 struct CertifyKeyChunk<B> {
     next_handle: DpeContextHandle,
     rsp: B,
@@ -1184,6 +1292,30 @@ pub async fn walk_dpe_chain<A: ApiAlloc, S: DpeChainSink>(
     Ok(total)
 }
 
+/// Invoke DPE `Sign` for a typed signing input.
+///
+/// This Caliptra 2.1 implementation supports P-384 digests and ML-DSA-87
+/// external `mu`. Raw ML-DSA-87 messages are represented for API compatibility
+/// with Caliptra 2.0 and return [`NOT_IMPLEMENTED`] here.
+#[inline(never)]
+pub async fn dpe_sign<A: ApiAlloc>(
+    alloc: &A,
+    handle: Option<&DpeContextHandle>,
+    label: &[u8; DPE_LABEL_LEN],
+    signing_input: SigningInput<'_>,
+    signature: &mut [u8],
+) -> McuResult<(DpeContextHandle, usize)> {
+    match signing_input {
+        SigningInput::EccP384Digest(digest) => {
+            dpe_sign_ecc_p384(alloc, handle, label, digest, signature).await
+        }
+        SigningInput::Mldsa87RawMessage(_) => Err(NOT_IMPLEMENTED),
+        SigningInput::Mldsa87ExternalMu(mu) => {
+            dpe_sign_mldsa87(alloc, handle, label, mu, signature).await
+        }
+    }
+}
+
 /// Invoke DPE `Sign` (P-384 / SHA-384) for the default context handle
 /// and the given 48-byte `label`. Signs `digest` and writes the
 /// concatenated (r || s) signature into `signature`.
@@ -1198,7 +1330,7 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
     digest: &[u8],
     signature: &mut [u8],
 ) -> McuResult<(DpeContextHandle, usize)> {
-    if signature.len() < DPE_P384_SIGNATURE_SIZE || digest.len() < DPE_LABEL_LEN {
+    if signature.len() < DPE_P384_SIGNATURE_SIZE || digest.len() < DPE_P384_DIGEST_SIZE {
         return Err(INVARIANT);
     }
 
@@ -1215,7 +1347,9 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
         cmd.handle = *dpe_handle_or_default(handle);
         cmd.label = *label;
         cmd.flags = U32::new(0);
-        cmd.digest = *digest.first_chunk::<DPE_LABEL_LEN>().ok_or(INVARIANT)?;
+        cmd.digest = *digest
+            .first_chunk::<DPE_P384_DIGEST_SIZE>()
+            .ok_or(INVARIANT)?;
     }
     let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
     *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
@@ -1251,6 +1385,106 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
     let (sig_s, _) = rest.split_first_chunk_mut::<48>().ok_or(INVARIANT)?;
     *sig_s = sign_resp.sig_s;
     Ok((sign_resp._new_context_handle, DPE_P384_SIGNATURE_SIZE))
+}
+
+/// Invoke DPE `Sign` for ML-DSA-87 using a precomputed external `mu`.
+///
+/// `signature` must provide at least [`DPE_MLDSA87_SIGNATURE_SIZE`] bytes.
+/// Returns the rotated context handle and signature length.
+#[inline(never)]
+pub async fn dpe_sign_mldsa87<A: ApiAlloc>(
+    alloc: &A,
+    handle: Option<&DpeContextHandle>,
+    label: &[u8; DPE_LABEL_LEN],
+    mu: &[u8; DPE_MLDSA87_MU_SIZE],
+    signature: &mut [u8],
+) -> McuResult<(DpeContextHandle, usize)> {
+    if signature.len() < DPE_MLDSA87_SIGNATURE_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let request = build_sign_mldsa87_req(alloc, dpe_handle_or_default(handle), label, mu)?;
+    let mut response = alloc.alloc(SIGN_MLDSA87_RESP_LEN)?;
+    let response_len = mbox_execute(CMD_INVOKE_DPE_MLDSA87, &request, &mut response).await?;
+    parse_sign_mldsa87_response(&response, response_len, signature)
+}
+
+fn build_sign_mldsa87_req<'a, A: ApiAlloc>(
+    alloc: &'a A,
+    handle: &DpeContextHandle,
+    label: &[u8; DPE_LABEL_LEN],
+    mu: &[u8; DPE_MLDSA87_MU_SIZE],
+) -> McuResult<A::Buf<'a>> {
+    let mut request = alloc.alloc(SIGN_MLDSA87_REQ_LEN)?;
+    request.fill(0);
+    let command_offset = build_invoke_dpe_header_profile(
+        &mut request,
+        SIGN_MLDSA87_DPE_PAYLOAD_LEN,
+        DPE_CMD_SIGN,
+        DpeProfile::Mldsa87,
+        None,
+    )?;
+    let command = SignMldsa87Cmd::mut_from_bytes(checked_slice_mut(
+        &mut request,
+        command_offset,
+        size_of::<SignMldsa87Cmd>(),
+    )?)
+    .map_err(|_| INVARIANT)?;
+    command.handle = *handle;
+    command.label = *label;
+    command.flags = U32::new(0);
+    command.mu = *mu;
+
+    let checksum = calc_checksum(CMD_INVOKE_DPE_MLDSA87, &request);
+    *request.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
+    Ok(request)
+}
+
+fn parse_sign_mldsa87_response(
+    response: &[u8],
+    response_len: usize,
+    signature: &mut [u8],
+) -> McuResult<(DpeContextHandle, usize)> {
+    if signature.len() < DPE_MLDSA87_SIGNATURE_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let body_offset = size_of::<InvokeDpeRespPrefix>();
+    if response_len < body_offset + size_of::<DpeResponseHdr>() {
+        return Err(INTERNAL_BUG);
+    }
+    let dpe_header = DpeResponseHdr::ref_from_bytes(internal_slice(
+        response,
+        body_offset,
+        size_of::<DpeResponseHdr>(),
+    )?)
+    .map_err(|_| INTERNAL_BUG)?;
+    if dpe_header.magic.get() != DPE_RESPONSE_MAGIC
+        || dpe_header.status.get() != 0
+        || dpe_header.profile.get() != DPE_PROFILE_MLDSA87
+    {
+        return Err(INTERNAL_BUG);
+    }
+    if response_len != SIGN_MLDSA87_RESP_LEN {
+        return Err(INTERNAL_BUG);
+    }
+
+    let sign_response = SignMldsa87RespBody::ref_from_bytes(internal_slice(
+        response,
+        body_offset,
+        size_of::<SignMldsa87RespBody>(),
+    )?)
+    .map_err(|_| INTERNAL_BUG)?;
+    if sign_response.padding != [0] {
+        return Err(INTERNAL_BUG);
+    }
+    copy_bytes(
+        signature
+            .get_mut(..DPE_MLDSA87_SIGNATURE_SIZE)
+            .ok_or(INVARIANT)?,
+        &sign_response.signature,
+    )?;
+    Ok((sign_response.new_context_handle, DPE_MLDSA87_SIGNATURE_SIZE))
 }
 
 /// Invoke DPE `RotateContextHandle` for the default context handle,
@@ -1611,6 +1845,104 @@ mod tests {
     }
 
     #[test]
+    fn certify_key_mldsa87_pubkey_parser_copies_raw_key() {
+        let expected_key = [0x5au8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE];
+        let mut response = std::vec![0u8; CERTIFY_KEY_MLDSA87_RESP_PREFIX_LEN];
+        response[..4].copy_from_slice(&DPE_RESPONSE_MAGIC.to_le_bytes());
+        response[8..12].copy_from_slice(&DPE_PROFILE_MLDSA87.to_le_bytes());
+        response[CERTIFY_KEY_RESP_PUBKEY_X_OFF
+            ..CERTIFY_KEY_RESP_PUBKEY_X_OFF + CERTIFY_KEY_MLDSA87_PUBKEY_SIZE]
+            .copy_from_slice(&expected_key);
+
+        let mut public_key = [0u8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE];
+        parse_certify_key_mldsa87_pubkey(&response, &mut public_key).unwrap();
+
+        assert_eq!(public_key, expected_key);
+    }
+
+    #[test]
+    fn sign_mldsa87_request_preserves_fields() {
+        let alloc = TestAlloc;
+        let handle = [0x11u8; DPE_CONTEXT_HANDLE_SIZE];
+        let label = [0x22u8; DPE_LABEL_LEN];
+        let mu = [0x33u8; DPE_MLDSA87_MU_SIZE];
+        let request = build_sign_mldsa87_req(&alloc, &handle, &label, &mu).unwrap();
+
+        let prefix = InvokeDpeMldsa87ReqPrefix::ref_from_prefix(&request)
+            .unwrap()
+            .0;
+        assert_eq!(prefix.flags.get(), 0);
+        assert_eq!(prefix.axi_addr_lo.get(), 0);
+        assert_eq!(prefix.axi_addr_hi.get(), 0);
+        assert_eq!(prefix.axi_max_size.get(), 0);
+        assert_eq!(prefix.data_size.get(), SIGN_MLDSA87_DPE_PAYLOAD_LEN);
+
+        let header_offset = size_of::<InvokeDpeMldsa87ReqPrefix>();
+        let header = DpeCommandHdr::ref_from_prefix(&request[header_offset..])
+            .unwrap()
+            .0;
+        assert_eq!(header.magic.get(), DPE_COMMAND_MAGIC);
+        assert_eq!(header.cmd_id.get(), DPE_CMD_SIGN);
+        assert_eq!(header.profile.get(), DPE_PROFILE_MLDSA87);
+
+        let command_offset = header_offset + size_of::<DpeCommandHdr>();
+        let command = SignMldsa87Cmd::ref_from_prefix(&request[command_offset..])
+            .unwrap()
+            .0;
+        assert_eq!(command.handle, handle);
+        assert_eq!(command.label, label);
+        assert_eq!(command.flags.get(), 0);
+        assert_eq!(command.mu, mu);
+
+        let mut checksum_input = request.clone();
+        checksum_input[..4].fill(0);
+        assert_eq!(
+            prefix.chksum.get(),
+            calc_checksum(CMD_INVOKE_DPE_MLDSA87, &checksum_input)
+        );
+    }
+
+    #[test]
+    fn sign_mldsa87_response_parser_returns_handle_and_signature() {
+        let handle = [0x44u8; DPE_CONTEXT_HANDLE_SIZE];
+        let expected_signature = [0x55u8; DPE_MLDSA87_SIGNATURE_SIZE];
+        let mut response = std::vec![0u8; SIGN_MLDSA87_RESP_LEN];
+        let body_offset = size_of::<InvokeDpeRespPrefix>();
+        response[body_offset..body_offset + 4].copy_from_slice(&DPE_RESPONSE_MAGIC.to_le_bytes());
+        response[body_offset + 8..body_offset + 12]
+            .copy_from_slice(&DPE_PROFILE_MLDSA87.to_le_bytes());
+        response[body_offset + 12..body_offset + 12 + DPE_CONTEXT_HANDLE_SIZE]
+            .copy_from_slice(&handle);
+        let signature_offset = body_offset + 12 + DPE_CONTEXT_HANDLE_SIZE;
+        response[signature_offset..signature_offset + DPE_MLDSA87_SIGNATURE_SIZE]
+            .copy_from_slice(&expected_signature);
+
+        let mut signature = std::vec![0u8; DPE_MLDSA87_SIGNATURE_SIZE];
+        let result =
+            parse_sign_mldsa87_response(&response, response.len(), &mut signature).unwrap();
+
+        assert_eq!(result, (handle, DPE_MLDSA87_SIGNATURE_SIZE));
+        assert_eq!(signature, expected_signature);
+    }
+
+    #[test]
+    fn sign_mldsa87_response_parser_rejects_error_and_padding() {
+        let mut response = std::vec![0u8; SIGN_MLDSA87_RESP_LEN];
+        let body_offset = size_of::<InvokeDpeRespPrefix>();
+        response[body_offset..body_offset + 4].copy_from_slice(&DPE_RESPONSE_MAGIC.to_le_bytes());
+        response[body_offset + 8..body_offset + 12]
+            .copy_from_slice(&DPE_PROFILE_MLDSA87.to_le_bytes());
+        let mut signature = std::vec![0u8; DPE_MLDSA87_SIGNATURE_SIZE];
+
+        response[body_offset + 4..body_offset + 8].copy_from_slice(&1u32.to_le_bytes());
+        assert!(parse_sign_mldsa87_response(&response, response.len(), &mut signature).is_err());
+
+        response[body_offset + 4..body_offset + 8].fill(0);
+        *response.last_mut().unwrap() = 1;
+        assert!(parse_sign_mldsa87_response(&response, response.len(), &mut signature).is_err());
+    }
+
+    #[test]
     fn derive_context_reads_child_and_parent_handles() {
         let child_handle = [0x3cu8; DPE_CONTEXT_HANDLE_SIZE];
         let parent_handle = [0xc3u8; DPE_CONTEXT_HANDLE_SIZE];
@@ -1745,6 +2077,26 @@ mod tests {
         assert_eq!(DpeProfile::P384Sha384.invoke_cmd_id(), CMD_INVOKE_DPE);
         assert_eq!(DpeProfile::Mldsa87.profile_id(), 5);
         assert_eq!(DpeProfile::Mldsa87.invoke_cmd_id(), CMD_INVOKE_DPE_MLDSA87);
+    }
+
+    #[test]
+    fn signing_input_selects_dpe_profile() {
+        let digest = [0u8; DPE_P384_DIGEST_SIZE];
+        let message = [0u8; 1];
+        let mu = [0u8; DPE_MLDSA87_MU_SIZE];
+
+        assert_eq!(
+            SigningInput::EccP384Digest(&digest).profile(),
+            DpeProfile::P384Sha384
+        );
+        assert_eq!(
+            SigningInput::Mldsa87RawMessage(&message).profile(),
+            DpeProfile::Mldsa87
+        );
+        assert_eq!(
+            SigningInput::Mldsa87ExternalMu(&mu).profile(),
+            DpeProfile::Mldsa87
+        );
     }
 
     #[test]

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -54,6 +54,8 @@ pub mod image_loader;
 mod import;
 pub mod mailbox;
 #[cfg(feature = "mailbox-io")]
+mod mldsa;
+#[cfg(feature = "mailbox-io")]
 mod pcr;
 #[cfg(feature = "mailbox-io")]
 mod pcr_quote;
@@ -63,6 +65,8 @@ pub mod raw;
 mod rng;
 #[cfg(feature = "mailbox-io")]
 mod sha;
+#[cfg(feature = "mailbox-io")]
+mod shake;
 #[cfg(feature = "mailbox-io")]
 mod slice;
 #[cfg(feature = "mailbox-io")]
@@ -101,14 +105,17 @@ pub use debug_unlock::{
 };
 #[cfg(feature = "mailbox-io")]
 pub use dpe::{
-    dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
-    dpe_derive_context, dpe_derive_context_exported_cdi, dpe_get_cert_chain_chunk,
-    dpe_get_tagged_tci, dpe_rotate_context_default, dpe_sign_ecc_p384, dpe_tag_tci,
+    dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice,
+    dpe_certify_key_mldsa87_pubkey, dpe_certify_key_pubkey, dpe_derive_context,
+    dpe_derive_context_exported_cdi, dpe_get_cert_chain_chunk, dpe_get_tagged_tci,
+    dpe_rotate_context_default, dpe_sign, dpe_sign_ecc_p384, dpe_sign_mldsa87, dpe_tag_tci,
     dpe_update_context_measurement, walk_dpe_chain, DpeChainSink, DpeContextHandle,
     DpeDeriveContextExportedCdiResult, DpeDeriveContextFlags, DpeDeriveContextParams,
     DpeDeriveContextResult, DpeProfile, DpeTaggedTci, DpeUpdateContextMeasurementParams,
-    DpeUpdateContextMeasurementResult, DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE,
-    DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE, DPE_TCI_MEASUREMENT_SIZE, EXPORTED_CDI_SIZE,
+    DpeUpdateContextMeasurementResult, SigningInput, CERTIFY_KEY_MLDSA87_PUBKEY_SIZE,
+    DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE,
+    DPE_MLDSA87_MU_SIZE, DPE_MLDSA87_SIGNATURE_SIZE, DPE_P384_DIGEST_SIZE, DPE_P384_SIGNATURE_SIZE,
+    DPE_TCI_MEASUREMENT_SIZE, EXPORTED_CDI_SIZE,
 };
 #[cfg(feature = "mailbox-io")]
 pub use ecdh::{
@@ -127,6 +134,10 @@ pub use image_loader::{core_image_info, GetImageInfoResp};
 #[cfg(feature = "mailbox-io")]
 pub use import::{cm_delete, cm_import};
 #[cfg(feature = "mailbox-io")]
+pub use mldsa::{
+    mldsa87_compute_mu, mldsa87_compute_tr, MLDSA87_CONTEXT_MAX_SIZE, MLDSA87_TR_SIZE,
+};
+#[cfg(feature = "mailbox-io")]
 pub use pcr::{extend_pcr31, PCR31_INDEX, PCR31_MEASUREMENT_SIZE};
 #[cfg(feature = "mailbox-io")]
 pub use pcr_quote::{
@@ -139,6 +150,11 @@ pub use rng::rng_generate;
 pub use sha::{
     hash_all, sha_finish, sha_init, sha_update, HashAlgo, HashState, SHA_CHUNK_SIZE,
     SHA_CONTEXT_SIZE,
+};
+#[cfg(feature = "mailbox-io")]
+pub use shake::{
+    shake256_finish, shake256_hash, shake256_init, shake256_update, Shake256State,
+    SHAKE256_CHUNK_SIZE, SHAKE256_CONTEXT_SIZE, SHAKE256_OUTPUT_SIZE,
 };
 #[cfg(feature = "mailbox-io")]
 pub use stable_key::{derive_stable_key, StableKeyType, CM_STABLE_KEY_INFO_SIZE};

--- a/runtime/userspace/api/caliptra-api/src/mldsa.rs
+++ b/runtime/userspace/api/caliptra-api/src/mldsa.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache-2.0 license
+
+//! ML-DSA-87 message-representative construction for external-`mu` signing.
+
+use mcu_error::codes::INVARIANT;
+use mcu_error::McuResult;
+
+use crate::dpe::{CERTIFY_KEY_MLDSA87_PUBKEY_SIZE, DPE_MLDSA87_MU_SIZE};
+use crate::{
+    shake256_finish, shake256_hash, shake256_init, shake256_update, ApiAlloc, SHAKE256_CONTEXT_SIZE,
+};
+
+/// Width of the ML-DSA public-key hash `tr`.
+pub const MLDSA87_TR_SIZE: usize = 64;
+
+/// Maximum context length allowed by FIPS 204.
+pub const MLDSA87_CONTEXT_MAX_SIZE: usize = u8::MAX as usize;
+
+const PURE_MLDSA_DOMAIN_SEPARATOR: u8 = 0;
+
+/// Calculate `tr = SHAKE256(raw_public_key, 64)`.
+///
+/// `raw_public_key` is the 2,592-byte ML-DSA-87 key returned by DPE
+/// `CertifyKey`, not its DER SubjectPublicKeyInfo encoding.
+#[inline(never)]
+pub async fn mldsa87_compute_tr<A: ApiAlloc>(
+    alloc: &A,
+    raw_public_key: &[u8; CERTIFY_KEY_MLDSA87_PUBKEY_SIZE],
+    tr: &mut [u8; MLDSA87_TR_SIZE],
+) -> McuResult<()> {
+    shake256_hash(alloc, raw_public_key, tr).await
+}
+
+/// Calculate the external `mu` consumed by DPE ML-DSA-87 `Sign`.
+///
+/// For pure ML-DSA this computes:
+/// `SHAKE256(tr || 0x00 || len(context) || context || message_parts..., 64)`.
+#[inline(never)]
+pub async fn mldsa87_compute_mu<A: ApiAlloc>(
+    alloc: &A,
+    tr: &[u8; MLDSA87_TR_SIZE],
+    context: &[u8],
+    message_parts: &[&[u8]],
+    mu: &mut [u8; DPE_MLDSA87_MU_SIZE],
+) -> McuResult<()> {
+    let domain = mldsa87_domain(context.len())?;
+    let state_buffer = alloc.alloc(SHAKE256_CONTEXT_SIZE)?;
+    let mut state = shake256_init(alloc, state_buffer, tr).await?;
+    shake256_update(alloc, &mut state, &domain).await?;
+    shake256_update(alloc, &mut state, context).await?;
+    for part in message_parts {
+        shake256_update(alloc, &mut state, part).await?;
+    }
+    shake256_finish(alloc, &mut state, mu).await
+}
+
+fn mldsa87_domain(context_len: usize) -> McuResult<[u8; 2]> {
+    if context_len > MLDSA87_CONTEXT_MAX_SIZE {
+        return Err(INVARIANT);
+    }
+    Ok([PURE_MLDSA_DOMAIN_SEPARATOR, context_len as u8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pure_mldsa_domain_encodes_context_length() {
+        assert_eq!(mldsa87_domain(0).unwrap(), [0, 0]);
+        assert_eq!(mldsa87_domain(255).unwrap(), [0, 255]);
+        assert!(mldsa87_domain(256).is_err());
+    }
+}

--- a/runtime/userspace/api/caliptra-api/src/shake.rs
+++ b/runtime/userspace/api/caliptra-api/src/shake.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache-2.0 license
+
+//! Running SHAKE256 via Caliptra `CM_SHAKE256_*` mailbox commands.
+
+use caliptra_api::mailbox::{
+    CmShake256FinalReq, CmShake256FinalResp, CmShake256InitReq, CmShake256InitResp,
+    CmShake256UpdateReq, CommandId, CMB_SHAKE256_CONTEXT_SIZE, MAX_CMB_DATA_SIZE,
+    SHAKE256_MAX_DIGEST_BYTE_SIZE,
+};
+use core::mem::{offset_of, size_of};
+use core::ops::{Deref, DerefMut};
+use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
+use mcu_error::McuResult;
+use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::slice::{checked_slice, checked_slice_mut, copy_bytes};
+use crate::wire::{pad4, populate_checksum};
+use crate::ApiAlloc;
+
+/// Maximum input bytes sent in one SHAKE256 mailbox request.
+pub const SHAKE256_CHUNK_SIZE: usize = 512;
+
+/// Size of the caller-owned encrypted SHAKE256 running context.
+pub const SHAKE256_CONTEXT_SIZE: usize = CMB_SHAKE256_CONTEXT_SIZE;
+
+/// SHAKE256 output width exposed by the Caliptra mailbox API.
+pub const SHAKE256_OUTPUT_SIZE: usize = SHAKE256_MAX_DIGEST_BYTE_SIZE;
+
+const CMD_CM_SHAKE256_INIT: u32 = CommandId::CM_SHAKE256_INIT.0;
+const CMD_CM_SHAKE256_UPDATE: u32 = CommandId::CM_SHAKE256_UPDATE.0;
+const CMD_CM_SHAKE256_FINAL: u32 = CommandId::CM_SHAKE256_FINAL.0;
+const _: () = assert!(SHAKE256_CHUNK_SIZE <= MAX_CMB_DATA_SIZE);
+
+/// Caliptra-mailbox SHAKE256 running context.
+pub struct Shake256State<B> {
+    inner: B,
+}
+
+impl<B: Deref<Target = [u8]> + DerefMut> Shake256State<B> {
+    #[inline]
+    fn context(&self) -> McuResult<&[u8]> {
+        checked_slice(&self.inner, 0, SHAKE256_CONTEXT_SIZE)
+    }
+
+    #[inline]
+    fn context_mut(&mut self) -> McuResult<&mut [u8]> {
+        checked_slice_mut(&mut self.inner, 0, SHAKE256_CONTEXT_SIZE)
+    }
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct Shake256InitPrefix {
+    chksum: U32,
+    input_size: U32,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct Shake256UpdatePrefix {
+    chksum: U32,
+    context: [u8; SHAKE256_CONTEXT_SIZE],
+    input_size: U32,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct Shake256ContextResp {
+    _chksum: U32,
+    _fips_status: U32,
+    context: [u8; SHAKE256_CONTEXT_SIZE],
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct Shake256FinalResp {
+    _chksum: U32,
+    _fips_status: U32,
+    output: [u8; SHAKE256_OUTPUT_SIZE],
+}
+
+const _: () = assert!(offset_of!(CmShake256InitReq, input) == size_of::<Shake256InitPrefix>());
+const _: () = assert!(offset_of!(CmShake256UpdateReq, input) == size_of::<Shake256UpdatePrefix>());
+const _: () = assert!(offset_of!(CmShake256FinalReq, input) == size_of::<Shake256UpdatePrefix>());
+const _: () = assert!(size_of::<CmShake256InitResp>() == size_of::<Shake256ContextResp>());
+const _: () =
+    assert!(offset_of!(CmShake256InitResp, context) == offset_of!(Shake256ContextResp, context));
+const _: () = assert!(size_of::<CmShake256FinalResp>() == size_of::<Shake256FinalResp>());
+const _: () =
+    assert!(offset_of!(CmShake256FinalResp, hash) == offset_of!(Shake256FinalResp, output));
+
+/// Begin a SHAKE256 operation using caller-owned context storage.
+#[inline(never)]
+pub async fn shake256_init<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
+    alloc: &A,
+    mut buffer: B,
+    seed: &[u8],
+) -> McuResult<Shake256State<B>> {
+    checked_slice_mut(&mut buffer, 0, SHAKE256_CONTEXT_SIZE)?.fill(0);
+    let mut state = Shake256State { inner: buffer };
+    let first_len = seed.len().min(SHAKE256_CHUNK_SIZE);
+    shake256_call(
+        alloc,
+        CMD_CM_SHAKE256_INIT,
+        checked_slice(seed, 0, first_len)?,
+        &mut state,
+        None,
+    )
+    .await?;
+    let remaining = checked_slice(seed, first_len, seed.len() - first_len)?;
+    if !remaining.is_empty() {
+        shake256_update(alloc, &mut state, remaining).await?;
+    }
+    Ok(state)
+}
+
+/// Append data to a running SHAKE256 operation.
+#[inline(never)]
+pub async fn shake256_update<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
+    alloc: &A,
+    state: &mut Shake256State<B>,
+    data: &[u8],
+) -> McuResult<()> {
+    for chunk in data.chunks(SHAKE256_CHUNK_SIZE) {
+        shake256_call(alloc, CMD_CM_SHAKE256_UPDATE, chunk, state, None).await?;
+    }
+    Ok(())
+}
+
+/// Finalize SHAKE256 and return its 64-byte output.
+#[inline(never)]
+pub async fn shake256_finish<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
+    alloc: &A,
+    state: &mut Shake256State<B>,
+    output: &mut [u8; SHAKE256_OUTPUT_SIZE],
+) -> McuResult<()> {
+    shake256_call(alloc, CMD_CM_SHAKE256_FINAL, &[], state, Some(output)).await
+}
+
+/// Compute a 64-byte SHAKE256 output over one contiguous input.
+#[inline(never)]
+pub async fn shake256_hash<A: ApiAlloc>(
+    alloc: &A,
+    data: &[u8],
+    output: &mut [u8; SHAKE256_OUTPUT_SIZE],
+) -> McuResult<()> {
+    let context = alloc.alloc(SHAKE256_CONTEXT_SIZE)?;
+    let mut state = shake256_init(alloc, context, data).await?;
+    shake256_finish(alloc, &mut state, output).await
+}
+
+async fn shake256_call<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
+    alloc: &A,
+    command: u32,
+    data: &[u8],
+    state: &mut Shake256State<B>,
+    output: Option<&mut [u8; SHAKE256_OUTPUT_SIZE]>,
+) -> McuResult<()> {
+    let request = if command == CMD_CM_SHAKE256_INIT {
+        build_shake256_request(alloc, command, None, data)?
+    } else {
+        build_shake256_request(alloc, command, Some(state.context()?), data)?
+    };
+
+    if let Some(output) = output {
+        let mut response = alloc.alloc(size_of::<Shake256FinalResp>())?;
+        let response_len = crate::wire::mbox_execute(command, &request, &mut response).await?;
+        if response_len < size_of::<Shake256FinalResp>() {
+            return Err(INTERNAL_BUG);
+        }
+        let response = Shake256FinalResp::ref_from_bytes(checked_slice(
+            &response,
+            0,
+            size_of::<Shake256FinalResp>(),
+        )?)
+        .map_err(|_| INTERNAL_BUG)?;
+        *output = response.output;
+    } else {
+        let mut response = alloc.alloc(size_of::<Shake256ContextResp>())?;
+        let response_len = crate::wire::mbox_execute(command, &request, &mut response).await?;
+        if response_len < size_of::<Shake256ContextResp>() {
+            return Err(INTERNAL_BUG);
+        }
+        let response = Shake256ContextResp::ref_from_bytes(checked_slice(
+            &response,
+            0,
+            size_of::<Shake256ContextResp>(),
+        )?)
+        .map_err(|_| INTERNAL_BUG)?;
+        copy_bytes(state.context_mut()?, &response.context)?;
+    }
+    Ok(())
+}
+
+fn build_shake256_request<'a, A: ApiAlloc>(
+    alloc: &'a A,
+    command: u32,
+    context: Option<&[u8]>,
+    data: &[u8],
+) -> McuResult<A::Buf<'a>> {
+    if data.len() > MAX_CMB_DATA_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let is_init = command == CMD_CM_SHAKE256_INIT;
+    if !is_init && command != CMD_CM_SHAKE256_UPDATE && command != CMD_CM_SHAKE256_FINAL {
+        return Err(INVARIANT);
+    }
+    if is_init != context.is_none() {
+        return Err(INVARIANT);
+    }
+
+    let prefix_len = if is_init {
+        size_of::<Shake256InitPrefix>()
+    } else {
+        size_of::<Shake256UpdatePrefix>()
+    };
+    let mut request = alloc.alloc(pad4(prefix_len.checked_add(data.len()).ok_or(INVARIANT)?))?;
+    request.fill(0);
+
+    if is_init {
+        let prefix =
+            Shake256InitPrefix::mut_from_bytes(checked_slice_mut(&mut request, 0, prefix_len)?)
+                .map_err(|_| INVARIANT)?;
+        prefix.input_size = U32::new(data.len() as u32);
+    } else {
+        let prefix =
+            Shake256UpdatePrefix::mut_from_bytes(checked_slice_mut(&mut request, 0, prefix_len)?)
+                .map_err(|_| INVARIANT)?;
+        copy_bytes(
+            &mut prefix.context,
+            checked_slice(context.ok_or(INVARIANT)?, 0, SHAKE256_CONTEXT_SIZE)?,
+        )?;
+        prefix.input_size = U32::new(data.len() as u32);
+    }
+
+    copy_bytes(
+        checked_slice_mut(&mut request, prefix_len, data.len())?,
+        data,
+    )?;
+    populate_checksum(command, &mut request)?;
+    Ok(request)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use crate::wire::calc_checksum;
+    use std::vec::Vec;
+
+    struct TestAlloc;
+
+    impl ApiAlloc for TestAlloc {
+        type Buf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc(&self, len: usize) -> McuResult<Self::Buf<'_>> {
+            Ok(std::vec![0; len])
+        }
+    }
+
+    #[test]
+    fn shake256_init_request_preserves_input_and_checksum() {
+        let data = [0x5au8; 17];
+        let request =
+            build_shake256_request(&TestAlloc, CMD_CM_SHAKE256_INIT, None, &data).unwrap();
+        let prefix = Shake256InitPrefix::ref_from_prefix(&request).unwrap().0;
+        let mut checksum_input = request.clone();
+        checksum_input[..4].fill(0);
+
+        assert_eq!(prefix.input_size.get(), data.len() as u32);
+        assert_eq!(
+            &request[size_of::<Shake256InitPrefix>()..][..data.len()],
+            &data
+        );
+        assert_eq!(
+            prefix.chksum.get(),
+            calc_checksum(CMD_CM_SHAKE256_INIT, &checksum_input)
+        );
+    }
+
+    #[test]
+    fn shake256_update_request_preserves_context_and_input() {
+        let context = [0xa5u8; SHAKE256_CONTEXT_SIZE];
+        let data = [0x3cu8; 9];
+        let request =
+            build_shake256_request(&TestAlloc, CMD_CM_SHAKE256_UPDATE, Some(&context), &data)
+                .unwrap();
+        let prefix = Shake256UpdatePrefix::ref_from_prefix(&request).unwrap().0;
+
+        assert_eq!(prefix.context, context);
+        assert_eq!(prefix.input_size.get(), data.len() as u32);
+        assert_eq!(
+            &request[size_of::<Shake256UpdatePrefix>()..][..data.len()],
+            &data
+        );
+    }
+}

--- a/runtime/userspace/api/measurement-api/src/api/mod.rs
+++ b/runtime/userspace/api/measurement-api/src/api/mod.rs
@@ -27,10 +27,11 @@ use caliptra_mcu_libtock_platform::Syscalls;
 use core::marker::PhantomData;
 use mcu_caliptra_api::{
     dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
-    dpe_derive_context_exported_cdi, dpe_rotate_context_default, dpe_sign_ecc_p384, dpe_tag_tci,
-    sha_finish, sha_init, sha_update, ApiAlloc, AuthorizeAndStashFlags, AuthorizeAndStashParams,
+    dpe_derive_context_exported_cdi, dpe_rotate_context_default, dpe_sign, dpe_tag_tci, sha_finish,
+    sha_init, sha_update, ApiAlloc, AuthorizeAndStashFlags, AuthorizeAndStashParams,
     DpeContextHandle, DpeDeriveContextFlags, DpeDeriveContextParams, DpeProfile, HashAlgo,
-    DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN, DPE_TCI_MEASUREMENT_SIZE, SHA_CONTEXT_SIZE,
+    SigningInput, DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN, DPE_TCI_MEASUREMENT_SIZE,
+    SHA_CONTEXT_SIZE,
 };
 
 use crate::attestation_manifest::{parse_and_validate, AttestationManifest, MCU_RT_FW_ID};
@@ -341,21 +342,21 @@ impl<'a, S: Syscalls> MeasurementApi<'a, S> {
             .map_err(|_| MeasurementApiError::DigestFailed)
     }
 
-    /// Sign a digest with the configured attestation target and persist the
-    /// rotated target handle returned by DPE.
+    /// Sign a typed input with the configured attestation target and persist
+    /// the rotated target handle returned by DPE.
     pub async fn sign<A: ApiAlloc>(
         &mut self,
         alloc: &A,
         key_label: &[u8; DPE_LABEL_LEN],
-        digest: &[u8],
+        signing_input: SigningInput<'_>,
         signature: &mut [u8],
     ) -> MeasurementApiResult<usize> {
         let target = self.read_attestation_target_record()?;
-        let (next_handle, signature_len) = dpe_sign_ecc_p384(
+        let (next_handle, signature_len) = dpe_sign(
             alloc,
             Some(&target.context_handle),
             key_label,
-            digest,
+            signing_input,
             signature,
         )
         .await

--- a/runtime/userspace/api/measurement-api/src/lib.rs
+++ b/runtime/userspace/api/measurement-api/src/lib.rs
@@ -16,9 +16,8 @@ use errors::{MeasurementApiError, MeasurementApiResult};
 pub use image_metadata::{
     ImageMetadata, ImageMetadataFlags, MeasurementOperation, IMAGE_MEASUREMENT_DIGEST_SIZE,
 };
-pub use mcu_caliptra_api::DpeProfile;
-pub use mcu_caliptra_api::ImageHashSource;
 use mcu_caliptra_api::{ApiAlloc, DPE_LABEL_LEN};
+pub use mcu_caliptra_api::{DpeProfile, ImageHashSource, SigningInput};
 use mcu_error::McuResult;
 
 static MEASUREMENT_API: Mutex<
@@ -184,18 +183,18 @@ pub async fn leaf_kid<A: ApiAlloc>(
     api.leaf_kid(alloc, key_label, kid).await
 }
 
-/// Sign `digest` with the configured attestation target.
+/// Sign a typed input with the configured attestation target.
 pub async fn sign<A: ApiAlloc>(
     alloc: &A,
     key_label: &[u8; DPE_LABEL_LEN],
-    digest: &[u8],
+    signing_input: SigningInput<'_>,
     signature: &mut [u8],
 ) -> MeasurementApiResult<usize> {
     let mut guard = MEASUREMENT_API.lock().await;
     let api = guard
         .as_mut()
         .ok_or(MeasurementApiError::AttestationDisabled)?;
-    api.sign(alloc, key_label, digest, signature).await
+    api.sign(alloc, key_label, signing_input, signature).await
 }
 
 /// Generate a selected-AK `kid`, encode concise evidence, build the evidence
@@ -243,7 +242,14 @@ where
         .digest_for_signature(alloc, concise_evidence_len, sig_digest)
         .await?;
     let (evidence_len, signature) = evidence_builder.signature_buffer_mut(payload_len)?;
-    let sig_len = api.sign(alloc, key_label, sig_digest, signature).await?;
+    let sig_len = api
+        .sign(
+            alloc,
+            key_label,
+            SigningInput::EccP384Digest(sig_digest),
+            signature,
+        )
+        .await?;
     if sig_len != signature.len() {
         return Err(mcu_error::codes::INTERNAL_BUG);
     }

--- a/runtime/userspace/api/spdm-lib/pal/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/alloc.rs
@@ -61,8 +61,8 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
         self.allocator.alloc_bytes(len)
     }
 
-    fn large_capacity(&self) -> usize {
-        self.max_spdm_msg_size
+    fn large_buffered_msg_capacity(&self) -> usize {
+        self.large_buffered_msg_capacity
     }
 
     type LargeBuf = BitmapBytes<'static>;
@@ -109,7 +109,7 @@ mod tests {
     }
 
     /// Validates the *shipping* emulator configuration: a 12 KiB pool must be
-    /// able to hand out the declared `MAX_SPDM_MSG_SIZE` (8 KiB) large buffer
+    /// able to hand out the declared 8 KiB buffered large-message allocation
     /// while the session working set is live, after sustained request churn.
     ///
     /// This is the empirical counterpart to the platform's `required_scratch()`
@@ -117,19 +117,18 @@ mod tests {
     /// allocator can actually place the run.
     ///
     /// Mirrors `platforms/emulator/.../spdm/mod.rs`:
-    ///   * pool            = `SPDM_SCRATCH_SIZE`      = 12 KiB
-    ///   * large buffer    = `MAX_SPDM_MSG_SIZE`      =  8 KiB
-    ///   * session set     = `SESSION_WORKING_SET`    = ~2.3 KiB live throughout
-    ///   * inline response = `MAX_TRANSPORT_MTU`      =  1 KiB, concurrent with
+    ///   * pool            = `SPDM_SCRATCH_SIZE`              = 12 KiB
+    ///   * large buffer    = `MAX_BUFFERED_SPDM_MSG_SIZE`      =  8 KiB
+    ///   * session set     = `SESSION_WORKING_SET`            = ~2.3 KiB live throughout
+    ///   * inline response = `MAX_TRANSPORT_MTU`              =  1 KiB, concurrent with
     ///     the large buffer
     ///
     /// If this fails, either `SPDM_SCRATCH_SIZE` must grow or
-    /// `MAX_SPDM_MSG_SIZE` must shrink — the responder would otherwise
-    /// advertise a `MaxSPDMmsgSize` it cannot honor.
+    /// `MAX_BUFFERED_SPDM_MSG_SIZE` must shrink.
     #[test]
-    fn declared_max_spdm_msg_size_is_allocatable_from_shipping_pool() {
+    fn buffered_large_message_capacity_is_allocatable_from_shipping_pool() {
         const POOL: usize = 12 * 1024;
-        const MAX_SPDM_MSG_SIZE: usize = 8 * 1024;
+        const MAX_BUFFERED_SPDM_MSG_SIZE: usize = 8 * 1024;
         const MAX_TRANSPORT_MTU: usize = 1024;
 
         let (alloc, _buf) = make_alloc(POOL);
@@ -177,16 +176,16 @@ mod tests {
             .expect("inline response buffer must fit alongside the session set");
 
         let largest_run_bytes = alloc.largest_free_run() * BITMAP_SLOT_SIZE;
-        let large = alloc.alloc_bytes(MAX_SPDM_MSG_SIZE);
+        let large = alloc.alloc_bytes(MAX_BUFFERED_SPDM_MSG_SIZE);
 
         match large {
-            Ok(buf) => assert_eq!(buf.len(), MAX_SPDM_MSG_SIZE),
+            Ok(buf) => assert_eq!(buf.len(), MAX_BUFFERED_SPDM_MSG_SIZE),
             Err(_) => panic!(
-                "declared MaxSPDMmsgSize is not deliverable: {} B allocation failed \
+                "buffered large-message allocation is not deliverable: {} B allocation failed \
                  from a {} B pool after 50 cycles. baseline_live={} slots, \
                  largest_free_run={} bytes. Raise SPDM_SCRATCH_SIZE or lower \
-                 MAX_SPDM_MSG_SIZE in the platform SPDM config.",
-                MAX_SPDM_MSG_SIZE, POOL, baseline_live, largest_run_bytes
+                 MAX_BUFFERED_SPDM_MSG_SIZE in the platform SPDM config.",
+                MAX_BUFFERED_SPDM_MSG_SIZE, POOL, baseline_live, largest_run_bytes
             ),
         }
     }

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
@@ -271,7 +271,21 @@ const MANAGED_ERASED_BYTE: u8 = 0xFF;
 #[cfg(feature = "set-certificate")]
 const MANAGED_KEY_USAGE_MASK: u16 = 0x0003;
 #[cfg(feature = "set-certificate")]
-const MANAGED_MAX_DER_LEN: usize = (u16::MAX as usize) - 52;
+const SPDM_CERT_CHAIN_HEADER_SIZE: usize = 4 + 48;
+/// This limit is tunable based on the integrator's requirements.
+#[cfg(feature = "set-certificate")]
+const MANAGED_MAX_DER_LEN: usize = (u16::MAX as usize) - SPDM_CERT_CHAIN_HEADER_SIZE;
+
+/// Usable DER bytes in one managed endorsement region.
+#[cfg(feature = "set-certificate")]
+pub const fn managed_endorsement_der_capacity(region_size: usize) -> usize {
+    let available = region_size.saturating_sub(MANAGED_HEADER_SIZE);
+    if available < MANAGED_MAX_DER_LEN {
+        available
+    } else {
+        MANAGED_MAX_DER_LEN
+    }
+}
 
 #[cfg(feature = "set-certificate")]
 type CertStoreFlash = SpiFlash<DefaultSyscalls>;
@@ -595,9 +609,7 @@ impl ManagedEndorsement {
     }
 
     fn der_capacity(&self) -> usize {
-        self.capacity
-            .saturating_sub(MANAGED_HEADER_SIZE)
-            .min(MANAGED_MAX_DER_LEN)
+        managed_endorsement_der_capacity(self.capacity)
     }
 }
 
@@ -730,5 +742,13 @@ mod tests {
     fn managed_capacity_excludes_header() {
         let endorsement = ManagedEndorsement::new(2, 0x7000_000A, 0, 4096);
         assert_eq!(endorsement.der_capacity(), 4096 - MANAGED_HEADER_SIZE);
+    }
+
+    #[test]
+    fn managed_der_capacity_obeys_standard_cert_chain_limit() {
+        assert_eq!(
+            managed_endorsement_der_capacity(usize::MAX),
+            u16::MAX as usize - SPDM_CERT_CHAIN_HEADER_SIZE
+        );
     }
 }

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
@@ -304,7 +304,6 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
     ) -> McuResult<usize> {
         let idx = slot_index(slot).ok_or(INVARIANT)?;
 
-        // 1. PRE-CHECK: Ensure Slot is provisioned and not undergoing updates before starting
         if self.cert_store.cert_slots()[idx]
             .write_in_progress
             .load(Ordering::Relaxed)
@@ -312,33 +311,12 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
             return Err(INVARIANT);
         }
 
-        let cert_slot = &self.cert_store.cert_slots()[idx];
-        let capacity = cert_slot
+        // SlotSizeRequested describes endorsement storage. The generated DPE
+        // and leaf certificates appended to GET_CERTIFICATE are not stored here.
+        self.cert_store.cert_slots()[idx]
             .endorsement
             .capacity(algo)
-            .map_err(|_| INVARIANT)?;
-        let total = if cert_slot.is_writable() {
-            let (dpe_len, dpe_skip_len) = dpe_chain_len_and_skip_prefix(
-                self,
-                DpeProfile::from(algo),
-                DPE_IDEVID_AND_LDEVID_CERT_COUNT,
-            )
-            .await?;
-            let leaf_len = probe_leaf_len(self, DpeProfile::from(algo)).await?;
-            ChainLayout::new(capacity, dpe_len, dpe_skip_len, leaf_len)?.total_len()
-        } else {
-            capacity
-        };
-
-        // 2. POST-CHECK: Verify Slot remained unlocked during the intermediate async .await points
-        if self.cert_store.cert_slots()[idx]
-            .write_in_progress
-            .load(Ordering::Relaxed)
-        {
-            return Err(INVARIANT);
-        }
-
-        Ok(total)
+            .map_err(|_| INVARIANT)
     }
 
     #[inline]

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
@@ -17,7 +17,7 @@ pub mod store;
 
 use super::measurements::MeasurementProvider;
 use super::*;
-use caliptra_mcu_spdm_traits::{SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHashAlgo};
+use caliptra_mcu_spdm_traits::{SigningInput, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHashAlgo};
 use core::ops::Range;
 use core::sync::atomic::Ordering;
 use endorsement::slot_index;
@@ -537,18 +537,26 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         Ok(written)
     }
 
-    async fn sign_hash(
+    async fn sign(
         &self,
         _io: &Self::Io<'_>,
         slot: u8,
-        _algo: SpdmPalAsymAlgo,
-        digest: &[u8],
+        algo: SpdmPalAsymAlgo,
+        signing_input: SigningInput<'_>,
         signature: &mut [u8],
     ) -> McuResult<usize> {
         let _idx = slot_index(slot).ok_or(INVARIANT)?;
-        caliptra_mcu_measurement_api::sign(self.allocator, &DPE_LEAF_LABEL, digest, signature)
-            .await
-            .map_err(|_| INTERNAL_BUG)
+        if DpeProfile::from(algo) != signing_input.profile() {
+            return Err(INVARIANT);
+        }
+        caliptra_mcu_measurement_api::sign(
+            self.allocator,
+            &DPE_LEAF_LABEL,
+            signing_input,
+            signature,
+        )
+        .await
+        .map_err(|_| INTERNAL_BUG)
     }
 
     #[cfg(feature = "set-certificate")]

--- a/runtime/userspace/api/spdm-lib/pal/src/pal.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/pal.rs
@@ -54,15 +54,13 @@ pub struct McuSpdmPal<M: MeasurementProvider> {
     /// Measurement data provider (monomorphized).
     pub(crate) meas_provider: M,
 
-    /// Largest single in-flight SPDM message (request or response) this
-    /// responder supports, as declared by the integrator.
+    /// Endpoint-wide logical request limit advertised as `MaxSPDMmsgSize`.
     ///
-    /// This is a contract, not a measurement: it is advertised verbatim as
-    /// `MaxSPDMmsgSize` in `CAPABILITIES` and used for buffered large
-    /// request/response admission checks. The scratch pool backing
-    /// [`Self::allocator`] must be sized to satisfy it; see the platform's
-    /// scratch budget assertion.
-    pub(crate) max_spdm_msg_size: usize,
+    /// This is the maximum across buffered and streamed request paths.
+    pub(crate) max_inbound_spdm_request_size: usize,
+
+    /// Scratch-backed capacity for a complete buffered request or response.
+    pub(crate) large_buffered_msg_capacity: usize,
 }
 
 impl<M: MeasurementProvider> McuSpdmPal<M> {
@@ -80,22 +78,24 @@ impl<M: MeasurementProvider> McuSpdmPal<M> {
     ///
     /// # Parameters
     ///
-    /// * `max_spdm_msg_size` — Largest single in-flight SPDM message this
-    ///   responder supports. Advertised as `MaxSPDMmsgSize`, so the caller
-    ///   must have sized the scratch region behind `allocator` to satisfy it.
+    /// * `max_inbound_spdm_request_size` — Advertised logical request limit across
+    ///   buffered and streamed receive paths.
+    /// * `large_buffered_msg_capacity` — Scratch-backed buffered-message limit.
     pub unsafe fn new(
         transport: Box<dyn SpdmPalTransport>,
         allocator: &'static BitmapAllocator,
         cert_store: &'static SharedCertStore,
         meas_provider: M,
-        max_spdm_msg_size: usize,
+        max_inbound_spdm_request_size: usize,
+        large_buffered_msg_capacity: usize,
     ) -> Self {
         Self {
             transport: UnsafeCell::new(transport),
             allocator,
             cert_store: TaskCertStore::new(cert_store),
             meas_provider,
-            max_spdm_msg_size,
+            max_inbound_spdm_request_size,
+            large_buffered_msg_capacity,
         }
     }
 
@@ -131,4 +131,8 @@ impl<M: MeasurementProvider> McuSpdmPal<M> {
     }
 }
 
-impl<M: MeasurementProvider> SpdmPal for McuSpdmPal<M> {}
+impl<M: MeasurementProvider> SpdmPal for McuSpdmPal<M> {
+    fn max_inbound_spdm_request_size(&self) -> usize {
+        self.max_inbound_spdm_request_size
+    }
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/build.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/build.rs
@@ -12,10 +12,10 @@
 //! never touch the PAL allocator directly, and never forget to
 //! reserve the transport-framing header.
 
-use caliptra_mcu_spdm_codec::{ResponseBody, SpdmVersion, WireWriter};
+use caliptra_mcu_spdm_codec::{ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, WireWriter};
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal};
 
-use crate::error::SpdmResult;
+use crate::error::{SpdmError, SpdmResult};
 
 /// Copy a fixed-size array `src` into `buf` at `pos`, returning the advanced
 /// cursor.
@@ -108,26 +108,33 @@ where
     Ok(buf)
 }
 
-/// Non-generic helper for the error path. Builds an ERROR PDU
-/// (DSP0274 §10.10) without going through the generic
-/// [`build_response`] — saves one monomorphisation worth of code and
-/// keeps the dispatcher's error branch tiny.
+/// Encodes an SPDM ERROR PDU into an existing buffer.
+pub(crate) fn encode_error_response(
+    out: &mut [u8],
+    version: SpdmVersion,
+    error: SpdmError,
+) -> SpdmResult<usize> {
+    let extended_data = error.extended_data();
+    let mut w = WireWriter::new(out);
+    w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::ERROR))?;
+    w.write(&[error.spec_byte(), error.error_data()])?;
+    w.write(extended_data)?;
+    Ok(SpdmMsgHdrPdu::SIZE + 2 + extended_data.len())
+}
+
+/// Non-generic helper for the error path. Builds an ERROR PDU without going
+/// through the generic [`build_response`], saving one monomorphisation and
+/// keeping the dispatcher's error branch tiny.
 #[inline(never)]
 pub(crate) fn build_error_response<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &Pal::Io<'_>,
     version: SpdmVersion,
-    error_code: u8,
-    error_data: u8,
-    extended_data: &[u8],
+    error: SpdmError,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    use caliptra_mcu_spdm_codec::{ReqRespCode, SpdmMsgHdrPdu};
     let head = pal.header_size();
-    let raw_len = head + SpdmMsgHdrPdu::SIZE + 2 + extended_data.len();
+    let raw_len = head + SpdmMsgHdrPdu::SIZE + 2 + error.extended_data().len();
     let mut buf = alloc_padded(pal, io, raw_len)?;
-    let mut w = WireWriter::new(&mut buf[head..]);
-    w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::ERROR))?;
-    w.write(&[error_code, error_data])?;
-    w.write(extended_data)?;
+    encode_error_response(&mut buf[head..], version, error)?;
     Ok(buf)
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -35,9 +35,8 @@ use crate::version::SUPPORTED_VERSIONS;
 /// * `state` — Mutable connection state. On success, peer capability
 ///   fields are populated and `phase` advances to
 ///   [`Phase::AfterCapabilities`].
-/// * `pal` — Borrowed PAL used to allocate the response and query
-///   `mtu()` for the responder's `DataTransferSize` /
-///   `MaxSPDMmsgSize` fields.
+/// * `pal` — Borrowed PAL providing the single-frame and logical-request
+///   receive limits.
 /// * `io` — The I/O handle for the current request.
 ///
 /// # Returns
@@ -86,8 +85,9 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
         flags = CapFlags::from_bits(flags.into_bits() & !secure_session_caps.into_bits());
     }
     state.advertised_cap_flags = flags;
+    // MaxSPDMmsgSize covers all buffered and streamed inbound request paths.
     let max_spdm_msg_size = if flags.contains(CapFlags::CHUNK) {
-        pal.large_capacity().max(mtu)
+        pal.max_inbound_spdm_request_size()
     } else {
         mtu
     } as u32;

--- a/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
@@ -28,8 +28,7 @@ use crate::error::{
 };
 use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 
-/// Size of the SPDM cert-chain wire header that prepends every cert
-/// chain (DSP0274 §10.6.1 Table 33):
+/// Size of the currently supported SPDM cert-chain wire header:
 /// `Length(2) | Reserved(2) | RootHash(48)`.
 const SPDM_CERT_CHAIN_HDR_LEN: usize = 4 + 48;
 const SHA384_DIGEST_SIZE: usize = 48;
@@ -214,8 +213,12 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
         .checked_add(der_len)
         .ok_or(SPDM_UNSPECIFIED)?;
 
-    if total_len_usize > req.max_length_cap() {
-        return Err(SPDM_DATA_TOO_LARGE);
+    if total_len_usize > u16::MAX as usize {
+        if state.version >= SpdmVersion::V14 && !req.is_large() {
+            let actual_size = u32::try_from(total_len_usize).map_err(|_| SPDM_UNSPECIFIED)?;
+            return Err(SPDM_DATA_TOO_LARGE.with_extended_data(actual_size.to_le_bytes()));
+        }
+        return Err(SPDM_UNSPECIFIED);
     }
 
     let single_frame_portion = state
@@ -232,7 +235,7 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
         let chunking = state.chunking_enabled();
         let max_portion = if chunking {
             state
-                .effective_max_spdm_msg_size(pal)
+                .peer_max_spdm_message_size()?
                 .saturating_sub(SpdmMsgHdrPdu::SIZE + req.rsp_header_body_size())
         } else {
             single_frame_portion
@@ -267,9 +270,7 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
             pal,
             io,
             state.version,
-            SPDM_LARGE_RESPONSE.spec_byte(),
-            0,
-            &[handle],
+            SPDM_LARGE_RESPONSE.with_extended_data([handle]),
         )?;
 
         state.transcript.append_m1(pal, io, spdm_msg).await?;
@@ -346,7 +347,9 @@ pub(crate) async fn fill_cert_chain_portion<Pal: SpdmPal>(
         return Ok(());
     }
     let der_len = pal.cert_chain_len(io, slot, asym_algo).await?;
-    let total_len = SPDM_CERT_CHAIN_HDR_LEN + der_len;
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN
+        .checked_add(der_len)
+        .ok_or(mcu_error::codes::INVARIANT)?;
     let end = offset
         .checked_add(dst.len())
         .ok_or(mcu_error::codes::INVARIANT)?;
@@ -358,11 +361,8 @@ pub(crate) async fn fill_cert_chain_portion<Pal: SpdmPal>(
     let mut written = 0;
     if offset < SPDM_CERT_CHAIN_HDR_LEN {
         let mut hdr = [0u8; SPDM_CERT_CHAIN_HDR_LEN];
-        let len_bytes = (total_len as u16).to_le_bytes();
-        for (d, s) in hdr.iter_mut().take(len_bytes.len()).zip(&len_bytes) {
-            *d = *s;
-        }
-        // bytes 2..4 (Reserved) stay zero
+        let length = u16::try_from(total_len).map_err(|_| mcu_error::codes::INVARIANT)?;
+        hdr[..2].copy_from_slice(&length.to_le_bytes());
         let root_hash = hdr
             .get_mut(4..4 + SHA384_DIGEST_SIZE)
             .ok_or(mcu_error::codes::INVARIANT)?;

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -156,7 +156,13 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
         .get_mut(head + no_sig_len..head + no_sig_len + ECC_P384_SIGNATURE_SIZE)
         .ok_or(SPDM_UNSPECIFIED)?;
     let sig_len = pal
-        .sign_hash(io, slot_id, asym_algo, &m1_hash, sig_slot)
+        .sign(
+            io,
+            slot_id,
+            asym_algo,
+            SigningInput::EccP384Digest(&m1_hash),
+            sig_slot,
+        )
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
     if sig_len != ECC_P384_SIGNATURE_SIZE {

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
@@ -14,8 +14,8 @@ use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTranspo
 use crate::build::build_error_response;
 use crate::certificate::CertificateLargeResponse;
 use crate::error::{
-    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE, SPDM_UNEXPECTED_REQUEST,
-    SPDM_UNSPECIFIED,
+    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE, SPDM_RESPONSE_TOO_LARGE,
+    SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
 };
 use crate::stack::ConnectionState;
 
@@ -355,15 +355,17 @@ pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
     let capacity = if let Some(buf) = state.large_msg_ctx.get_buffer() {
         buf.len()
     } else {
-        pal.large_capacity()
+        pal.large_buffered_msg_capacity()
     };
 
-    validate_buffered_large_response_with_capacity(state, pal, large_resp_len, capacity)
+    validate_buffered_large_response_with_capacity(state, large_resp_len, capacity)
 }
 
-pub(crate) fn validate_buffered_large_response_with_capacity<Pal: SpdmPal>(
-    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    pal: &Pal,
+pub(crate) fn validate_buffered_large_response_with_capacity<
+    S,
+    L: core::ops::DerefMut<Target = [u8]>,
+>(
+    state: &ConnectionState<S, L>,
     large_resp_len: usize,
     capacity: usize,
 ) -> SpdmResult<()> {
@@ -374,15 +376,15 @@ pub(crate) fn validate_buffered_large_response_with_capacity<Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
-    let local_max_spdm_msg_size = capacity.max(pal.mtu());
-    let peer_max_spdm_msg_size = if state.peer_max_spdm_msg_size == 0 {
-        local_max_spdm_msg_size
-    } else {
-        state.peer_max_spdm_msg_size as usize
-    };
-    let effective_max_spdm_msg_size = local_max_spdm_msg_size.min(peer_max_spdm_msg_size);
+    // ResponseTooLarge applies only when the response exceeds the requester's
+    // advertised MaxSPDMmsgSize.
+    if large_resp_len > state.peer_max_spdm_message_size()? {
+        let actual_size = u32::try_from(large_resp_len).map_err(|_| SPDM_UNSPECIFIED)?;
+        return Err(SPDM_RESPONSE_TOO_LARGE.with_extended_data(actual_size.to_le_bytes()));
+    }
 
-    if large_resp_len > capacity || large_resp_len > effective_max_spdm_msg_size {
+    // Exceeding Caliptra's buffer is a local capacity failure.
+    if large_resp_len > capacity {
         return Err(SPDM_UNSPECIFIED);
     }
     Ok(())
@@ -400,9 +402,7 @@ pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
         pal,
         io,
         state.version,
-        SPDM_LARGE_RESPONSE.spec_byte(),
-        0,
-        &[handle],
+        SPDM_LARGE_RESPONSE.with_extended_data([handle]),
     )?;
     let spdm_len = resp.len() - pal.header_size();
     let rent_buf = state.large_msg_ctx.take_buffer();
@@ -410,4 +410,49 @@ pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
         .large_msg_ctx
         .start_response(LargeResponse::Buffered, large_resp_len, rent_buf)?;
     Ok((resp, spdm_len))
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::vec::Vec;
+    use caliptra_mcu_spdm_codec::{CapFlags, ReqRespCode, SpdmVersion};
+
+    use super::*;
+    use crate::build::encode_error_response;
+
+    #[test]
+    fn buffered_response_distinguishes_peer_and_local_limits() {
+        let mut state: ConnectionState<(), Vec<u8>> = ConnectionState::default();
+        state.peer_cap_flags = CapFlags::CHUNK;
+        state.peer_max_spdm_msg_size = 1024;
+
+        let err = validate_buffered_large_response_with_capacity(&state, 1025, 2048).unwrap_err();
+        assert_eq!(err.spec_byte(), SPDM_RESPONSE_TOO_LARGE.spec_byte());
+        assert_eq!(err.error_data(), 0);
+        assert_eq!(err.extended_data(), 1025u32.to_le_bytes());
+
+        let mut error_rsp = [0u8; 8];
+        let error_rsp_len = encode_error_response(&mut error_rsp, SpdmVersion::V12, err).unwrap();
+        assert_eq!(error_rsp_len, error_rsp.len());
+        assert_eq!(
+            error_rsp,
+            [
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_RESPONSE_TOO_LARGE.spec_byte(),
+                0,
+                1,
+                4,
+                0,
+                0,
+            ]
+        );
+
+        state.peer_max_spdm_msg_size = 2048;
+        let err = validate_buffered_large_response_with_capacity(&state, 1025, 1024).unwrap_err();
+        assert_eq!(err, SPDM_UNSPECIFIED);
+        assert!(err.extended_data().is_empty());
+    }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
@@ -17,7 +17,7 @@ use super::ActiveLargeRequest;
 use super::StreamPrefixState;
 #[cfg(any(test, feature = "generic-large-request"))]
 use super::WipeOnDrop;
-use crate::build::alloc_padded;
+use crate::build::{alloc_padded, encode_error_response};
 use crate::error::*;
 #[cfg(feature = "set-certificate")]
 use crate::set_certificate;
@@ -84,9 +84,17 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         }) => {
             abort_active_streaming_request(state, pal, io, vdm).await;
             let mut error = [0u8; 4];
-            encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
+            let error_len = encode_error_response(&mut error, state.version, SPDM_INVALID_REQUEST)?;
             state.reset_chunk_assembly();
-            build_chunk_send_ack(pal, io, state.version, true, handle, chunk_seq_num, &error)
+            build_chunk_send_ack(
+                pal,
+                io,
+                state.version,
+                true,
+                handle,
+                chunk_seq_num,
+                &error[..error_len],
+            )
         }
     }
 }
@@ -152,8 +160,8 @@ async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         return Err(ChunkProcessError::Spdm(SPDM_UNEXPECTED_REQUEST));
     }
 
-    // Ensure the incoming request message fits our standard effective bounds, not raw MTU.
-    if req.len() > state.effective_data_transfer_size(pal) {
+    // Incoming chunks use our DataTransferSize; the peer's limit is outbound.
+    if req.len() > pal.mtu() {
         return Err(ChunkProcessError::Spdm(SPDM_INVALID_REQUEST));
     }
 
@@ -256,12 +264,14 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         - ChunkSendReqBody::SIZE
         - 4;
 
+    // CHUNK_SEND is valid only above our single-frame limit and within our
+    // endpoint-wide logical request limit.
     let invalid = chunk_seq_num != 0
         || last_chunk
         || chunk_size < min_chunk_size
         || chunk_size >= large_msg_size
-        || large_msg_size <= CapabilitiesBody::MIN_DATA_TRANSFER_SIZE as usize
-        || large_msg_size > pal.large_capacity();
+        || large_msg_size <= pal.mtu()
+        || large_msg_size > pal.max_inbound_spdm_request_size();
     if invalid {
         return Err(ChunkProcessError::Early {
             handle,
@@ -324,6 +334,13 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     }
     #[cfg(any(test, feature = "generic-large-request"))]
     {
+        // Only non-streamed requests consume the persistent scratch buffer.
+        if large_msg_size > pal.large_buffered_msg_capacity() {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            });
+        }
         let rent_buf = match pal.alloc_large_buf(large_msg_size) {
             Ok(buf) => buf,
             Err(_) => {
@@ -695,7 +712,26 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     chunk_seq_num: u16,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     let len = state.large_msg_ctx.state.large_msg_size as usize;
-    let mut response_to_large_request = [0u8; LARGE_REQUEST_RESPONSE_BUF_SIZE];
+    let mut response_to_large_request =
+        match SpdmPalAlloc::alloc(pal, io, [0u8; LARGE_REQUEST_RESPONSE_BUF_SIZE]) {
+            Ok(response) => response,
+            Err(_) => {
+                abort_active_streaming_request(state, pal, io, vdm).await;
+                state.reset_chunk_assembly();
+                let mut error = [0u8; 4];
+                let error_len = encode_error_response(&mut error, state.version, SPDM_UNSPECIFIED)?;
+                return build_chunk_send_ack(
+                    pal,
+                    io,
+                    state.version,
+                    false,
+                    handle,
+                    chunk_seq_num,
+                    &error[..error_len],
+                )
+                .map_err(|_| SPDM_UNSPECIFIED);
+            }
+        };
     let active = state.large_msg_ctx.active_request().copied();
     let (mut response_len, early_error) = match active {
         #[cfg(feature = "set-certificate")]
@@ -714,11 +750,11 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                 Err(spdm) => {
                     set_certificate::abort_set_certificate_stream(state, pal, io, &stream).await;
                     (
-                        write_error_response_to_large_request(
-                            &mut response_to_large_request,
+                        encode_error_response(
+                            &mut response_to_large_request[..],
                             state.version,
                             spdm,
-                        ),
+                        )?,
                         false,
                     )
                 }
@@ -729,11 +765,11 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             let envelope_len = SpdmMsgHdrPdu::SIZE + 2 + 2 + 1 + vendor_id.len() + 2;
             if envelope_len > response_to_large_request.len() {
                 (
-                    write_error_response_to_large_request(
-                        &mut response_to_large_request,
+                    encode_error_response(
+                        &mut response_to_large_request[..],
                         state.version,
                         SPDM_UNSPECIFIED,
-                    ),
+                    )?,
                     false,
                 )
             } else {
@@ -760,11 +796,11 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                             .is_err();
                         if invalid_response {
                             (
-                                write_error_response_to_large_request(
-                                    &mut response_to_large_request,
+                                encode_error_response(
+                                    &mut response_to_large_request[..],
                                     state.version,
                                     SPDM_UNSPECIFIED,
-                                ),
+                                )?,
                                 false,
                             )
                         } else {
@@ -772,22 +808,22 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                         }
                     }
                     _ => (
-                        write_error_response_to_large_request(
-                            &mut response_to_large_request,
+                        encode_error_response(
+                            &mut response_to_large_request[..],
                             state.version,
                             SPDM_UNSPECIFIED,
-                        ),
+                        )?,
                         false,
                     ),
                 }
             }
         }
         _ if len < SpdmMsgHdrPdu::SIZE => (
-            write_error_response_to_large_request(
-                &mut response_to_large_request,
+            encode_error_response(
+                &mut response_to_large_request[..],
                 state.version,
                 SPDM_INVALID_REQUEST,
-            ),
+            )?,
             false,
         ),
         #[cfg(any(test, feature = "generic-large-request"))]
@@ -798,27 +834,23 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             vdm,
             len,
             state.large_msg_ctx.state.session_id.is_some(),
-            &mut response_to_large_request,
+            &mut response_to_large_request[..],
         )
         .await
         {
             Ok(response_len) => (response_len, false),
             Err(err) => (
-                write_error_response_to_large_request(
-                    &mut response_to_large_request,
-                    state.version,
-                    err.spdm,
-                ),
+                encode_error_response(&mut response_to_large_request[..], state.version, err.spdm)?,
                 err.early_error,
             ),
         },
         #[cfg(not(any(test, feature = "generic-large-request")))]
         _ => (
-            write_error_response_to_large_request(
-                &mut response_to_large_request,
+            encode_error_response(
+                &mut response_to_large_request[..],
                 state.version,
                 SPDM_UNSUPPORTED_REQUEST,
-            ),
+            )?,
             false,
         ),
     };
@@ -827,11 +859,11 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         .effective_data_transfer_size(pal)
         .saturating_sub(SpdmMsgHdrPdu::SIZE + ChunkSendAckBody::SIZE);
     if response_len > max_response_len {
-        response_len = write_error_response_to_large_request(
-            &mut response_to_large_request,
+        response_len = encode_error_response(
+            &mut response_to_large_request[..],
             state.version,
             SPDM_LARGE_RESPONSE,
-        );
+        )?;
     }
 
     build_chunk_send_ack(
@@ -902,34 +934,6 @@ async fn dispatch_large_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         .map_err(Into::into),
         _ => Err(SPDM_UNSUPPORTED_REQUEST.into()),
     }
-}
-
-fn write_error_response_to_large_request(
-    out: &mut [u8],
-    version: SpdmVersion,
-    err: SpdmError,
-) -> usize {
-    let bytes = encode_error_response_to_large_request(version, err);
-    let len = bytes.len();
-    if let Some(dst) = out.get_mut(..len) {
-        dst.copy_from_slice(&bytes);
-        len
-    } else {
-        0
-    }
-}
-
-fn encode_error_response_to_large_request(version: SpdmVersion, err: SpdmError) -> [u8; 4] {
-    let mut out = [0u8; 4];
-    encode_error_pdu(version, err, &mut out);
-    out
-}
-
-fn encode_error_pdu(version: SpdmVersion, err: SpdmError, out: &mut [u8; 4]) {
-    out[0] = version.to_u8();
-    out[1] = ReqRespCode::ERROR.0;
-    out[2] = err.spec_byte();
-    out[3] = err.error_data();
 }
 
 #[cfg(test)]
@@ -1131,7 +1135,10 @@ mod tests {
 
     #[test]
     fn chunked_vendor_defined_debug_unlock_token_preserves_host_mailbox_payload() {
-        let pal = TestPal::default();
+        let pal = TestPal {
+            mtu: 96,
+            ..TestPal::default()
+        };
         let mut state = chunking_state();
         let vdm = CaptureVdmBackend::new();
 
@@ -1220,8 +1227,197 @@ mod tests {
     }
 
     #[test]
+    fn final_response_allocation_failure_returns_ack_and_resets_request() {
+        let pal = TestPal {
+            mtu: 96,
+            typed_alloc_error: Some(mcu_error::codes::OUT_OF_MEMORY),
+            ..TestPal::default()
+        };
+        let mut state = chunking_state();
+        let vdm = CaptureVdmBackend::new();
+        let large_req = vendor_defined_authorize_debug_unlock_request(&[0x5a; 96]);
+        let (first, second) = large_req.split_at(64);
+        let first_chunk = chunk_send_request(14, 0, false, Some(large_req.len()), first);
+        let second_chunk = chunk_send_request(14, 1, true, None, second);
+
+        let first_io = TestIo::message(first_chunk.clone());
+        block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            None,
+            true,
+        ))
+        .unwrap();
+        assert!(state.large_msg_ctx.request_in_progress());
+
+        let second_io = TestIo::message(second_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &second_io,
+            &vdm,
+            &second_chunk,
+            None,
+            true,
+        ))
+        .unwrap();
+
+        assert!(!state.large_msg_ctx.request_in_progress());
+        assert_eq!(
+            &rsp[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                14,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_UNSPECIFIED.spec_byte(),
+                0,
+            ]
+        );
+    }
+
+    #[test]
+    fn incoming_chunk_uses_local_data_transfer_size() {
+        let pal = TestPal {
+            mtu: 96,
+            max_inbound_spdm_request_size: 256,
+            ..TestPal::default()
+        };
+        let mut state = chunking_state();
+        state.peer_data_transfer_size = CapabilitiesBody::MIN_DATA_TRANSFER_SIZE;
+        let vdm = CaptureVdmBackend::new();
+
+        let host_mailbox_payload = vec![0x5au8; 4 + 96];
+        let large_req = vendor_defined_authorize_debug_unlock_request(&host_mailbox_payload);
+        assert!(large_req.len() > pal.mtu());
+
+        let first_chunk = chunk_send_request(10, 0, false, Some(large_req.len()), &large_req[..64]);
+        assert!(first_chunk.len() > state.peer_data_transfer_size as usize);
+        assert!(first_chunk.len() <= pal.mtu());
+
+        let first_io = TestIo::message(first_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            None,
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(rsp[1], ReqRespCode::CHUNK_SEND_ACK.0);
+        assert_eq!(rsp[2] & CHUNK_ACK_ATTR_EARLY_ERROR, 0);
+        assert!(state.large_msg_ctx.request_in_progress());
+    }
+
+    #[test]
+    fn incoming_chunk_rejects_frame_over_local_data_transfer_size() {
+        let pal = TestPal {
+            mtu: 79,
+            max_inbound_spdm_request_size: 256,
+            ..TestPal::default()
+        };
+        let mut state = chunking_state();
+        let vdm = CaptureVdmBackend::new();
+        let host_mailbox_payload = vec![0x5au8; 4 + 96];
+        let large_req = vendor_defined_authorize_debug_unlock_request(&host_mailbox_payload);
+        let first_chunk = chunk_send_request(11, 0, false, Some(large_req.len()), &large_req[..64]);
+        assert!(first_chunk.len() > pal.mtu());
+
+        let first_io = TestIo::message(first_chunk.clone());
+        let err = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            None,
+            true,
+        ))
+        .unwrap_err();
+
+        assert_eq!(err, SPDM_INVALID_REQUEST);
+        assert!(!state.large_msg_ctx.request_in_progress());
+    }
+
+    #[test]
+    fn incoming_chunk_rejects_non_large_logical_message() {
+        let pal = TestPal {
+            mtu: 128,
+            max_inbound_spdm_request_size: 256,
+            ..TestPal::default()
+        };
+        let mut state = chunking_state();
+        let vdm = CaptureVdmBackend::new();
+        let host_mailbox_payload = vec![0x5au8; 4 + 96];
+        let large_req = vendor_defined_authorize_debug_unlock_request(&host_mailbox_payload);
+        assert!(large_req.len() <= pal.mtu());
+        let first_chunk = chunk_send_request(12, 0, false, Some(large_req.len()), &large_req[..64]);
+
+        let first_io = TestIo::message(first_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            None,
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(rsp[1], ReqRespCode::CHUNK_SEND_ACK.0);
+        assert_ne!(rsp[2] & CHUNK_ACK_ATTR_EARLY_ERROR, 0);
+        assert!(!state.large_msg_ctx.request_in_progress());
+    }
+
+    #[test]
+    fn incoming_chunk_rejects_logical_message_over_receive_limit() {
+        let pal = TestPal {
+            mtu: 96,
+            max_inbound_spdm_request_size: 100,
+            ..TestPal::default()
+        };
+        let mut state = chunking_state();
+        let vdm = CaptureVdmBackend::new();
+        let host_mailbox_payload = vec![0x5au8; 4 + 96];
+        let large_req = vendor_defined_authorize_debug_unlock_request(&host_mailbox_payload);
+        assert!(large_req.len() > pal.max_inbound_spdm_request_size());
+        let first_chunk = chunk_send_request(13, 0, false, Some(large_req.len()), &large_req[..64]);
+
+        let first_io = TestIo::message(first_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            None,
+            true,
+        ))
+        .unwrap();
+
+        assert_eq!(rsp[1], ReqRespCode::CHUNK_SEND_ACK.0);
+        assert_ne!(rsp[2] & CHUNK_ACK_ATTR_EARLY_ERROR, 0);
+        assert!(!state.large_msg_ctx.request_in_progress());
+    }
+
+    #[test]
     fn chunked_vendor_defined_debug_unlock_falls_back_when_streaming_declines() {
-        let pal = TestPal::default();
+        let pal = TestPal {
+            mtu: 96,
+            large_buffered_msg_capacity: 256,
+            ..TestPal::default()
+        };
         let mut state = chunking_state();
         let vdm = BufferedOnlyVdmBackend::new();
 

--- a/runtime/userspace/api/spdm-lib/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/digests.rs
@@ -136,11 +136,8 @@ fn fill_multi_key_conn_rsp_data<Pal: SpdmPal>(pal: &Pal, provisioned: u8, dst: &
 /// Stream a slot's SPDM cert-chain bytes through the negotiated
 /// hash and write the digest into `out`.
 ///
-/// The SPDM cert-chain wire format (DSP0274 §10.6.1 Table 33) is
-/// `Length(2) | Reserved(2) | RootHash(48) | DER chain[..]`. We
-/// build the 52-byte header on the stack (the user explicitly
-/// allowed this small allocation) and stream the variable-length
-/// DER bytes from a pool-allocated chunk buffer.
+/// The current SPDM cert-chain wire format is
+/// `Length(2) | Reserved(2) | RootHash(48) | DER chain[..]`.
 #[inline(never)]
 pub(crate) async fn cert_chain_hash<Pal: SpdmPal>(
     pal: &Pal,
@@ -157,12 +154,13 @@ pub(crate) async fn cert_chain_hash<Pal: SpdmPal>(
     let der_len = pal.cert_chain_len(io, slot, asym_algo).await?;
     let digest_size = algo.hash_size();
 
-    // 52-byte SPDM cert-chain header on the stack. Per the user:
-    // allocating 52 B on the stack is fine.
     let mut hdr = [0u8; 4 + 48];
-    let total = (hdr.len() + der_len) as u16;
-    write_fixed(&mut hdr, 0, &total.to_le_bytes());
-    // bytes 2..4 (Reserved) already zero
+    let total_len = hdr
+        .len()
+        .checked_add(der_len)
+        .ok_or(mcu_error::codes::INVARIANT)?;
+    let length = u16::try_from(total_len).map_err(|_| mcu_error::codes::INVARIANT)?;
+    write_fixed(&mut hdr, 0, &length.to_le_bytes());
     pal.root_cert_hash(io, slot, asym_algo, algo, &mut hdr[4..4 + digest_size])
         .await?;
 

--- a/runtime/userspace/api/spdm-lib/stack/src/error.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/error.rs
@@ -2,7 +2,7 @@
 
 //! SPDM-level error type for handler ↔ dispatcher boundary.
 //!
-//! [`SpdmError`] carries the SPDM `ERROR` wire byte and any
+//! [`SpdmError`] carries the SPDM `ERROR` wire byte and up to four
 //! associated extended-data bytes that an SPDM responder needs to put
 //! into an `ERROR` PDU. Handlers return [`SpdmResult<T>`]; the
 //! dispatcher catches `Err(SpdmError)` and emits the wire-format
@@ -17,14 +17,21 @@
 use caliptra_mcu_spdm_errors::{as_spdm_wire, is_mctp_error, is_vdm_no_response};
 use mcu_error::{domain, McuErrorCode};
 
+/// SPDM permits up to 32 bytes of extended error data. Caliptra's generic
+/// error path currently retains at most four bytes.
+pub(crate) const CALIPTRA_EXTENDED_ERROR_SIZE: usize = 4;
+
 /// SPDM-level error suitable for emission as an `ERROR` PDU.
 ///
 /// Carries the SPDM `ERROR` wire byte and the one-byte `Param2`
-/// error data field used by errors such as `UnsupportedRequest`.
+/// error data field used by errors such as `UnsupportedRequest`, plus
+/// fixed-size extended data used by errors such as `ResponseTooLarge`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SpdmError {
     spec_byte: u8,
     error_data: u8,
+    extended_data_len: u8,
+    extended_data: [u8; CALIPTRA_EXTENDED_ERROR_SIZE],
 }
 
 /// Convenience alias for `core::result::Result<T, SpdmError>`.
@@ -37,6 +44,8 @@ impl SpdmError {
         Self {
             spec_byte: 0,
             error_data: 0,
+            extended_data_len: 0,
+            extended_data: [0; CALIPTRA_EXTENDED_ERROR_SIZE],
         }
     }
 
@@ -61,6 +70,8 @@ impl SpdmError {
         Self {
             spec_byte,
             error_data: 0,
+            extended_data_len: 0,
+            extended_data: [0; CALIPTRA_EXTENDED_ERROR_SIZE],
         }
     }
 
@@ -68,6 +79,19 @@ impl SpdmError {
     #[inline]
     pub const fn with_data(self, error_data: u8) -> Self {
         Self { error_data, ..self }
+    }
+
+    /// Attaches up to four bytes of extended error data.
+    #[inline]
+    pub const fn with_extended_data<const N: usize>(mut self, extended_data: [u8; N]) -> Self {
+        assert!(N <= CALIPTRA_EXTENDED_ERROR_SIZE);
+        let mut index = 0;
+        while index < N {
+            self.extended_data[index] = extended_data[index];
+            index += 1;
+        }
+        self.extended_data_len = N as u8;
+        self
     }
 
     /// Returns the SPDM `ERROR` wire byte for this error.
@@ -85,6 +109,12 @@ impl SpdmError {
     #[inline]
     pub const fn error_data(&self) -> u8 {
         self.error_data
+    }
+
+    /// Returns the extended error data associated with this error.
+    #[inline]
+    pub fn extended_data(&self) -> &[u8] {
+        &self.extended_data[..self.extended_data_len as usize]
     }
 }
 
@@ -149,6 +179,8 @@ pub const SPDM_SESSION_REQUIRED: SpdmError = SpdmError::new(0x0B);
 pub const SPDM_SESSION_LIMIT_EXCEEDED: SpdmError = SpdmError::new(0x0A);
 /// `ResetRequired` — responder requires a reset before the request can complete.
 pub const SPDM_RESET_REQUIRED: SpdmError = SpdmError::new(0x0C);
+/// `ResponseTooLarge` — response exceeds the requester's `MaxSPDMmsgSize`.
+pub const SPDM_RESPONSE_TOO_LARGE: SpdmError = SpdmError::new(0x0D);
 /// `DecryptError` — secured-message decryption / MAC verification
 /// failed.
 pub const SPDM_DECRYPT_ERROR: SpdmError = SpdmError::new(0x06);

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -302,10 +302,18 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     compute_tbs_hash(pal, io, signing_ctx, th1)
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
-    let tbs_hash = &signing_ctx[..SHA384_HASH_SIZE];
+    let tbs_hash = signing_ctx[..]
+        .first_chunk::<SHA384_HASH_SIZE>()
+        .ok_or(SPDM_UNSPECIFIED)?;
 
     let sig_len = pal
-        .sign_hash(io, slot_id, asym_algo, tbs_hash, signature)
+        .sign(
+            io,
+            slot_id,
+            asym_algo,
+            SigningInput::EccP384Digest(tbs_hash),
+            signature,
+        )
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
     if sig_len != ECC_P384_SIGNATURE_SIZE {

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -230,7 +230,7 @@ async fn handle_measurements_response<'a, Pal: SpdmPal>(
     let raw_len = head.checked_add(spdm_len).ok_or(SPDM_UNSPECIFIED)?;
     let use_normal_response = spdm_len <= state.effective_data_transfer_size(pal);
     if !use_normal_response {
-        chunk::validate_buffered_large_response_with_capacity(state, pal, spdm_len, buf.len())?;
+        chunk::validate_buffered_large_response_with_capacity(state, spdm_len, buf.len())?;
     }
 
     if plan.signature_requested {

--- a/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/measurements.rs
@@ -250,7 +250,13 @@ async fn handle_measurements_response<'a, Pal: SpdmPal>(
             .get_mut(signature_offset..signature_offset + ECC_P384_SIGNATURE_SIZE)
             .ok_or(SPDM_UNSPECIFIED)?;
         let sig_len = pal
-            .sign_hash(io, plan.slot_id, asym_algo, &hash, signature)
+            .sign(
+                io,
+                plan.slot_id,
+                asym_algo,
+                SigningInput::EccP384Digest(&hash),
+                signature,
+            )
             .await
             .map_err(|_| SPDM_UNSPECIFIED)?;
         if sig_len != ECC_P384_SIGNATURE_SIZE {

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -23,10 +23,11 @@ use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use caliptra_mcu_spdm_traits::*;
 use zerocopy::FromBytes;
 
-use crate::build::{alloc_padded, build_error_response};
+use crate::build::{alloc_padded, build_error_response, encode_error_response};
 use crate::error::{
-    SpdmError, SpdmResult, SPDM_DECRYPT_ERROR, SPDM_INVALID_REQUEST, SPDM_SESSION_REQUIRED,
-    SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
+    SpdmError, SpdmResult, CALIPTRA_EXTENDED_ERROR_SIZE, SPDM_DECRYPT_ERROR, SPDM_INVALID_REQUEST,
+    SPDM_SESSION_REQUIRED, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST,
+    SPDM_VERSION_MISMATCH,
 };
 use crate::key_schedule::SessionKeyType;
 use crate::session::{SessionInfo, SessionManager, SessionState};
@@ -218,14 +219,19 @@ impl<S, L> ConnectionState<S, L> {
         pal.mtu().min(peer)
     }
 
-    pub(crate) fn effective_max_spdm_msg_size<Pal: SpdmPal>(&self, pal: &Pal) -> usize {
-        let local = pal.large_capacity().max(pal.mtu());
-        let peer = if self.peer_max_spdm_msg_size == 0 {
-            local
-        } else {
-            self.peer_max_spdm_msg_size as usize
-        };
-        local.min(peer)
+    /// Peer-advertised `MaxSPDMmsgSize`.
+    ///
+    /// Successful capabilities negotiation guarantees a non-zero peer limit.
+    pub(crate) fn peer_max_spdm_message_size(&self) -> SpdmResult<usize> {
+        if self.peer_max_spdm_msg_size == 0 {
+            return Err(SPDM_UNSPECIFIED);
+        }
+        Ok(self.peer_max_spdm_msg_size as usize)
+    }
+
+    /// Maximum buffered response allowed by both local storage and the peer.
+    pub(crate) fn max_buffered_response_size(&self, local_capacity: usize) -> SpdmResult<usize> {
+        Ok(local_capacity.min(self.peer_max_spdm_message_size()?))
     }
 
     /// Convert the negotiated asymmetric algorithm to
@@ -359,8 +365,16 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     /// If the PAL cannot hold at least one transport-sized large message,
     /// `CHUNK` is removed from the advertised capabilities.
     pub fn with_vdm_backend(pal: Pal, vdm_backend: Vdm) -> Self {
+        assert!(
+            pal.max_inbound_spdm_request_size() >= pal.mtu(),
+            "MaxSPDMmsgSize must be at least DataTransferSize"
+        );
+        assert!(
+            pal.max_inbound_spdm_request_size() <= u32::MAX as usize,
+            "MaxSPDMmsgSize exceeds the SPDM field width"
+        );
         let mut state = ConnectionState::<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>::default();
-        if pal.large_capacity() < pal.mtu() {
+        if pal.large_buffered_msg_capacity() < pal.mtu() {
             state.cap_flags =
                 CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
         }
@@ -537,14 +551,7 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
             req_version
         };
 
-        let Ok(mut err_rsp) = build_error_response(
-            &self.pal,
-            io,
-            rsp_version,
-            err.spec_byte(),
-            err.error_data(),
-            &[],
-        ) else {
+        let Ok(mut err_rsp) = build_error_response(&self.pal, io, rsp_version, err) else {
             // Allocator exhausted or codec failure — nothing more we
             // can do for this exchange.
             return Ok(());
@@ -706,12 +713,10 @@ async fn handle_secured_request<
                 SessionState::HandshakeInProgress => SessionKeyType::ResponseHandshakeKey,
                 SessionState::Established => SessionKeyType::ResponseDataKey,
             };
-            let error_rsp = [
-                state.version.to_u8(),
-                ReqRespCode::ERROR.0,
-                e.spec_byte(),
-                e.error_data(),
-            ];
+            let mut error_rsp = [0u8; SpdmMsgHdrPdu::SIZE + 2 + CALIPTRA_EXTENDED_ERROR_SIZE];
+            let Ok(error_rsp_len) = encode_error_response(&mut error_rsp, state.version, e) else {
+                return Ok(None);
+            };
             let rsp = encrypt_secured_spdm_response(
                 pal,
                 io,
@@ -719,7 +724,7 @@ async fn handle_secured_request<
                 session_id,
                 state.version,
                 key_type,
-                &error_rsp,
+                &error_rsp[..error_rsp_len],
             )
             .await
             .ok();

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -57,7 +57,10 @@ fn dispatch_request(
 
 #[test]
 fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
-    let pal = TestPal::default();
+    let pal = TestPal {
+        max_inbound_spdm_request_size: 4096,
+        ..TestPal::default()
+    };
     let mut state = ConnectionState::default();
     state.phase = Phase::AfterVersion;
     let mut sessions = SessionManager::new();
@@ -84,6 +87,7 @@ fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
         u32::from_le_bytes(rsp[8..12].try_into().unwrap()),
         state.advertised_cap_flags.into_bits()
     );
+    assert_eq!(u32::from_le_bytes(rsp[16..20].try_into().unwrap()), 4096);
     assert_eq!(state.version, SpdmVersion::V14);
     assert_eq!(state.phase, Phase::AfterCapabilities);
     assert_eq!(state.peer_cap_flags.into_bits(), peer_flags.into_bits());

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
@@ -16,7 +16,7 @@ use std::vec;
 use std::vec::Vec;
 use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
 
-use crate::error::SPDM_LARGE_RESPONSE;
+use crate::error::{SPDM_DATA_TOO_LARGE, SPDM_LARGE_RESPONSE, SPDM_UNSPECIFIED};
 
 #[path = "support.rs"]
 mod support;
@@ -24,6 +24,10 @@ use support::{
     drain_chunked_response, negotiated_state, TestHashState, TestIo, TestPal,
     SPDM_CERT_CHAIN_HDR_LEN, TEST_CERT_CHAIN,
 };
+
+const STREAMED_CERT_CHAIN: &[u8] = &[0xA5; 2048];
+const OVERSIZED_COMPOSED_CERT_CHAIN: &[u8] =
+    &[0xA5; u16::MAX as usize - SPDM_CERT_CHAIN_HDR_LEN + 1];
 
 fn init_cert_test_state(
     version: SpdmVersion,
@@ -215,6 +219,34 @@ fn test_get_certificate_v14_large_size_req() {
 }
 
 #[test]
+fn test_get_certificate_composed_chain_length_limits() {
+    let pal = TestPal {
+        cert_chain: OVERSIZED_COMPOSED_CERT_CHAIN,
+        ..TestPal::default()
+    };
+    let actual_size =
+        u32::try_from(SPDM_CERT_CHAIN_HDR_LEN + OVERSIZED_COMPOSED_CERT_CHAIN.len()).unwrap();
+
+    let mut state = init_cert_test_state(SpdmVersion::V13, &pal);
+    let mut sessions = SessionManager::new();
+    let req = standard_cert_request(SpdmVersion::V13, 0, 0, 0, u16::MAX);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_UNSPECIFIED.spec_byte());
+
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    state.advertised_cap_flags |= CapFlags::LARGE_RESP;
+    let mut sessions = SessionManager::new();
+    let req = standard_cert_request(SpdmVersion::V14, 0, 0, 0, u16::MAX);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_DATA_TOO_LARGE.spec_byte());
+    assert_eq!(err.extended_data(), actual_size.to_le_bytes());
+
+    let req = large_cert_request(SpdmVersion::V14, 0, 0, 0, u32::MAX);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_UNSPECIFIED.spec_byte());
+}
+
+#[test]
 fn test_get_certificate_large_on_v13_returns_invalid_request() {
     let pal = TestPal::default();
     let mut state = init_cert_test_state(SpdmVersion::V13, &pal);
@@ -247,18 +279,24 @@ fn test_get_certificate_v14_large_invalid_slot_or_offset() {
 
 #[test]
 fn test_get_certificate_chunked_full_fetch() {
-    let pal = TestPal::default();
+    let pal = TestPal {
+        cert_chain: STREAMED_CERT_CHAIN,
+        ..TestPal::default()
+    };
+    assert!(
+        SPDM_CERT_CHAIN_HDR_LEN + STREAMED_CERT_CHAIN.len() > pal.large_buffered_msg_capacity()
+    );
 
     let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
     state.cap_flags |= CapFlags::CHUNK | CapFlags::LARGE_RESP;
     state.peer_cap_flags |= CapFlags::CHUNK;
     state.advertised_cap_flags |= CapFlags::CHUNK | CapFlags::LARGE_RESP;
     state.peer_data_transfer_size = 42; // Constrained DataTransferSize to force chunking
-    state.peer_max_spdm_msg_size = 1024;
+    state.peer_max_spdm_msg_size = 4096;
     let mut sessions = SessionManager::new();
 
-    let total_len = SPDM_CERT_CHAIN_HDR_LEN + TEST_CERT_CHAIN.len(); // 60 bytes
-    let total_spdm_msg_len = SpdmMsgHdrPdu::SIZE + CertificateLargeRspBody::SIZE + total_len; // 76 bytes
+    let total_len = SPDM_CERT_CHAIN_HDR_LEN + STREAMED_CERT_CHAIN.len();
+    let total_spdm_msg_len = SpdmMsgHdrPdu::SIZE + CertificateLargeRspBody::SIZE + total_len;
 
     // Request full large cert
     let req = large_cert_request(SpdmVersion::V14, 0, 0, 0, 0xFFFFFFFF);
@@ -296,7 +334,7 @@ fn test_get_certificate_chunked_full_fetch() {
     assert_eq!(body, &wanted_body);
 
     // Followed by SPDM cert chain header + DER certs
-    assert_eq!(&payload[SPDM_CERT_CHAIN_HDR_LEN..], TEST_CERT_CHAIN);
+    assert_eq!(&payload[SPDM_CERT_CHAIN_HDR_LEN..], STREAMED_CERT_CHAIN);
 }
 
 #[test]

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
@@ -3,14 +3,28 @@
 extern crate std;
 
 use super::*;
-use caliptra_mcu_spdm_codec::CHUNK_ACK_ATTR_EARLY_ERROR;
+use caliptra_mcu_spdm_codec::{SetCertificateReqBody, CHUNK_ACK_ATTR_EARLY_ERROR};
 use caliptra_mcu_spdm_traits::NoVdmBackend;
 use futures::executor::block_on;
+use std::vec;
 use std::vec::Vec;
 
 #[path = "support.rs"]
 mod support;
 use support::*;
+
+const CHUNKED_TEST_CERT_CHAIN: &[u8] = &[
+    0x30, 0x03, 1, 2, 3, 0x30, 0x01, 4, 0x30, 0x03, 1, 2, 3, 0x30, 0x01, 4, 0x30, 0x03, 1, 2, 3,
+    0x30, 0x01, 4,
+];
+
+fn chunked_set_certificate_pal() -> TestPal {
+    TestPal {
+        mtu: 76,
+        cert_chain: CHUNKED_TEST_CERT_CHAIN,
+        ..TestPal::default()
+    }
+}
 
 fn send_secured_chunk(
     state: &mut ConnectionState<TestHashState, Vec<u8>>,
@@ -51,7 +65,7 @@ fn send_plaintext_chunk(
 
 #[test]
 fn plaintext_chunked_set_certificate_succeeds() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let mut state = chunking_state();
     let mut sessions = crate::session::SessionManager::new();
     let large_req = set_certificate_request(&pal);
@@ -104,8 +118,84 @@ fn plaintext_chunked_set_certificate_succeeds() {
 }
 
 #[test]
+fn plaintext_chunked_set_certificate_can_stream_beyond_8k_buffer() {
+    let pal = TestPal {
+        large_buffered_msg_capacity: 8 * 1024,
+        max_inbound_spdm_request_size: SpdmMsgHdrPdu::SIZE
+            + SetCertificateReqBody::SIZE
+            + u16::MAX as usize,
+        ..TestPal::default()
+    };
+    let mut state = chunking_state();
+    let mut sessions = crate::session::SessionManager::new();
+
+    let mut der = Vec::new();
+    for _ in 0..8185 {
+        der.extend_from_slice(TEST_CERT_CHAIN);
+    }
+    der.extend_from_slice(&[0x30, 0x01, 4]);
+    let payload = cert_payload(&der, test_digest(&der[..5]));
+    let mut large_req = vec![
+        SpdmVersion::V12.to_u8(),
+        ReqRespCode::SET_CERTIFICATE.0,
+        1,
+        0,
+    ];
+    large_req.extend_from_slice(&payload);
+
+    assert!(large_req.len() > pal.large_buffered_msg_capacity());
+    assert_eq!(large_req.len(), pal.max_inbound_spdm_request_size());
+
+    let mut offset = 0;
+    let mut seq = 0u16;
+    while offset < large_req.len() {
+        let overhead = SpdmMsgHdrPdu::SIZE
+            + caliptra_mcu_spdm_codec::ChunkSendReqBody::SIZE
+            + usize::from(seq == 0) * 4;
+        let end = (offset + pal.mtu() - overhead).min(large_req.len());
+        let last = end == large_req.len();
+        let chunk = chunk_send_request(
+            7,
+            seq,
+            last,
+            (seq == 0).then_some(large_req.len()),
+            &large_req[offset..end],
+        );
+        let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &chunk);
+        if last {
+            assert_eq!(
+                &rsp[6..],
+                &[
+                    SpdmVersion::V12.to_u8(),
+                    ReqRespCode::SET_CERTIFICATE_RSP.0,
+                    1,
+                    0,
+                ]
+            );
+        } else {
+            assert!(state.large_msg_ctx.request_in_progress());
+            assert!(state.large_msg_ctx.get_buffer().is_none());
+        }
+        offset = end;
+        seq += 1;
+    }
+
+    assert!(!state.large_msg_ctx.request_in_progress());
+    assert_eq!(
+        pal.op.take(),
+        Some(StoreOp::Write {
+            slot: 1,
+            key_pair_id: 0,
+            cert_model: 2,
+            root_hash: test_digest(&der[..5]),
+            cert_chain: der,
+        })
+    );
+}
+
+#[test]
 fn get_version_aborts_chunked_set_certificate_stream() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let mut state = chunking_state();
     let mut sessions = crate::session::SessionManager::new();
     let large_req = set_certificate_request(&pal);
@@ -137,7 +227,7 @@ fn get_version_aborts_chunked_set_certificate_stream() {
 
 #[test]
 fn chunked_set_certificate_rejects_context_switch_without_resetting() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let (mut state, mut sessions, session_id) = handshake_session(&pal);
     let large_req = set_certificate_request(&pal);
     let (first, second) = split_large_request(&large_req);
@@ -175,7 +265,7 @@ fn chunked_set_certificate_rejects_context_switch_without_resetting() {
 
 #[test]
 fn secured_chunked_set_certificate_succeeds() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let (mut state, mut sessions, session_id) = established_session(&pal);
     let large_req = set_certificate_request(&pal);
     let (first, second) = split_large_request(&large_req);
@@ -228,7 +318,7 @@ fn secured_chunked_set_certificate_succeeds() {
 
 #[test]
 fn handshake_session_chunked_set_certificate_is_rejected() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let (mut state, mut sessions, session_id) = handshake_session(&pal);
     let large_req = set_certificate_request(&pal);
     let (first, _) = split_large_request(&large_req);
@@ -256,7 +346,7 @@ fn handshake_session_chunked_set_certificate_is_rejected() {
 
 #[test]
 fn plaintext_chunked_set_certificate_bad_root_hash_does_not_commit() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let mut state = chunking_state();
     let mut sessions = crate::session::SessionManager::new();
     let mut large_req = set_certificate_request(&pal);
@@ -305,7 +395,7 @@ fn plaintext_chunked_set_certificate_bad_root_hash_does_not_commit() {
 
 #[test]
 fn plaintext_chunked_set_certificate_truncated_final_der_aborts() {
-    let pal = TestPal::default();
+    let pal = chunked_set_certificate_pal();
     let mut state = chunking_state();
     let mut sessions = crate::session::SessionManager::new();
     let mut large_req = set_certificate_request(&pal);

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -10,9 +10,9 @@ use caliptra_mcu_spdm_codec::{
     LARGE_RESPONSE_SIZE_FIELD_SIZE, SECURED_MSG_HDR_SIZE,
 };
 use caliptra_mcu_spdm_traits::{
-    MeasurementInfo, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash, SpdmPalHashAlgo,
-    SpdmPalIo, SpdmPalIoKind, SpdmPalIoTransport, SpdmPalMeasurements, SpdmPalSessionCrypto,
-    SPDM_NONCE_LEN,
+    MeasurementInfo, SigningInput, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash,
+    SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoKind, SpdmPalIoTransport, SpdmPalMeasurements,
+    SpdmPalSessionCrypto, SPDM_NONCE_LEN,
 };
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -363,12 +363,12 @@ impl SpdmPalCertStore for TestPal {
         Ok(src.len())
     }
 
-    async fn sign_hash(
+    async fn sign(
         &self,
         _io: &Self::Io<'_>,
         _slot: u8,
         _algo: SpdmPalAsymAlgo,
-        _digest: &[u8],
+        _signing_input: SigningInput<'_>,
         signature: &mut [u8],
     ) -> McuResult<usize> {
         signature.fill(0x77);

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -101,12 +101,15 @@ impl<T> DerefMut for TestBox<'_, T> {
 
 pub struct TestPal {
     pub mtu: usize,
+    pub large_buffered_msg_capacity: usize,
+    pub max_inbound_spdm_request_size: usize,
     pub supported_slots: u8,
     pub provisioned_slots: u8,
     pub authorized: bool,
     pub validate_error: Option<McuErrorCode>,
     pub write_error: Option<McuErrorCode>,
     pub erase_error: Option<McuErrorCode>,
+    pub typed_alloc_error: Option<McuErrorCode>,
     pub cert_chain: &'static [u8],
     pub measurement_info: &'static [MeasurementInfo],
     pub measurement_value: &'static [u8],
@@ -119,12 +122,15 @@ impl Default for TestPal {
     fn default() -> Self {
         Self {
             mtu: 1024,
+            large_buffered_msg_capacity: 1024,
+            max_inbound_spdm_request_size: 1024,
             supported_slots: u8::MAX,
             provisioned_slots: 1,
             authorized: true,
             validate_error: None,
             write_error: None,
             erase_error: None,
+            typed_alloc_error: None,
             cert_chain: TEST_CERT_CHAIN,
             measurement_info: &[],
             measurement_value: &[],
@@ -167,6 +173,9 @@ impl SpdmPalAlloc for TestPal {
     type LargeBuf = Vec<u8>;
 
     fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
+        if let Some(err) = self.typed_alloc_error {
+            return Err(err);
+        }
         Ok(TestBox {
             value: Box::new(value),
             _lifetime: PhantomData,
@@ -177,8 +186,8 @@ impl SpdmPalAlloc for TestPal {
         Ok(vec![0u8; len])
     }
 
-    fn large_capacity(&self) -> usize {
-        self.mtu
+    fn large_buffered_msg_capacity(&self) -> usize {
+        self.large_buffered_msg_capacity
     }
 
     fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
@@ -622,7 +631,11 @@ impl SpdmPalSessionCrypto for TestPal {
     }
 }
 
-impl caliptra_mcu_spdm_traits::SpdmPal for TestPal {}
+impl caliptra_mcu_spdm_traits::SpdmPal for TestPal {
+    fn max_inbound_spdm_request_size(&self) -> usize {
+        self.max_inbound_spdm_request_size
+    }
+}
 
 pub fn test_digest(data: &[u8]) -> [u8; SHA384_DIGEST_SIZE] {
     let mut digest = [0u8; SHA384_DIGEST_SIZE];
@@ -731,6 +744,8 @@ pub fn negotiated_state(version: SpdmVersion) -> ConnectionState<TestHashState, 
 pub fn chunking_state() -> ConnectionState<TestHashState, Vec<u8>> {
     let mut state = negotiated_state(SpdmVersion::V12);
     state.peer_cap_flags = CapFlags::CHUNK;
+    state.peer_data_transfer_size = 1024;
+    state.peer_max_spdm_msg_size = 1024;
     state
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
@@ -71,8 +71,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
         let requested = vdm.large_response_capacity(decoded.payload);
         if requested > inline_cap {
             state
-                .effective_max_spdm_msg_size(pal)
-                .min(pal.large_capacity())
+                .max_buffered_response_size(pal.large_buffered_msg_capacity())?
                 .saturating_sub(envelope)
                 .min(requested)
         } else {

--- a/runtime/userspace/api/spdm-lib/traits/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/alloc.rs
@@ -65,10 +65,12 @@ pub trait SpdmPalAlloc: mcu_caliptra_api::ApiAlloc + mcu_caliptra_api::ApiAllocP
     // then parked on `ConnectionState::large_buf` so it can survive across later
     // exchanges until chunking completes.
 
-    /// Maximum size, in bytes, of a single in-flight large SPDM message this
-    /// responder can hold. Drives the `CHUNK` capability advertisement
-    /// (`MaxSPDMmsgSize`) and buffered large-response/request validation.
-    fn large_capacity(&self) -> usize;
+    /// Scratch-backed capacity for retaining one complete large request or
+    /// response.
+    ///
+    /// This is not advertised as `MaxSPDMmsgSize`; streamed messages may exceed
+    /// it.
+    fn large_buffered_msg_capacity(&self) -> usize;
 
     /// RAII guard type returned by [`Self::alloc_large_buf`].
     type LargeBuf: DerefMut<Target = [u8]>;

--- a/runtime/userspace/api/spdm-lib/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/cert.rs
@@ -3,11 +3,11 @@
 //! SPDM cert-store abstraction (DSP0274 §10.5 / §10.6).
 //!
 //! All cert-chain methods take an [`SpdmPalAsymAlgo`] parameter
-//! so each slot can hold chains for multiple algorithms (e.g.
-//! ECC-384 and MLDSA-87). Only ECC-384 is implemented today;
-//! MLDSA-87 will be added later using the same interfaces.
+//! so each slot can hold chains and signing keys for multiple algorithms
+//! such as ECC-384 and ML-DSA-87.
 
 use crate::SpdmPalHashAlgo;
+pub use mcu_caliptra_api::SigningInput;
 use mcu_error::McuResult;
 
 /// Maximum number of cert-chain slots the responder advertises.
@@ -23,7 +23,7 @@ pub const MAX_SLOTS: u8 = 8;
 pub enum SpdmPalAsymAlgo {
     /// ECDSA P-384 / SHA-384 (96-byte signature: r || s).
     EccP384,
-    /// ML-DSA-87 (post-quantum). Reserved for future use.
+    /// ML-DSA-87 (post-quantum).
     MlDsa87,
 }
 
@@ -158,13 +158,15 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
         dst: &mut [u8],
     ) -> McuResult<usize>;
 
-    /// Sign `digest` using the key in `slot` for the given algorithm.
-    async fn sign_hash(
+    /// Sign the caller-prepared input using the key in `slot`.
+    ///
+    /// `algo` must identify the same DPE profile as `signing_input`.
+    async fn sign(
         &self,
         io: &Self::Io<'_>,
         slot: u8,
         algo: SpdmPalAsymAlgo,
-        digest: &[u8],
+        signing_input: SigningInput<'_>,
         signature: &mut [u8],
     ) -> McuResult<usize>;
 

--- a/runtime/userspace/api/spdm-lib/traits/src/pal.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/pal.rs
@@ -24,4 +24,11 @@ pub trait SpdmPal:
     + SpdmPalMeasurements
     + SpdmPalSessionCrypto
 {
+    /// Endpoint-wide maximum logical SPDM request this responder accepts.
+    ///
+    /// Advertised as `MaxSPDMmsgSize`. This is the maximum across buffered and
+    /// streamed request paths, and must be at least [`Self::mtu`].
+    fn max_inbound_spdm_request_size(&self) -> usize {
+        self.large_buffered_msg_capacity().max(self.mtu())
+    }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
@@ -33,6 +33,53 @@ const DOT_ROTATE_PAYLOAD_LEN: usize = 4 + core::mem::size_of::<DotRotatePayload>
 #[cfg(feature = "device-ownership-transfer")]
 const DOT_BACKUP_PAYLOAD_LEN: usize = 4;
 
+const AUTHORIZATION_TRAILER_LEN: usize = AUTH_CMD_NONCE_LEN
+    + 2 * ECC_P384_COORD_SIZE
+    + MLDSA87_PUB_KEY_SIZE
+    + core::mem::size_of::<HybridSignature>();
+
+const MAX_AUTHORIZED_PAYLOAD_LEN: usize = {
+    let mut max = FE_PROG_PAYLOAD_LEN;
+    if PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN > max {
+        max = PROVISION_VENDOR_PK_HASH_PAYLOAD_LEN;
+    }
+    if PROVISION_OWNER_PK_HASH_PAYLOAD_LEN > max {
+        max = PROVISION_OWNER_PK_HASH_PAYLOAD_LEN;
+    }
+    if INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN > max {
+        max = INCREASE_CALIPTRA_MIN_SVN_PAYLOAD_LEN;
+    }
+    if REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN > max {
+        max = REVOKE_VENDOR_PUB_KEY_PAYLOAD_LEN;
+    }
+    if REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN > max {
+        max = REVOKE_VENDOR_PK_HASH_PAYLOAD_LEN;
+    }
+    if FUSE_LOCK_PARTITION_PAYLOAD_LEN > max {
+        max = FUSE_LOCK_PARTITION_PAYLOAD_LEN;
+    }
+    #[cfg(feature = "device-ownership-transfer")]
+    {
+        if DOT_LOCK_PAYLOAD_LEN > max {
+            max = DOT_LOCK_PAYLOAD_LEN;
+        }
+        if DOT_DISABLE_PAYLOAD_LEN > max {
+            max = DOT_DISABLE_PAYLOAD_LEN;
+        }
+        if DOT_ROTATE_PAYLOAD_LEN > max {
+            max = DOT_ROTATE_PAYLOAD_LEN;
+        }
+        if DOT_BACKUP_PAYLOAD_LEN > max {
+            max = DOT_BACKUP_PAYLOAD_LEN;
+        }
+    }
+    max
+};
+
+/// Largest `AuthorizedCommand` body after the Caliptra VDM header.
+pub(in crate::iana::ocp::caliptra_vdm) const MAX_REQUEST_LEN: usize =
+    core::mem::size_of::<u32>() + MAX_AUTHORIZED_PAYLOAD_LEN + AUTHORIZATION_TRAILER_LEN;
+
 /// MC_GET_AUTH_CMD_CHALLENGE sub-command (`MACC`).
 pub const GET_AUTH_CHALLENGE_CMD_ID: u32 = 0x4D41_4343;
 /// MC_PROVISION_VENDOR_PK_HASH sub-command (`PVPK`).
@@ -566,12 +613,8 @@ fn split_authorized_request(
     req: &[u8],
     payload_len: usize,
 ) -> Result<AuthorizedRequest<'_>, CaliptraCompletionCode> {
-    let auth_len = AUTH_CMD_NONCE_LEN
-        + 2 * ECC_P384_COORD_SIZE
-        + MLDSA87_PUB_KEY_SIZE
-        + core::mem::size_of::<HybridSignature>();
     let expected_len = payload_len
-        .checked_add(auth_len)
+        .checked_add(AUTHORIZATION_TRAILER_LEN)
         .ok_or(CaliptraCompletionCode::InvalidPayloadSize)?;
     if req.len() != expected_len {
         return Err(CaliptraCompletionCode::InvalidPayloadSize);

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -12,7 +12,7 @@ mod commands;
 
 use caliptra_mcu_common_commands::CaliptraCmdHandler;
 use caliptra_mcu_mbox_common::messages::{HybridSignature, AUTH_CMD_NONCE_LEN};
-use caliptra_mcu_spdm_codec::StandardsBodyId;
+use caliptra_mcu_spdm_codec::{SpdmMsgHdrPdu, StandardsBodyId, VendorDefinedReqPdu};
 use caliptra_mcu_spdm_traits::{
     McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse, VdmResponseBuffer,
 };
@@ -39,6 +39,19 @@ const MAX_LARGE_COMMAND_DATA_LEN: usize = 4 * 1024;
 /// Maximum complete Caliptra VDM large payload:
 /// `[command_version, command_code, completion, data_len, data...]`.
 const MAX_LARGE_VDM_PAYLOAD_LEN: usize = LARGE_PAYLOAD_HEADER_LEN + MAX_LARGE_COMMAND_DATA_LEN;
+
+/// SPDM and Caliptra VDM bytes preceding a command body:
+/// common header, VENDOR_DEFINED prefix, IANA vendor ID, request length, and
+/// Caliptra command header.
+pub const SPDM_REQUEST_FRAMING_LEN: usize = SpdmMsgHdrPdu::SIZE
+    + VendorDefinedReqPdu::SIZE
+    + core::mem::size_of::<u32>()
+    + core::mem::size_of::<u16>()
+    + VDM_HEADER_LEN;
+
+/// Largest complete logical SPDM request for an enabled `AuthorizedCommand`.
+pub const MAX_AUTHORIZED_COMMAND_SPDM_REQUEST_LEN: usize =
+    SPDM_REQUEST_FRAMING_LEN + commands::authorized_command::MAX_REQUEST_LEN;
 
 /// Platform hook for SPDM-specific Caliptra VDM stream state.
 pub trait CaliptraVdmStreamOps {
@@ -270,17 +283,6 @@ pub const fn large_response_capacity<H: CaliptraCmdHandler>() -> usize {
         MAX_LARGE_VDM_PAYLOAD_LEN
     }
 }
-
-/// Caliptra VDM framing an inbound streamed request carries on top of its
-/// mailbox payload.
-///
-/// Streamed requests (the debug unlock token, and anything else routed through
-/// [`CaliptraVdmStreamOps`]) never materialize in the SPDM scratch pool, so
-/// they cost no pool memory. They still bound `MaxSPDMmsgSize`, because the
-/// `CHUNK_SEND` admission check rejects any message larger than the advertised
-/// value *before* the streaming path is reached. Integrators add this to their
-/// largest streamed payload to size that declaration.
-pub const LARGE_REQUEST_FRAMING_LEN: usize = VDM_HEADER_LEN;
 
 impl<H, S, A> SpdmVdmBackend for CaliptraVdm<'_, H, S, A>
 where
@@ -652,7 +654,7 @@ mod tests {
             Ok(vec![0; len])
         }
 
-        fn large_capacity(&self) -> usize {
+        fn large_buffered_msg_capacity(&self) -> usize {
             4096
         }
 

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/pci_sig/ide_km/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/pci_sig/ide_km/mod.rs
@@ -816,7 +816,7 @@ mod tests {
             Ok(vec![0; len])
         }
 
-        fn large_capacity(&self) -> usize {
+        fn large_buffered_msg_capacity(&self) -> usize {
             0
         }
 

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/pci_sig/mod.rs
@@ -205,7 +205,7 @@ mod tests {
             Ok(vec![0; len])
         }
 
-        fn large_capacity(&self) -> usize {
+        fn large_buffered_msg_capacity(&self) -> usize {
             0
         }
 


### PR DESCRIPTION
### Commit 1: SPDM streamed and buffered message limits

- Size streamed certificate responses from the requester receive limit.
- Advertise inbound logical request capacity independently of scratch buffering.
- Stream SET_CERTIFICATE directly into storage with a tunable standard CertChain limit.
- Reassemble MCTP AuthorizedCommand requests without inflating DOE task state.
- Validate CHUNK_SEND frames against responder transport and logical-request limits.

### Commit 2: Caliptra API ML-DSA signing primitives

- Add SHAKE256 and ML-DSA tr/mu helpers.
- Add raw public-key retrieval and normal-mailbox DPE signing.
- Model Caliptra 2.0 raw-message and 2.1 external-mu signing explicitly.

### Commit 3: SPDM ML-DSA cert-store signing

- Route typed signing inputs through the Measurement API and SPDM certificate store.
- Preserve DPE handle rotation across signing operations.