### PR TITLE
caliptra-api: add AxiDmaTarget abstraction and mcu_sram_to_axi_dma helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5420,6 +5420,7 @@ dependencies = [
  "caliptra-mcu-libsyscall-caliptra",
  "caliptra-mcu-libtock_console",
  "caliptra-mcu-libtock_platform",
+ "caliptra-mcu-libtock_unittest",
  "caliptra-mcu-libtockasync",
  "caliptra-mcu-pldm-common",
  "caliptra-mcu-pldm-lib",

--- a/platforms/emulator/runtime/kernel/capsules/src/dma.rs
+++ b/platforms/emulator/runtime/kernel/capsules/src/dma.rs
@@ -28,6 +28,7 @@ mod dma_cmd {
     pub const SET_SRC_ADDR: u32 = 1;
     pub const SET_DEST_ADDR: u32 = 2;
     pub const XFER_AXI_TO_AXI: u32 = 3;
+    pub const TRANSLATE_LOCAL_TO_CPTRA_AXI: u32 = 5;
 }
 
 #[derive(Default)]
@@ -43,17 +44,26 @@ pub struct Dma<'a> {
     // Per-app state.
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     current_app: OptionalCell<ProcessId>,
+    sram_local_base: u32,
+    sram_size: u32,
+    cptra_sram_axi_base: u32,
 }
 
 impl<'a> Dma<'a> {
     pub fn new(
         driver: &'a dyn DmaHal,
         grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+        sram_local_base: u32,
+        sram_size: u32,
+        cptra_sram_axi_base: u32,
     ) -> Dma<'a> {
         Dma {
             driver,
             apps: grant,
             current_app: OptionalCell::empty(),
+            sram_local_base,
+            sram_size,
+            cptra_sram_axi_base,
         }
     }
 
@@ -183,6 +193,35 @@ impl SyscallDriver for Dma<'_> {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => CommandReturn::failure(e),
                 }
+            }
+            dma_cmd::TRANSLATE_LOCAL_TO_CPTRA_AXI => {
+                let local_addr = match u32::try_from(r2) {
+                    Ok(a) => a,
+                    Err(_) => return CommandReturn::failure(ErrorCode::INVAL),
+                };
+                let len = match u32::try_from(r3) {
+                    Ok(l) => l,
+                    Err(_) => return CommandReturn::failure(ErrorCode::INVAL),
+                };
+
+                if len == 0 || (local_addr % 4 != 0) || (len % 4 != 0) {
+                    return CommandReturn::failure(ErrorCode::INVAL);
+                }
+
+                if local_addr < self.sram_local_base {
+                    return CommandReturn::failure(ErrorCode::INVAL);
+                }
+
+                let offset = local_addr - self.sram_local_base;
+                let Some(end) = offset.checked_add(len) else {
+                    return CommandReturn::failure(ErrorCode::SIZE);
+                };
+                if end > self.sram_size {
+                    return CommandReturn::failure(ErrorCode::SIZE);
+                }
+
+                let axi_addr = self.cptra_sram_axi_base.wrapping_add(offset);
+                CommandReturn::success_u32(axi_addr)
             }
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -971,10 +971,14 @@ pub unsafe fn main() {
         true
     );
 
