### PR TITLE
caliptra-api: Add ML-KEM

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/example/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/main.rs
@@ -187,6 +187,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_caliptra_crypto::test_caliptra_sha(alloc).await;
         test_caliptra_crypto::test_caliptra_rng(alloc).await;
         test_caliptra_crypto::test_caliptra_ecdh(alloc).await;
+        test_caliptra_crypto::test_caliptra_mlkem(alloc).await;
         test_caliptra_crypto::test_caliptra_hmac(alloc).await;
         test_caliptra_crypto::test_caliptra_aes_gcm_cipher(alloc).await;
         test_caliptra_crypto::test_caliptra_ecdsa(alloc).await;

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
@@ -6,10 +6,11 @@ use core::ptr::NonNull;
 use mcu_caliptra_api::{
     cm_hmac, cm_import, dpe_certify_key_pubkey, dpe_sign_ecc_p384, ecdh_finish, ecdh_generate,
     ecdsa_verify, hash_all, hkdf_expand, hkdf_extract, mldsa87_compute_mu, mldsa87_compute_tr,
-    rng_generate, sha_finish, sha_init, sha_update, spdm_aes_gcm_decrypt, spdm_aes_gcm_encrypt,
-    CmKeyUsage, HashAlgo, HkdfSalt, CERTIFY_KEY_MLDSA87_PUBKEY_SIZE,
-    CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, DPE_LABEL_LEN,
-    DPE_MLDSA87_MU_SIZE, DPE_P384_SIGNATURE_SIZE, MLDSA87_TR_SIZE, SHA_CONTEXT_SIZE,
+    mlkem_decapsulate, mlkem_encapsulate, mlkem_key_gen, rng_generate, sha_finish, sha_init,
+    sha_update, spdm_aes_gcm_decrypt, spdm_aes_gcm_encrypt, CmKeyUsage, HashAlgo, HkdfSalt,
+    CERTIFY_KEY_MLDSA87_PUBKEY_SIZE, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE,
+    CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, DPE_LABEL_LEN, DPE_MLDSA87_MU_SIZE, DPE_P384_SIGNATURE_SIZE,
+    MLDSA87_TR_SIZE, MLKEM1024_CIPHERTEXT_SIZE, MLKEM1024_ENCAPS_KEY_SIZE, SHA_CONTEXT_SIZE,
 };
 
 const CRYPTO_SCRATCH_SIZE: usize = 16 * 1024;