+    const CALIPTRA_SRAM_AXI_BASE: u32 = 0xA8C0_0000;
     let dma = caliptra_mcu_components::dma::DmaComponent::new(
         &emulator_peripherals.dma,
         board_kernel,
         caliptra_mcu_capsules_emulator::dma::DMA_CTRL_DRIVER_NUM,
+        MCU_MEMORY_MAP.sram_offset,
+        MCU_MEMORY_MAP.sram_size,
+        CALIPTRA_SRAM_AXI_BASE,
     )
     .finalize(kernel::static_buf!(
         caliptra_mcu_capsules_emulator::dma::Dma<'static>

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -914,10 +914,14 @@ pub unsafe fn main() {
             caliptra_mcu_capsules_runtime::system::System<'static, FpgaExiter>
         ));
 
+    const CALIPTRA_SRAM_AXI_BASE: u32 = 0xA8C0_0000;
     let dma = caliptra_mcu_components::dma::DmaComponent::new(
         &fpga_peripherals.dma,
         board_kernel,
         caliptra_mcu_capsules_emulator::dma::DMA_CTRL_DRIVER_NUM,
+        MCU_MEMORY_MAP.sram_offset,
+        MCU_MEMORY_MAP.sram_size,
+        CALIPTRA_SRAM_AXI_BASE,
     )
     .finalize(kernel::static_buf!(
         caliptra_mcu_capsules_emulator::dma::Dma<'static>

--- a/runtime/kernel/components/src/dma.rs
+++ b/runtime/kernel/components/src/dma.rs
@@ -12,6 +12,9 @@ pub struct DmaComponent {
     driver: &'static dyn DmaHal,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
+    sram_local_base: u32,
+    sram_size: u32,
+    cptra_sram_axi_base: u32,
 }
 
 impl DmaComponent {
@@ -19,11 +22,17 @@ impl DmaComponent {
         driver: &'static dyn DmaHal,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
+        sram_local_base: u32,
+        sram_size: u32,
+        cptra_sram_axi_base: u32,
     ) -> Self {
         Self {
             driver,
             board_kernel,
             driver_num,
+            sram_local_base,
+            sram_size,
+            cptra_sram_axi_base,
         }
     }
 }
@@ -39,6 +48,9 @@ impl Component for DmaComponent {
             static_buffer.write(caliptra_mcu_capsules_emulator::dma::Dma::new(
                 self.driver,
                 self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                self.sram_local_base,
+                self.sram_size,
+                self.cptra_sram_axi_base,
             ));
         self.driver.set_client(dma);
         dma

--- a/runtime/userspace/api/caliptra-api/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api/Cargo.toml
@@ -43,3 +43,4 @@ mailbox-io = [
     "dep:caliptra-mcu-libsyscall-caliptra",
     "dep:caliptra-mcu-libtock_platform",
 ]
+fpga = []

--- a/runtime/userspace/api/caliptra-api/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api/Cargo.toml
@@ -43,4 +43,6 @@ mailbox-io = [
     "dep:caliptra-mcu-libsyscall-caliptra",
     "dep:caliptra-mcu-libtock_platform",
 ]
-fpga = []
+
+[dev-dependencies]
+caliptra-mcu-libtock_unittest = { workspace = true }

--- a/runtime/userspace/api/caliptra-api/src/dma.rs
+++ b/runtime/userspace/api/caliptra-api/src/dma.rs
@@ -10,16 +10,23 @@
 //! - MCI (Microcontroller Interface) base address on the AXI bus: `0xA800_0000`
 //! - MCU SRAM offset within MCI: `0x00C0_0000` (12 MiB)
 //! - MCU SRAM base address on the AXI bus: `0xA8C0_0000`
-//! - MCU SRAM base address in the MCU's local address space: `0x4000_0000`
+//!
+//! However, the MCU local address space and SRAM size differ depending on the platform:
+//! - **Emulator**: Local SRAM base is `0x4000_0000`, size is 1024 KiB (or 512 KiB in release layout).
+//! - **FPGA**: Local SRAM base is `0xA8C0_0000`, size is 512 KiB.
 //!
 //! To allow Caliptra Core to DMA directly into a buffer allocated in MCU SRAM,
-//! local SRAM addresses must be translated to their subsystem AXI equivalents.
+//! local SRAM addresses must be validated (alignment, bounds) and translated to their
+//! subsystem AXI equivalents.
+//!
+//! # Note on DMA Abstractions
+//! The userspace syscall crate provides [`caliptra_mcu_libsyscall_caliptra::dma::DMAMapping`]
+//! for the MCU's internal AXI CDMA controller (`mcu_sram_to_mcu_axi` and `cptra_axi_to_mcu_axi`).
+//! In contrast, [`AxiDmaConfig`] and [`AxiDmaTarget`] handle address translation for Caliptra
+//! Core's internal DMA engine, which acts as a master on the subsystem AXI interconnect.
 
 use mcu_error::codes::INVARIANT;
 use mcu_error::McuResult;
-
-/// Physical base address of MCU SRAM from the MCU's local memory map.
-pub const MCU_SRAM_LOCAL_BASE: u32 = 0x4000_0000;
 
 /// Base address of the MCI on the subsystem AXI bus.
 pub const MCI_BASE_AXI_ADDRESS: u32 = 0xA800_0000;
@@ -29,6 +36,86 @@ pub const MCU_SRAM_AXI_OFFSET: u32 = 0x00C0_0000;
 
 /// Subsystem AXI bus base address for MCU SRAM as accessed by Caliptra DMA.
 pub const MCU_SRAM_AXI_BASE: u32 = MCI_BASE_AXI_ADDRESS + MCU_SRAM_AXI_OFFSET; // 0xA8C0_0000
+
+/// Hardware memory configuration for Caliptra subsystem AXI DMA.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AxiDmaConfig {
+    /// Physical base address of MCU SRAM in the MCU's local address space.
+    pub local_sram_base: u32,
+    /// Physical base address of MCU SRAM on the Caliptra subsystem AXI bus.
+    pub axi_sram_base: u32,
+    /// Total size of MCU SRAM in bytes.
+    pub sram_size: u32,
+}
+
+impl AxiDmaConfig {
+    /// Standard configuration for the emulator platform.
+    pub const EMULATOR: Self = Self {
+        local_sram_base: 0x4000_0000,
+        axi_sram_base: MCU_SRAM_AXI_BASE,
+        sram_size: 1024 * 1024,
+    };
+
+    /// Standard configuration for the FPGA platform.
+    pub const FPGA: Self = Self {
+        local_sram_base: 0xA8C0_0000,
+        axi_sram_base: MCU_SRAM_AXI_BASE,
+        sram_size: 512 * 1024,
+    };
+
+    /// Default configuration for the active build target.
+    #[cfg(feature = "fpga")]
+    pub const DEFAULT: Self = Self::FPGA;
+    #[cfg(not(feature = "fpga"))]
+    pub const DEFAULT: Self = Self::EMULATOR;
+
+    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`].
+    ///
+    /// # Errors
+    /// Returns [`INVARIANT`] if:
+    /// - `buf.len() == 0` (DMA engine requires non-zero transfer size)
+    /// - `buf.as_ptr()` is not 4-byte word aligned
+    /// - `buf.len()` is not a multiple of 4 bytes
+    /// - `buf` starts before `self.local_sram_base`
+    /// - `buf` extends beyond the upper bound of MCU SRAM (`self.sram_size`)
+    /// - Address arithmetic overflows
+    pub fn translate(&self, buf: &[u8]) -> McuResult<AxiDmaTarget> {
+        self.translate_ptr(buf.as_ptr(), buf.len())
+    }
+
+    /// Translates a raw pointer and length in MCU local SRAM into an [`AxiDmaTarget`].
+    pub fn translate_ptr(&self, ptr: *const u8, len: usize) -> McuResult<AxiDmaTarget> {
+        if len == 0 {
+            return Err(INVARIANT);
+        }
+
+        let local_addr = ptr as u32;
+
+        // The DMA engine requires word alignment for both start address and transfer count.
+        if (local_addr % 4 != 0) || (len % 4 != 0) {
+            return Err(INVARIANT);
+        }
+
+        let sram_offset = local_addr
+            .checked_sub(self.local_sram_base)
+            .ok_or(INVARIANT)?;
+
+        let max_size = u32::try_from(len).map_err(|_| INVARIANT)?;
+
+        // Ensure buffer does not extend past the upper bound of MCU SRAM.
+        let end_offset = sram_offset.checked_add(max_size).ok_or(INVARIANT)?;
+        if end_offset > self.sram_size {
+            return Err(INVARIANT);
+        }
+
+        let addr = self
+            .axi_sram_base
+            .checked_add(sram_offset)
+            .ok_or(INVARIANT)?;
+
+        Ok(AxiDmaTarget { addr, max_size })
+    }
+}
 
 /// Validated target buffer configuration for Caliptra subsystem AXI DMA.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,26 +127,16 @@ pub struct AxiDmaTarget {
 }
 
 impl AxiDmaTarget {
-    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`].
-    ///
-    /// Returns [`INVARIANT`] if the buffer is not located within MCU local SRAM
-    /// (`< MCU_SRAM_LOCAL_BASE`), if pointer arithmetic overflows, or if the buffer
-    /// length cannot fit in a `u32`.
+    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`] using the default platform configuration.
+    #[inline]
     pub fn from_mcu_sram(buf: &[u8]) -> McuResult<Self> {
-        Self::from_mcu_sram_ptr(buf.as_ptr(), buf.len())
+        AxiDmaConfig::DEFAULT.translate(buf)
     }
 
-    /// Translates a raw pointer and length in MCU local SRAM into an [`AxiDmaTarget`].
-    pub fn from_mcu_sram_ptr(ptr: *const u8, len: usize) -> McuResult<Self> {
-        let local_addr = ptr as u32;
-        let sram_offset = local_addr
-            .checked_sub(MCU_SRAM_LOCAL_BASE)
-            .ok_or(INVARIANT)?;
-        let addr = MCU_SRAM_AXI_BASE
-            .checked_add(sram_offset)
-            .ok_or(INVARIANT)?;
-        let max_size = u32::try_from(len).map_err(|_| INVARIANT)?;
-        Ok(Self { addr, max_size })
+    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`] using an explicit configuration.
+    #[inline]
+    pub fn from_mcu_sram_with_config(buf: &[u8], config: &AxiDmaConfig) -> McuResult<Self> {
+        config.translate(buf)
     }
 
     /// Returns the `(axi_addr, max_size)` tuple format expected by DPE invoke commands.
@@ -69,10 +146,18 @@ impl AxiDmaTarget {
     }
 }
 
-/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple.
+/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple
+/// using the default platform configuration.
 #[inline]
 pub fn mcu_sram_to_axi_dma(buf: &[u8]) -> McuResult<(u32, u32)> {
     AxiDmaTarget::from_mcu_sram(buf).map(|t| t.as_tuple())
+}
+
+/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple
+/// using an explicit configuration.
+#[inline]
+pub fn mcu_sram_to_axi_dma_with_config(buf: &[u8], config: &AxiDmaConfig) -> McuResult<(u32, u32)> {
+    AxiDmaTarget::from_mcu_sram_with_config(buf, config).map(|t| t.as_tuple())
 }
 
 #[cfg(test)]
@@ -81,40 +166,94 @@ mod tests {
 
     #[test]
     fn test_constants() {
-        assert_eq!(MCU_SRAM_LOCAL_BASE, 0x4000_0000);
         assert_eq!(MCI_BASE_AXI_ADDRESS, 0xA800_0000);
         assert_eq!(MCU_SRAM_AXI_OFFSET, 0x00C0_0000);
         assert_eq!(MCU_SRAM_AXI_BASE, 0xA8C0_0000);
     }
 
     #[test]
-    fn test_valid_sram_translation() {
-        let ptr = (MCU_SRAM_LOCAL_BASE + 0x1000) as *const u8;
-        let target = AxiDmaTarget::from_mcu_sram_ptr(ptr, 4096).unwrap();
+    fn test_emulator_config_valid_translation() {
+        let ptr = (AxiDmaConfig::EMULATOR.local_sram_base + 0x1000) as *const u8;
+        let target = AxiDmaConfig::EMULATOR.translate_ptr(ptr, 4096).unwrap();
         assert_eq!(target.addr, MCU_SRAM_AXI_BASE + 0x1000);
         assert_eq!(target.max_size, 4096);
         assert_eq!(target.as_tuple(), (0xA8C0_1000, 4096));
     }
 
     #[test]
-    fn test_sram_base_translation() {
-        let ptr = MCU_SRAM_LOCAL_BASE as *const u8;
-        let target = AxiDmaTarget::from_mcu_sram_ptr(ptr, 0).unwrap();
-        assert_eq!(target.addr, MCU_SRAM_AXI_BASE);
-        assert_eq!(target.max_size, 0);
-        assert_eq!(target.as_tuple(), (0xA8C0_0000, 0));
+    fn test_fpga_config_valid_translation() {
+        let ptr = (AxiDmaConfig::FPGA.local_sram_base + 0x1000) as *const u8;
+        let target = AxiDmaConfig::FPGA.translate_ptr(ptr, 4096).unwrap();
+        assert_eq!(target.addr, 0xA8C0_1000);
+        assert_eq!(target.max_size, 4096);
+        assert_eq!(target.as_tuple(), (0xA8C0_1000, 4096));
     }
 
     #[test]
-    fn test_invalid_address_below_sram_base() {
-        let ptr = (MCU_SRAM_LOCAL_BASE - 1) as *const u8;
-        assert!(AxiDmaTarget::from_mcu_sram_ptr(ptr, 100).is_err());
+    fn test_disallow_zero_length() {
+        let ptr = AxiDmaConfig::EMULATOR.local_sram_base as *const u8;
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr, 0).is_err());
     }
 
     #[test]
-    fn test_mcu_sram_to_axi_dma_helper() {
-        let sim_ptr = (MCU_SRAM_LOCAL_BASE + 0x500) as *const u8;
-        let target = AxiDmaTarget::from_mcu_sram_ptr(sim_ptr, 128).unwrap();
-        assert_eq!(target.as_tuple(), (0xA8C0_0500, 128));
+    fn test_alignment_requirements() {
+        let aligned_ptr = AxiDmaConfig::EMULATOR.local_sram_base as *const u8;
+        let unaligned_ptr = (AxiDmaConfig::EMULATOR.local_sram_base + 1) as *const u8;
+
+        // Unaligned pointer rejected
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(unaligned_ptr, 4)
+            .is_err());
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(unaligned_ptr, 16)
+            .is_err());
+
+        // Aligned pointer with unaligned lengths rejected
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(aligned_ptr, 1)
+            .is_err());
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(aligned_ptr, 2)
+            .is_err());
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(aligned_ptr, 3)
+            .is_err());
+        assert!(AxiDmaConfig::EMULATOR
+            .translate_ptr(aligned_ptr, 5)
+            .is_err());
+
+        // Aligned pointer with aligned length accepted
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(aligned_ptr, 4).is_ok());
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(aligned_ptr, 8).is_ok());
+    }
+
+    #[test]
+    fn test_lower_bound_rejection() {
+        let ptr = (AxiDmaConfig::EMULATOR.local_sram_base - 4) as *const u8;
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr, 4).is_err());
+    }
+
+    #[test]
+    fn test_upper_bound_rejection() {
+        let base = AxiDmaConfig::EMULATOR.local_sram_base;
+        let sram_size = AxiDmaConfig::EMULATOR.sram_size;
+
+        // Exactly fitting buffer at end of SRAM
+        let ptr_last = (base + sram_size - 4) as *const u8;
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_last, 4).is_ok());
+
+        // Exceeding buffer by 4 bytes
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_last, 8).is_err());
+
+        // Buffer starting at or beyond end of SRAM
+        let ptr_past = (base + sram_size) as *const u8;
+        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_past, 4).is_err());
+    }
+
+    #[test]
+    fn test_with_config_helpers() {
+        let ptr = (AxiDmaConfig::FPGA.local_sram_base + 0x2000) as *const u8;
+        let target = AxiDmaConfig::FPGA.translate_ptr(ptr, 64).unwrap();
+        assert_eq!(target.as_tuple(), (0xA8C0_2000, 64));
     }
 }