@@ -144,6 +145,42 @@ pub async fn test_caliptra_ecdh(alloc: &BitmapAllocator) {
         .await
         .unwrap_or_else(|_| test_exit(1));
     println!("ECDH/HMAC test completed successfully: {}", HexBytes(&mac));
+}
+
+pub async fn test_caliptra_mlkem(alloc: &BitmapAllocator) {
+    // Generate a seed CMK for ML-KEM (64 bytes: seed_d || seed_z)
+    let seed = [0x42; 64];
+    let seed_cmk = cm_import(alloc, CmKeyUsage::MlKem, &seed)
+        .await
+        .unwrap_or_else(|_| test_exit(1));
+
+    // Responder: Generate ML-KEM-1024 encapsulation key from seed
+    let mut encaps_key = [0u8; MLKEM1024_ENCAPS_KEY_SIZE];
+    mlkem_key_gen(alloc, &seed_cmk, &mut encaps_key)
+        .await
+        .unwrap_or_else(|_| {
+            println!("ML-KEM key-gen failed!");
+            test_exit(1)
+        });
+
+    // Initiator: Encapsulate to produce ciphertext and shared secret
+    let mut ciphertext = [0u8; MLKEM1024_CIPHERTEXT_SIZE];
+    let initiator_secret = mlkem_encapsulate(alloc, CmKeyUsage::Hmac, &encaps_key, &mut ciphertext)
+        .await
+        .unwrap_or_else(|_| {
+            println!("ML-KEM encapsulate failed!");
+            test_exit(1)
+        });
+
+    // Responder: Decapsulate to recover shared secret
+    let responder_secret = mlkem_decapsulate(alloc, CmKeyUsage::Hmac, &seed_cmk, &ciphertext)
+        .await
+        .unwrap_or_else(|_| {
+            println!("ML-KEM decapsulate failed!");
+            test_exit(1)
+        });
+
+    println!("ML-KEM/AES test completed successfully");
 }
 
 pub async fn test_caliptra_hmac(alloc: &BitmapAllocator) {

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -136,6 +136,11 @@ pub use image_loader::{core_image_info, GetImageInfoResp};
 #[cfg(feature = "mailbox-io")]
 pub use import::{cm_delete, cm_import};
 #[cfg(feature = "mailbox-io")]
+pub use ml_kem::{
+    mlkem_decapsulate, mlkem_encapsulate, mlkem_key_gen, MLKEM1024_CIPHERTEXT_SIZE,
+    MLKEM1024_ENCAPS_KEY_SIZE,
+};
+#[cfg(feature = "mailbox-io")]
 pub use mldsa::{
     mldsa87_compute_mu, mldsa87_compute_tr, MLDSA87_CONTEXT_MAX_SIZE, MLDSA87_TR_SIZE,
 };

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -54,6 +54,8 @@ pub mod image_loader;
 mod import;
 pub mod mailbox;
 #[cfg(feature = "mailbox-io")]
+mod ml_kem;
+#[cfg(feature = "mailbox-io")]
 mod mldsa;
 #[cfg(feature = "mailbox-io")]
 mod pcr;

--- a/runtime/userspace/api/caliptra-api/src/ml_kem.rs
+++ b/runtime/userspace/api/caliptra-api/src/ml_kem.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache-2.0 license
+
+//! `CM_MLKEM_KEY_GEN`, `CM_MLKEM_ENCAPSULATE` and `CM_MLKEM_DECAPSULATE` mailbox commands.
+//!
+//! These commands perform an ML-KEM key exchange through Caliptra:
+//!
+//! 1. [`mlkem_key_gen`] — generates an ML-KEM-1024 encapsulation key from a seed CMK.
+//! 2. [`mlkem_encapsulate`] — performs encapsulation against the encapsulation key,
+//!    producing ciphertext and a shared secret CMK.
+//! 3. [`mlkem_decapsulate`] — performs decapsulation using the seed and ciphertext,
+//!    recovering the shared secret CMK.
+
+use core::mem::size_of;
+use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
+use mcu_error::McuResult;
+use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::types::{CmKeyUsage, Cmk, CMK_SIZE};
+use crate::wire::{
+    mbox_execute, populate_checksum, CMD_CM_MLKEM_DECAPSULATE, CMD_CM_MLKEM_ENCAPSULATE,
+    CMD_CM_MLKEM_KEY_GEN, MBOX_RESP_HEADER_SIZE,
+};
+use crate::ApiAlloc;
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/// Size of the ML-KEM-1024 encapsulation key.
+pub const CMB_MLKEM_ENCAPS_KEY_SIZE: usize = 1568;
+
+/// Size of the ML-KEM-1024 ciphertext.
+pub const CMB_MLKEM_CIPHERTEXT_SIZE: usize = 1568;

--- a/runtime/userspace/api/caliptra-api/src/ml_kem.rs
+++ b/runtime/userspace/api/caliptra-api/src/ml_kem.rs
@@ -10,10 +10,15 @@
 //! 3. [`mlkem_decapsulate`] — performs decapsulation using the seed and ciphertext,
 //!    recovering the shared secret CMK.
 
+use caliptra_api::mailbox::{
+    CmMlkemDecapsulateReq, CmMlkemDecapsulateResp, CmMlkemEncapsulateReq, CmMlkemEncapsulateResp,
+    CmMlkemKeyGenReq,
+};
+pub use caliptra_api::mailbox::{MLKEM1024_CIPHERTEXT_SIZE, MLKEM1024_ENCAPS_KEY_SIZE};
 use core::mem::size_of;
 use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
 use mcu_error::McuResult;
-use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::FromBytes;
 
 use crate::types::{CmKeyUsage, Cmk, CMK_SIZE};
 use crate::wire::{
@@ -26,8 +31,146 @@ use crate::ApiAlloc;
 // Public constants
 // ---------------------------------------------------------------------------
 
-/// Size of the ML-KEM-1024 encapsulation key.
-pub const CMB_MLKEM_ENCAPS_KEY_SIZE: usize = 1568;
+const KEY_GEN_REQ_SIZE: usize = size_of::<CmMlkemKeyGenReq>();
 
-/// Size of the ML-KEM-1024 ciphertext.
-pub const CMB_MLKEM_CIPHERTEXT_SIZE: usize = 1568;
+const KEY_GEN_RSP_SIZE: usize = MBOX_RESP_HEADER_SIZE + MLKEM1024_ENCAPS_KEY_SIZE;
+
+const ENCAPSULATE_REQ_SIZE: usize = size_of::<CmMlkemEncapsulateReq>();
+
+const ENCAPSULATE_RSP_SIZE: usize = size_of::<CmMlkemEncapsulateResp>();
+
+const DECAPSULATE_REQ_SIZE: usize = size_of::<CmMlkemDecapsulateReq>();
+
+const DECAPSULATE_RSP_SIZE: usize = size_of::<CmMlkemDecapsulateResp>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Generate an ML-KEM-1024 encapsulation key from a seed CMK.
+///
+/// Writes the encapsulation key (to be sent to the peer for encapsulation).
+///
+/// * `seed_cmk` — CMK containing ML-KEM seed (seed_d || seed_z, 64 bytes).
+/// * `encaps_key` — Output buffer for the 1568-byte encapsulation key.
+#[inline(never)]
+pub async fn mlkem_key_gen<A: ApiAlloc>(
+    alloc: &A,
+    seed_cmk: &Cmk,
+    encaps_key: &mut [u8],
+) -> McuResult<()> {
+    if encaps_key.len() != MLKEM1024_ENCAPS_KEY_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let mut req = alloc.alloc(KEY_GEN_REQ_SIZE)?;
+    req.fill(0);
+    let req_struct =
+        CmMlkemKeyGenReq::mut_from_bytes(&mut req[..KEY_GEN_REQ_SIZE]).map_err(|_| INVARIANT)?;
+    req_struct.cmk = (*seed_cmk).into();
+    populate_checksum(CMD_CM_MLKEM_KEY_GEN, &mut req)?;
+
+    let mut rsp = alloc.alloc(KEY_GEN_RSP_SIZE)?;
+    let rsp_len = mbox_execute(CMD_CM_MLKEM_KEY_GEN, &req, &mut rsp).await?;
+    if rsp_len < KEY_GEN_RSP_SIZE {
+        return Err(INTERNAL_BUG);
+    }
+
+    *encaps_key
+        .first_chunk_mut::<MLKEM1024_ENCAPS_KEY_SIZE>()
+        .ok_or(INVARIANT)? = *rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<MLKEM1024_ENCAPS_KEY_SIZE>())
+        .ok_or(INTERNAL_BUG)?;
+    Ok(())
+}
+
+/// Perform ML-KEM-1024 encapsulation, producing ciphertext and a shared secret.
+///
+/// * `key_usage` — intended use of the shared secret CMK (e.g., `Hmac` for
+///   SPDM key schedule).
+/// * `encaps_key` — the peer's ML-KEM-1024 encapsulation key (1568 bytes).
+/// * `ciphertext` — output buffer for the 1568-byte ciphertext (to be sent to
+///   the peer).
+///
+/// Returns a CMK handle to the shared secret.
+#[inline(never)]
+pub async fn mlkem_encapsulate<A: ApiAlloc>(
+    alloc: &A,
+    key_usage: CmKeyUsage,
+    encaps_key: &[u8],
+    ciphertext: &mut [u8],
+) -> McuResult<Cmk> {
+    if encaps_key.len() != MLKEM1024_ENCAPS_KEY_SIZE
+        || ciphertext.len() != MLKEM1024_CIPHERTEXT_SIZE
+    {
+        return Err(INVARIANT);
+    }
+
+    let mut req_buf = alloc.alloc(ENCAPSULATE_REQ_SIZE)?;
+    req_buf.fill(0);
+    let req = CmMlkemEncapsulateReq::mut_from_bytes(&mut req_buf).map_err(|_| INVARIANT)?;
+    req.key_usage = key_usage as u32;
+    if encaps_key.len() != req.encaps_key.len() {
+        return Err(INTERNAL_BUG);
+    }
+    req.encaps_key.copy_from_slice(encaps_key);
+    populate_checksum(CMD_CM_MLKEM_ENCAPSULATE, &mut req_buf)?;
+
+    let mut rsp_buf = alloc.alloc(ENCAPSULATE_RSP_SIZE)?;
+    let rsp_len = mbox_execute(CMD_CM_MLKEM_ENCAPSULATE, &req_buf, &mut rsp_buf).await?;
+    if rsp_len < ENCAPSULATE_RSP_SIZE {
+        return Err(INTERNAL_BUG);
+    }
+    let rsp = CmMlkemEncapsulateResp::mut_from_bytes(&mut rsp_buf).map_err(|_| INTERNAL_BUG)?;
+
+    ciphertext
+        .first_chunk_mut::<MLKEM1024_CIPHERTEXT_SIZE>()
+        .map(|s| s.copy_from_slice(&rsp.ciphertext))
+        .ok_or(INVARIANT)?;
+
+    Ok((&rsp.shared_key).into())
+}
+
+/// Perform ML-KEM-1024 decapsulation, recovering the shared secret.
+///
+/// * `key_usage` — intended use of the shared secret CMK (e.g., `Hmac` for
+///   SPDM key schedule).
+/// * `seed_cmk` — CMK containing ML-KEM seed (seed_d || seed_z, 64 bytes).
+/// * `ciphertext` — the 1568-byte ciphertext from the peer.
+///
+/// Returns a CMK handle to the shared secret.
+#[inline(never)]
+pub async fn mlkem_decapsulate<A: ApiAlloc>(
+    alloc: &A,
+    key_usage: CmKeyUsage,
+    seed_cmk: &Cmk,
+    ciphertext: &[u8],
+) -> McuResult<Cmk> {
+    if ciphertext.len() != MLKEM1024_CIPHERTEXT_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let mut req_buf = alloc.alloc(DECAPSULATE_REQ_SIZE)?;
+    req_buf.fill(0);
+    let req = CmMlkemDecapsulateReq::mut_from_bytes(&mut req_buf).map_err(|_| INTERNAL_BUG)?;
+    req.key_usage = key_usage as u32;
+    req.cmk = (*seed_cmk).into();
+    if ciphertext.len() != req.ciphertext.len() {
+        return Err(INTERNAL_BUG);
+    }
+    req.ciphertext.copy_from_slice(ciphertext);
+    populate_checksum(CMD_CM_MLKEM_DECAPSULATE, &mut req_buf)?;
+
+    let mut rsp = alloc.alloc(DECAPSULATE_RSP_SIZE)?;
+    let rsp_len = mbox_execute(CMD_CM_MLKEM_DECAPSULATE, &req_buf, &mut rsp).await?;
+    if rsp_len < DECAPSULATE_RSP_SIZE {
+        return Err(INTERNAL_BUG);
+    }
+
+    let cmk = Cmk(*rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<CMK_SIZE>())
+        .ok_or(INTERNAL_BUG)?);
+    Ok(cmk)
+}

--- a/runtime/userspace/api/caliptra-api/src/types.rs
+++ b/runtime/userspace/api/caliptra-api/src/types.rs
@@ -31,6 +31,7 @@ pub enum CmKeyUsage {
     Aes = 2,
     Ecdsa = 3,
     Mldsa = 4,
+    MlKem = 5,
 }
 
 impl From<u32> for CmKeyUsage {
@@ -40,6 +41,7 @@ impl From<u32> for CmKeyUsage {
             2 => CmKeyUsage::Aes,
             3 => CmKeyUsage::Ecdsa,
             4 => CmKeyUsage::Mldsa,
+            5 => CmKeyUsage::MlKem,
             _ => CmKeyUsage::Reserved,
         }
     }
@@ -52,6 +54,7 @@ impl From<CmKeyUsage> for u32 {
             CmKeyUsage::Aes => 2,
             CmKeyUsage::Ecdsa => 3,
             CmKeyUsage::Mldsa => 4,
+            CmKeyUsage::MlKem => 5,
             CmKeyUsage::Reserved => 0,
         }
     }

--- a/runtime/userspace/api/caliptra-api/src/types.rs
+++ b/runtime/userspace/api/caliptra-api/src/types.rs
@@ -2,7 +2,9 @@
 
 //! Shared types for Caliptra Cryptographic Manager (CM) mailbox commands.
 
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+#[cfg(feature = "mailbox-io")]
+use caliptra_api::mailbox::Cmk as CoreCmk;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Size in bytes of a CMK handle.
 pub const CMK_SIZE: usize = 128;