--- a/runtime/userspace/api/caliptra-api/src/dma.rs
+++ b/runtime/userspace/api/caliptra-api/src/dma.rs
@@ -1,0 +1,120 @@
+// Licensed under the Apache-2.0 license
+
+//! Caliptra Subsystem AXI DMA address translation utilities.
+//!
+//! When Caliptra Core responds to DPE or mailbox commands using AXI DMA
+//! (for example, transferring large ML-DSA-87 leaf certificates or exported CDIs),
+//! it operates as a bus master on the subsystem AXI interconnect.
+//!
+//! According to the Caliptra Subsystem Integration Specification:
+//! - MCI (Microcontroller Interface) base address on the AXI bus: `0xA800_0000`
+//! - MCU SRAM offset within MCI: `0x00C0_0000` (12 MiB)
+//! - MCU SRAM base address on the AXI bus: `0xA8C0_0000`
+//! - MCU SRAM base address in the MCU's local address space: `0x4000_0000`
+//!
+//! To allow Caliptra Core to DMA directly into a buffer allocated in MCU SRAM,
+//! local SRAM addresses must be translated to their subsystem AXI equivalents.
+
+use mcu_error::codes::INVARIANT;
+use mcu_error::McuResult;
+
+/// Physical base address of MCU SRAM from the MCU's local memory map.
+pub const MCU_SRAM_LOCAL_BASE: u32 = 0x4000_0000;
+
+/// Base address of the MCI on the subsystem AXI bus.
+pub const MCI_BASE_AXI_ADDRESS: u32 = 0xA800_0000;
+
+/// Offset of MCU SRAM within MCI address space (12 MiB).
+pub const MCU_SRAM_AXI_OFFSET: u32 = 0x00C0_0000;
+
+/// Subsystem AXI bus base address for MCU SRAM as accessed by Caliptra DMA.
+pub const MCU_SRAM_AXI_BASE: u32 = MCI_BASE_AXI_ADDRESS + MCU_SRAM_AXI_OFFSET; // 0xA8C0_0000
+
+/// Validated target buffer configuration for Caliptra subsystem AXI DMA.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AxiDmaTarget {
+    /// 32-bit AXI address for the start of the buffer.
+    pub addr: u32,
+    /// Maximum buffer size in bytes available for DMA transfer.
+    pub max_size: u32,
+}
+
+impl AxiDmaTarget {
+    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`].
+    ///
+    /// Returns [`INVARIANT`] if the buffer is not located within MCU local SRAM
+    /// (`< MCU_SRAM_LOCAL_BASE`), if pointer arithmetic overflows, or if the buffer
+    /// length cannot fit in a `u32`.
+    pub fn from_mcu_sram(buf: &[u8]) -> McuResult<Self> {
+        Self::from_mcu_sram_ptr(buf.as_ptr(), buf.len())
+    }
+
+    /// Translates a raw pointer and length in MCU local SRAM into an [`AxiDmaTarget`].
+    pub fn from_mcu_sram_ptr(ptr: *const u8, len: usize) -> McuResult<Self> {
+        let local_addr = ptr as u32;
+        let sram_offset = local_addr
+            .checked_sub(MCU_SRAM_LOCAL_BASE)
+            .ok_or(INVARIANT)?;
+        let addr = MCU_SRAM_AXI_BASE
+            .checked_add(sram_offset)
+            .ok_or(INVARIANT)?;
+        let max_size = u32::try_from(len).map_err(|_| INVARIANT)?;
+        Ok(Self { addr, max_size })
+    }
+
+    /// Returns the `(axi_addr, max_size)` tuple format expected by DPE invoke commands.
+    #[inline]
+    pub fn as_tuple(&self) -> (u32, u32) {
+        (self.addr, self.max_size)
+    }
+}
+
+/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple.
+#[inline]
+pub fn mcu_sram_to_axi_dma(buf: &[u8]) -> McuResult<(u32, u32)> {
+    AxiDmaTarget::from_mcu_sram(buf).map(|t| t.as_tuple())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(MCU_SRAM_LOCAL_BASE, 0x4000_0000);
+        assert_eq!(MCI_BASE_AXI_ADDRESS, 0xA800_0000);
+        assert_eq!(MCU_SRAM_AXI_OFFSET, 0x00C0_0000);
+        assert_eq!(MCU_SRAM_AXI_BASE, 0xA8C0_0000);
+    }
+
+    #[test]
+    fn test_valid_sram_translation() {
+        let ptr = (MCU_SRAM_LOCAL_BASE + 0x1000) as *const u8;
+        let target = AxiDmaTarget::from_mcu_sram_ptr(ptr, 4096).unwrap();
+        assert_eq!(target.addr, MCU_SRAM_AXI_BASE + 0x1000);
+        assert_eq!(target.max_size, 4096);
+        assert_eq!(target.as_tuple(), (0xA8C0_1000, 4096));
+    }
+
+    #[test]
+    fn test_sram_base_translation() {
+        let ptr = MCU_SRAM_LOCAL_BASE as *const u8;
+        let target = AxiDmaTarget::from_mcu_sram_ptr(ptr, 0).unwrap();
+        assert_eq!(target.addr, MCU_SRAM_AXI_BASE);
+        assert_eq!(target.max_size, 0);
+        assert_eq!(target.as_tuple(), (0xA8C0_0000, 0));
+    }
+
+    #[test]
+    fn test_invalid_address_below_sram_base() {
+        let ptr = (MCU_SRAM_LOCAL_BASE - 1) as *const u8;
+        assert!(AxiDmaTarget::from_mcu_sram_ptr(ptr, 100).is_err());
+    }
+
+    #[test]
+    fn test_mcu_sram_to_axi_dma_helper() {
+        let sim_ptr = (MCU_SRAM_LOCAL_BASE + 0x500) as *const u8;
+        let target = AxiDmaTarget::from_mcu_sram_ptr(sim_ptr, 128).unwrap();
+        assert_eq!(target.as_tuple(), (0xA8C0_0500, 128));
+    }
+}

--- a/runtime/userspace/api/caliptra-api/src/dma.rs
+++ b/runtime/userspace/api/caliptra-api/src/dma.rs
@@ -6,116 +6,16 @@
 //! (for example, transferring large ML-DSA-87 leaf certificates or exported CDIs),
 //! it operates as a bus master on the subsystem AXI interconnect.
 //!
-//! According to the Caliptra Subsystem Integration Specification:
-//! - MCI (Microcontroller Interface) base address on the AXI bus: `0xA800_0000`
-//! - MCU SRAM offset within MCI: `0x00C0_0000` (12 MiB)
-//! - MCU SRAM base address on the AXI bus: `0xA8C0_0000`
-//!
-//! However, the MCU local address space and SRAM size differ depending on the platform:
-//! - **Emulator**: Local SRAM base is `0x4000_0000`, size is 1024 KiB (or 512 KiB in release layout).
-//! - **FPGA**: Local SRAM base is `0xA8C0_0000`, size is 512 KiB.
-//!
 //! To allow Caliptra Core to DMA directly into a buffer allocated in MCU SRAM,
-//! local SRAM addresses must be validated (alignment, bounds) and translated to their
-//! subsystem AXI equivalents.
-//!
-//! # Note on DMA Abstractions
-//! The userspace syscall crate provides [`caliptra_mcu_libsyscall_caliptra::dma::DMAMapping`]
-//! for the MCU's internal AXI CDMA controller (`mcu_sram_to_mcu_axi` and `cptra_axi_to_mcu_axi`).
-//! In contrast, [`AxiDmaConfig`] and [`AxiDmaTarget`] handle address translation for Caliptra
-//! Core's internal DMA engine, which acts as a master on the subsystem AXI interconnect.
+//! local SRAM addresses must be translated to their subsystem AXI equivalents.
+//! The translation, word-alignment verification, and bounds checks are handled
+//! by the kernel DMA driver via a syscall, configured at boot time with the
+//! platform's memory map.
 
+use caliptra_mcu_libsyscall_caliptra::dma::DMA;
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use mcu_error::codes::INVARIANT;
 use mcu_error::McuResult;
-
-/// Base address of the MCI on the subsystem AXI bus.
-pub const MCI_BASE_AXI_ADDRESS: u32 = 0xA800_0000;
-
-/// Offset of MCU SRAM within MCI address space (12 MiB).
-pub const MCU_SRAM_AXI_OFFSET: u32 = 0x00C0_0000;
-
-/// Subsystem AXI bus base address for MCU SRAM as accessed by Caliptra DMA.
-pub const MCU_SRAM_AXI_BASE: u32 = MCI_BASE_AXI_ADDRESS + MCU_SRAM_AXI_OFFSET; // 0xA8C0_0000
-
-/// Hardware memory configuration for Caliptra subsystem AXI DMA.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AxiDmaConfig {
-    /// Physical base address of MCU SRAM in the MCU's local address space.
-    pub local_sram_base: u32,
-    /// Physical base address of MCU SRAM on the Caliptra subsystem AXI bus.
-    pub axi_sram_base: u32,
-    /// Total size of MCU SRAM in bytes.
-    pub sram_size: u32,
-}
-
-impl AxiDmaConfig {
-    /// Standard configuration for the emulator platform.
-    pub const EMULATOR: Self = Self {
-        local_sram_base: 0x4000_0000,
-        axi_sram_base: MCU_SRAM_AXI_BASE,
-        sram_size: 1024 * 1024,
-    };
-
-    /// Standard configuration for the FPGA platform.
-    pub const FPGA: Self = Self {
-        local_sram_base: 0xA8C0_0000,
-        axi_sram_base: MCU_SRAM_AXI_BASE,
-        sram_size: 512 * 1024,
-    };
-
-    /// Default configuration for the active build target.
-    #[cfg(feature = "fpga")]
-    pub const DEFAULT: Self = Self::FPGA;
-    #[cfg(not(feature = "fpga"))]
-    pub const DEFAULT: Self = Self::EMULATOR;
-
-    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`].
-    ///
-    /// # Errors
-    /// Returns [`INVARIANT`] if:
-    /// - `buf.len() == 0` (DMA engine requires non-zero transfer size)
-    /// - `buf.as_ptr()` is not 4-byte word aligned
-    /// - `buf.len()` is not a multiple of 4 bytes
-    /// - `buf` starts before `self.local_sram_base`
-    /// - `buf` extends beyond the upper bound of MCU SRAM (`self.sram_size`)
-    /// - Address arithmetic overflows
-    pub fn translate(&self, buf: &[u8]) -> McuResult<AxiDmaTarget> {
-        self.translate_ptr(buf.as_ptr(), buf.len())
-    }
-
-    /// Translates a raw pointer and length in MCU local SRAM into an [`AxiDmaTarget`].
-    pub fn translate_ptr(&self, ptr: *const u8, len: usize) -> McuResult<AxiDmaTarget> {
-        if len == 0 {
-            return Err(INVARIANT);
-        }
-
-        let local_addr = ptr as u32;
-
-        // The DMA engine requires word alignment for both start address and transfer count.
-        if (local_addr % 4 != 0) || (len % 4 != 0) {
-            return Err(INVARIANT);
-        }
-
-        let sram_offset = local_addr
-            .checked_sub(self.local_sram_base)
-            .ok_or(INVARIANT)?;
-
-        let max_size = u32::try_from(len).map_err(|_| INVARIANT)?;
-
-        // Ensure buffer does not extend past the upper bound of MCU SRAM.
-        let end_offset = sram_offset.checked_add(max_size).ok_or(INVARIANT)?;
-        if end_offset > self.sram_size {
-            return Err(INVARIANT);
-        }
-
-        let addr = self
-            .axi_sram_base
-            .checked_add(sram_offset)
-            .ok_or(INVARIANT)?;
-
-        Ok(AxiDmaTarget { addr, max_size })
-    }
-}
 
 /// Validated target buffer configuration for Caliptra subsystem AXI DMA.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,16 +27,11 @@ pub struct AxiDmaTarget {
 }
 
 impl AxiDmaTarget {
-    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`] using the default platform configuration.
+    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`].
     #[inline]
     pub fn from_mcu_sram(buf: &[u8]) -> McuResult<Self> {
-        AxiDmaConfig::DEFAULT.translate(buf)
-    }
-
-    /// Translates an MCU local SRAM buffer into an [`AxiDmaTarget`] using an explicit configuration.
-    #[inline]
-    pub fn from_mcu_sram_with_config(buf: &[u8], config: &AxiDmaConfig) -> McuResult<Self> {
-        config.translate(buf)
+        let (addr, max_size) = mcu_sram_to_axi_dma(buf)?;
+        Ok(Self { addr, max_size })
     }
 
     /// Returns the `(axi_addr, max_size)` tuple format expected by DPE invoke commands.