@@ -13,7 +15,9 @@ pub const CMK_SIZE: usize = 128;
 /// 128-byte encrypted key material returned by CM mailbox commands and
 /// supplied back to subsequent CM commands.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq)]
+#[derive(
+    Clone, Copy, Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq, Unaligned,
+)]
 pub struct Cmk(pub [u8; CMK_SIZE]);
 
 impl Default for Cmk {
@@ -57,5 +61,19 @@ impl From<CmKeyUsage> for u32 {
             CmKeyUsage::MlKem => 5,
             CmKeyUsage::Reserved => 0,
         }
+    }
+}
+
+#[cfg(feature = "mailbox-io")]
+impl From<&CoreCmk> for Cmk {
+    fn from(value: &CoreCmk) -> Self {
+        Cmk(value.0)
+    }
+}
+
+#[cfg(feature = "mailbox-io")]
+impl From<Cmk> for CoreCmk {
+    fn from(value: Cmk) -> Self {
+        CoreCmk(value.0)
     }
 }

--- a/runtime/userspace/api/caliptra-api/src/wire.rs
+++ b/runtime/userspace/api/caliptra-api/src/wire.rs
@@ -154,6 +154,9 @@ pub(crate) const CMD_CM_AES_GCM_ENCRYPT_FINAL: u32 = 0x434D_4746; // "CMGF"
 pub(crate) const CMD_CM_AES_GCM_SPDM_DECRYPT_INIT: u32 = 0x434D_5344; // "CMSD"
 pub(crate) const CMD_CM_AES_GCM_DECRYPT_UPDATE: u32 = 0x434D_4455; // "CMDU"
 pub(crate) const CMD_CM_AES_GCM_DECRYPT_FINAL: u32 = 0x434D_4446; // "CMDF"
+pub(crate) const CMD_CM_MLKEM_KEY_GEN: u32 = 0x434D_4C4B; // "CMLK"
+pub(crate) const CMD_CM_MLKEM_ENCAPSULATE: u32 = 0x434D_4C45; // "CMLE"
+pub(crate) const CMD_CM_MLKEM_DECAPSULATE: u32 = 0x434D_4C44; // "CMLD"
 
 // ---- Hash algorithm discriminator -----------------------------------------
 


### PR DESCRIPTION
Adds commands to perform an ML-KEM key exchange through Caliptra:

1. `mlkem_key_gen` — generates an ML-KEM-1024 encapsulation key from a seed CMK.
2. `mlkem_encapsulate` — performs encapsulation against the encapsulation key,
    producing ciphertext and a shared secret CMK.
3. `mlkem_decapsulate` — performs decapsulation using the seed and ciphertext,
    recovering the shared secret CMK.

An emulator test was added for verification.

Signed-off-by: Marvin Gudel <marvin.gudel@9elements.com>
Assisted-by: Opencode:claude-sonnet-4-5