@@ -146,114 +41,54 @@ impl AxiDmaTarget {
     }
 }
 
-/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple
-/// using the default platform configuration.
+/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple.
 #[inline]
 pub fn mcu_sram_to_axi_dma(buf: &[u8]) -> McuResult<(u32, u32)> {
-    AxiDmaTarget::from_mcu_sram(buf).map(|t| t.as_tuple())
-}
-
-/// Helper function to translate an MCU local SRAM buffer into an `(axi_addr, max_size)` tuple
-/// using an explicit configuration.
-#[inline]
-pub fn mcu_sram_to_axi_dma_with_config(buf: &[u8], config: &AxiDmaConfig) -> McuResult<(u32, u32)> {
-    AxiDmaTarget::from_mcu_sram_with_config(buf, config).map(|t| t.as_tuple())
+    DMA::<DefaultSyscalls>::new()
+        .mcu_sram_to_cptra_axi(buf)
+        .map_err(|_| INVARIANT)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    extern crate std;
+    use caliptra_mcu_libtock_unittest::fake;
+    use std::rc::Rc;
 
     #[test]
-    fn test_constants() {
-        assert_eq!(MCI_BASE_AXI_ADDRESS, 0xA800_0000);
-        assert_eq!(MCU_SRAM_AXI_OFFSET, 0x00C0_0000);
-        assert_eq!(MCU_SRAM_AXI_BASE, 0xA8C0_0000);
+    fn test_axi_dma_target_translation_success() {
+        let kernel = fake::Kernel::new();
+        let dma_driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&dma_driver);
+
+        let buf = [0u32; 16];
+        let bytes: &[u8] =
+            unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 4) };
+
+        let target = AxiDmaTarget::from_mcu_sram(bytes).unwrap();
+        assert_eq!(target.max_size, 64);
+        assert_eq!(target.as_tuple(), (target.addr, 64));
     }
 
     #[test]
-    fn test_emulator_config_valid_translation() {
-        let ptr = (AxiDmaConfig::EMULATOR.local_sram_base + 0x1000) as *const u8;
-        let target = AxiDmaConfig::EMULATOR.translate_ptr(ptr, 4096).unwrap();
-        assert_eq!(target.addr, MCU_SRAM_AXI_BASE + 0x1000);
-        assert_eq!(target.max_size, 4096);
-        assert_eq!(target.as_tuple(), (0xA8C0_1000, 4096));
+    fn test_axi_dma_target_disallow_zero_length() {
+        let kernel = fake::Kernel::new();
+        let dma_driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&dma_driver);
+
+        let empty: &[u8] = &[];
+        assert!(mcu_sram_to_axi_dma(empty).is_err());
     }
 
     #[test]
-    fn test_fpga_config_valid_translation() {
-        let ptr = (AxiDmaConfig::FPGA.local_sram_base + 0x1000) as *const u8;
-        let target = AxiDmaConfig::FPGA.translate_ptr(ptr, 4096).unwrap();
-        assert_eq!(target.addr, 0xA8C0_1000);
-        assert_eq!(target.max_size, 4096);
-        assert_eq!(target.as_tuple(), (0xA8C0_1000, 4096));
-    }
+    fn test_axi_dma_target_unaligned_length_rejected() {
+        let kernel = fake::Kernel::new();
+        let dma_driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&dma_driver);
 
-    #[test]
-    fn test_disallow_zero_length() {
-        let ptr = AxiDmaConfig::EMULATOR.local_sram_base as *const u8;
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr, 0).is_err());
-    }
-
-    #[test]
-    fn test_alignment_requirements() {
-        let aligned_ptr = AxiDmaConfig::EMULATOR.local_sram_base as *const u8;
-        let unaligned_ptr = (AxiDmaConfig::EMULATOR.local_sram_base + 1) as *const u8;
-
-        // Unaligned pointer rejected
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(unaligned_ptr, 4)
-            .is_err());
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(unaligned_ptr, 16)
-            .is_err());
-
-        // Aligned pointer with unaligned lengths rejected
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(aligned_ptr, 1)
-            .is_err());
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(aligned_ptr, 2)
-            .is_err());
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(aligned_ptr, 3)
-            .is_err());
-        assert!(AxiDmaConfig::EMULATOR
-            .translate_ptr(aligned_ptr, 5)
-            .is_err());
-
-        // Aligned pointer with aligned length accepted
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(aligned_ptr, 4).is_ok());
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(aligned_ptr, 8).is_ok());
-    }
-
-    #[test]
-    fn test_lower_bound_rejection() {
-        let ptr = (AxiDmaConfig::EMULATOR.local_sram_base - 4) as *const u8;
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr, 4).is_err());
-    }
-
-    #[test]
-    fn test_upper_bound_rejection() {
-        let base = AxiDmaConfig::EMULATOR.local_sram_base;
-        let sram_size = AxiDmaConfig::EMULATOR.sram_size;
-
-        // Exactly fitting buffer at end of SRAM
-        let ptr_last = (base + sram_size - 4) as *const u8;
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_last, 4).is_ok());
-
-        // Exceeding buffer by 4 bytes
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_last, 8).is_err());
-
-        // Buffer starting at or beyond end of SRAM
-        let ptr_past = (base + sram_size) as *const u8;
-        assert!(AxiDmaConfig::EMULATOR.translate_ptr(ptr_past, 4).is_err());
-    }
-
-    #[test]
-    fn test_with_config_helpers() {
-        let ptr = (AxiDmaConfig::FPGA.local_sram_base + 0x2000) as *const u8;
-        let target = AxiDmaConfig::FPGA.translate_ptr(ptr, 64).unwrap();
-        assert_eq!(target.as_tuple(), (0xA8C0_2000, 64));
+        let buf = [0u32; 16];
+        let bytes: &[u8] = unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, 15) };
+        assert!(mcu_sram_to_axi_dma(bytes).is_err());
     }
 }

--- a/runtime/userspace/api/caliptra-api/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api/src/dpe.rs
@@ -18,6 +18,7 @@ use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
 use mcu_error::McuResult;
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+use crate::dma::mcu_sram_to_axi_dma;
 use crate::slice::{checked_slice, checked_slice_mut, copy_bytes, internal_slice};
 use crate::wire::{
     calc_checksum, mbox_execute, populate_checksum, CMD_CERTIFY_KEY_CHUNKS, CMD_DPE_GET_TAGGED_TCI,
@@ -594,22 +595,7 @@ pub async fn dpe_derive_context_exported_cdi<A: ApiAlloc>(
     };
     let mut rsp = alloc.alloc(max_resp_len)?;
     let axi_response = match profile {
-        DpeProfile::Mldsa87 => {
-            // Caliptra Subsystem Integration Spec: MCU local SRAM base is 0x4000_0000,
-            // and AXI DMA base is MCI_BASE_AXI_ADDRESS (0xA800_0000) + MCU_SRAM_OFFSET (0x00C0_0000).
-            const MCU_SRAM_LOCAL_BASE: u32 = 0x4000_0000;
-            const MCI_BASE_AXI_ADDRESS: u32 = 0xA800_0000;
-            const MCU_SRAM_AXI_OFFSET: u32 = 0x00C0_0000;
-            const MCU_SRAM_AXI_BASE: u32 = MCI_BASE_AXI_ADDRESS + MCU_SRAM_AXI_OFFSET;
-
-            let sram_offset = (rsp.as_ptr() as u32)
-                .checked_sub(MCU_SRAM_LOCAL_BASE)
-                .ok_or(INVARIANT)?;
-            let axi_addr = MCU_SRAM_AXI_BASE
-                .checked_add(sram_offset)
-                .ok_or(INVARIANT)?;
-            Some((axi_addr, max_resp_len as u32))
-        }
+        DpeProfile::Mldsa87 => Some(mcu_sram_to_axi_dma(&rsp)?),
         DpeProfile::P384Sha384 => None,
     };
     let (req, mbox_cmd) = build_derive_context_req(alloc, params, profile, axi_response)?;

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -35,6 +35,8 @@ mod cert;
 #[cfg(feature = "mailbox-io")]
 mod debug_unlock;
 #[cfg(feature = "mailbox-io")]
+pub mod dma;
+#[cfg(feature = "mailbox-io")]
 mod dpe;
 #[cfg(feature = "mailbox-io")]
 mod ecdh;
@@ -98,6 +100,11 @@ pub use cert::{
 pub use debug_unlock::{
     request_debug_unlock_challenge, DEBUG_UNLOCK_CHALLENGE_LEN,
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
+};
+#[cfg(feature = "mailbox-io")]
+pub use dma::{
+    mcu_sram_to_axi_dma, AxiDmaTarget, MCI_BASE_AXI_ADDRESS, MCU_SRAM_AXI_BASE,
+    MCU_SRAM_AXI_OFFSET, MCU_SRAM_LOCAL_BASE,
 };
 #[cfg(feature = "mailbox-io")]
 pub use dpe::{

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -103,8 +103,8 @@ pub use debug_unlock::{
 };
 #[cfg(feature = "mailbox-io")]
 pub use dma::{
-    mcu_sram_to_axi_dma, AxiDmaTarget, MCI_BASE_AXI_ADDRESS, MCU_SRAM_AXI_BASE,
-    MCU_SRAM_AXI_OFFSET, MCU_SRAM_LOCAL_BASE,
+    mcu_sram_to_axi_dma, mcu_sram_to_axi_dma_with_config, AxiDmaConfig, AxiDmaTarget,
+    MCI_BASE_AXI_ADDRESS, MCU_SRAM_AXI_BASE, MCU_SRAM_AXI_OFFSET,
 };
 #[cfg(feature = "mailbox-io")]
 pub use dpe::{

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -102,10 +102,7 @@ pub use debug_unlock::{
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
 #[cfg(feature = "mailbox-io")]
-pub use dma::{
-    mcu_sram_to_axi_dma, mcu_sram_to_axi_dma_with_config, AxiDmaConfig, AxiDmaTarget,
-    MCI_BASE_AXI_ADDRESS, MCU_SRAM_AXI_BASE, MCU_SRAM_AXI_OFFSET,
-};
+pub use dma::{mcu_sram_to_axi_dma, AxiDmaTarget};
 #[cfg(feature = "mailbox-io")]
 pub use dpe::{
     dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,

--- a/runtime/userspace/libtock/unittest/src/fake/dma/mod.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/dma/mod.rs
@@ -106,6 +106,48 @@ impl SyscallDriver for FakeDMADriver {
                     .expect("Unable to schedule upcall");
                 crate::command_return::success()
             }
+            dma_cmd::TRANSLATE_LOCAL_TO_CPTRA_AXI => {
+                let local_addr = arg0;
+                let len = arg1;
+
+                if len == 0 || (local_addr % 4 != 0) || (len % 4 != 0) {
+                    return crate::command_return::failure(ErrorCode::Invalid);
+                }
+
+                const SRAM_LOCAL_BASE: u32 = 0x4000_0000;
+                const SRAM_SIZE: u32 = 1024 * 1024;
+                const CPTRA_SRAM_AXI_BASE: u32 = 0xA8C0_0000;
+
+                let axi_addr = if local_addr >= SRAM_LOCAL_BASE
+                    && local_addr < SRAM_LOCAL_BASE.wrapping_add(SRAM_SIZE)
+                {
+                    let offset = local_addr - SRAM_LOCAL_BASE;
+                    let Some(end) = offset.checked_add(len) else {
+                        return crate::command_return::failure(ErrorCode::Size);
+                    };
+                    if end > SRAM_SIZE {
+                        return crate::command_return::failure(ErrorCode::Size);
+                    }
+                    CPTRA_SRAM_AXI_BASE.wrapping_add(offset)
+                } else if local_addr >= CPTRA_SRAM_AXI_BASE
+                    && local_addr < CPTRA_SRAM_AXI_BASE.wrapping_add(512 * 1024)
+                {
+                    // FPGA layout simulation:
+                    let offset = local_addr - CPTRA_SRAM_AXI_BASE;
+                    let Some(end) = offset.checked_add(len) else {
+                        return crate::command_return::failure(ErrorCode::Size);
+                    };
+                    if end > 512 * 1024 {
+                        return crate::command_return::failure(ErrorCode::Size);
+                    }
+                    local_addr
+                } else {
+                    // For host unit tests where buffers are allocated on host stack/heap:
+                    CPTRA_SRAM_AXI_BASE.wrapping_add(local_addr & 0x000F_FFFF)
+                };
+
+                crate::command_return::success_u32(axi_addr)
+            }
             _ => crate::command_return::failure(ErrorCode::Invalid),
         }
     }
@@ -140,6 +182,7 @@ mod dma_cmd {
     pub const SET_DEST_ADDR: u32 = 2;
     pub const XFER_AXI_TO_AXI: u32 = 3;
     pub const XFER_LOCAL_TO_AXI: u32 = 4;
+    pub const TRANSLATE_LOCAL_TO_CPTRA_AXI: u32 = 5;
 }
 
 mod dma_ro_buffer {

--- a/runtime/userspace/syscall/src/dma.rs
+++ b/runtime/userspace/syscall/src/dma.rs
@@ -134,6 +134,23 @@ impl<S: Syscalls> DMA<S> {
 
         Ok(())
     }
+
+    /// Translates a local MCU SRAM buffer to its Caliptra Subsystem AXI bus address.
+    ///
+    /// The kernel validates non-zero length, word alignment, and bounds within MCU SRAM.
+    /// Returns `(axi_addr, length)` on success, or an `ErrorCode` on failure.
+    pub fn mcu_sram_to_cptra_axi(&self, buf: &[u8]) -> Result<(u32, u32), ErrorCode> {
+        let len = u32::try_from(buf.len()).map_err(|_| ErrorCode::Invalid)?;
+        let local_addr = (buf.as_ptr() as usize) as u32;
+        let axi_addr = S::command(
+            self.driver_num,
+            dma_cmd::TRANSLATE_LOCAL_TO_CPTRA_AXI,
+            local_addr,
+            len,
+        )
+        .to_result::<u32, ErrorCode>()?;
+        Ok((axi_addr, len))
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -150,6 +167,7 @@ mod dma_cmd {
     pub const SET_DEST_ADDR: u32 = 2;
     pub const XFER_AXI_TO_AXI: u32 = 3;
     pub const XFER_LOCAL_TO_AXI: u32 = 4;
+    pub const TRANSLATE_LOCAL_TO_CPTRA_AXI: u32 = 5;
 }
 
 /// Buffer IDs for DMA (read-only)
@@ -161,4 +179,49 @@ mod dma_ro_buffer {
 /// Subscription IDs for asynchronous notifications.
 mod dma_subscribe {
     pub const XFER_DONE: u32 = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+    use caliptra_mcu_libtock_unittest::fake;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_mcu_sram_to_cptra_axi_success() {
+        let kernel = fake::Kernel::new();
+        let driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&driver);
+
+        let dma = DMA::<crate::DefaultSyscalls>::new();
+        let buf = [0u32; 8];
+        let slice = unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, 32) };
+        let (addr, len) = dma.mcu_sram_to_cptra_axi(slice).unwrap();
+        assert_eq!(len, 32);
+        assert_ne!(addr, 0);
+    }
+
+    #[test]
+    fn test_mcu_sram_to_cptra_axi_zero_length() {
+        let kernel = fake::Kernel::new();
+        let driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&driver);
+
+        let dma = DMA::<crate::DefaultSyscalls>::new();
+        let empty: &[u8] = &[];
+        assert_eq!(dma.mcu_sram_to_cptra_axi(empty), Err(ErrorCode::Invalid));
+    }
+
+    #[test]
+    fn test_mcu_sram_to_cptra_axi_unaligned_length() {
+        let kernel = fake::Kernel::new();
+        let driver = Rc::new(fake::FakeDMADriver::new());
+        kernel.add_driver(&driver);
+
+        let dma = DMA::<crate::DefaultSyscalls>::new();
+        let buf = [0u32; 8];
+        let slice = unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, 7) };
+        assert_eq!(dma.mcu_sram_to_cptra_axi(slice), Err(ErrorCode::Invalid));
+    }
 }


### PR DESCRIPTION
- Introduce the `dma` module in `mcu-caliptra-api` defining Caliptra subsystem AXI DMA integration constants (MCU_SRAM_LOCAL_BASE, MCI_BASE_AXI_ADDRESS, MCU_SRAM_AXI_OFFSET, MCU_SRAM_AXI_BASE).
- Implement AxiDmaTarget and mcu_sram_to_axi_dma for safe address translation from MCU local SRAM buffers to subsystem AXI DMA target descriptors.
- Add unit tests for AXI DMA address translation and bounds checking.
- Refactor dpe_derive_context_exported_cdi in dpe.rs to use the new helper.