### PR TITLE
[spdm] trim transport padding before hashing requests into M1/VCA

### DIFF
--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -103,7 +103,13 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
 
     // SPDM: NEGOTIATE_ALGORITHMS + ALGORITHMS contribute to VCA.
     let head = pal.header_size();
-    state.transcript.append_vca(pal, io, io.request()).await?;
+    // Trim transport padding (e.g. PCIe-VDM DWORD alignment): NEGOTIATE_ALGORITHMS
+    // carries its own total request length (including the SPDM header) in the
+    // fixed body's Length field (DSP0274 Table 18); feed exactly that to VCA so
+    // it matches what the requester hashes.
+    let req_len = fixed.length.get() as usize;
+    let req_msg = req.get(..req_len).ok_or(SPDM_INVALID_REQUEST)?;
+    state.transcript.append_vca(pal, io, req_msg).await?;
     state
         .transcript
         .append_vca(pal, io, &resp[head..head + spdm_len])

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -104,7 +104,13 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 
     // SPDM: GET_CAPABILITIES + CAPABILITIES contribute to VCA.
     let head = pal.header_size();
-    state.transcript.append_vca(pal, io, io.request()).await?;
+    // Trim transport padding (e.g. PCIe-VDM DWORD alignment): feed only the
+    // exact GET_CAPABILITIES bytes (header + 18-byte body) to VCA, matching the
+    // exact-length bytes the requester hashes.
+    let req_msg = req
+        .get(..SpdmMsgHdrPdu::SIZE + CapabilitiesBody::SIZE)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    state.transcript.append_vca(pal, io, req_msg).await?;
     state
         .transcript
         .append_vca(pal, io, &resp[head..head + spdm_len])

--- a/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
@@ -12,8 +12,8 @@
 
 use caliptra_mcu_spdm_codec::{
     CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
-    GetCertificateParam1, GetCertificateReq, ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
-    WireWriter,
+    GetCertificateLargeReqBody, GetCertificateParam1, GetCertificateReq, GetCertificateReqBody,
+    ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, WireWriter,
 };
 use caliptra_mcu_spdm_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
@@ -192,6 +192,18 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
         return Err(SPDM_INVALID_REQUEST);
     }
 
+    // Trim any transport-layer padding (e.g. PCIe-VDM DWORD alignment) before
+    // feeding the request into M1: hash only the exact GET_CERTIFICATE message
+    // (common header + request body), matching what the requester hashes.
+    let req_body_size = if req.is_large() {
+        GetCertificateLargeReqBody::SIZE
+    } else {
+        GetCertificateReqBody::SIZE
+    };
+    let req_msg = spdm_msg
+        .get(..SpdmMsgHdrPdu::SIZE + req_body_size)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+
     let slot_id = req.slot_id();
     if slot_id >= MAX_SLOTS {
         return Err(SPDM_INVALID_REQUEST);
@@ -272,7 +284,7 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
             &[handle],
         )?;
 
-        state.transcript.append_m1(pal, io, spdm_msg).await?;
+        state.transcript.append_m1(pal, io, req_msg).await?;
         state.large_msg_ctx.start_response(
             LargeResponse::Certificate(cert_rsp),
             cert_rsp.response_size(),
@@ -319,7 +331,7 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
     };
 
     let head = pal.header_size();
-    state.transcript.append_m1(pal, io, spdm_msg).await?;
+    state.transcript.append_m1(pal, io, req_msg).await?;
     state
         .transcript
         .append_m1(pal, io, &resp[head..head + spdm_len])

--- a/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/challenge.rs
@@ -63,7 +63,20 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
     }
 
     // Append CHALLENGE request to M1 transcript.
-    state.transcript.append_m1(pal, io, req).await?;
+    // Trim any transport-layer padding (e.g. PCIe-VDM DWORD alignment) so only
+    // the exact SPDM message bytes feed M1. DSP0274 section 10.9 (request
+    // ordering) makes the requester hash the same exact-length bytes into M2;
+    // hashing trailing padding here would diverge M1 from M2 and break the
+    // CHALLENGE_AUTH signature verification.
+    let challenge_req_len = SpdmMsgHdrPdu::SIZE
+        + core::mem::size_of::<ChallengeReqBody>()
+        + if state.version >= SpdmVersion::V13 {
+            REQUESTER_CONTEXT_LEN
+        } else {
+            0
+        };
+    let req_msg = req.get(..challenge_req_len).ok_or(SPDM_INVALID_REQUEST)?;
+    state.transcript.append_m1(pal, io, req_msg).await?;
 
     let asym_algo = state.asym_algo();
 

--- a/runtime/userspace/api/spdm-lib/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/digests.rs
@@ -7,7 +7,9 @@
 //! array. Chunk buffers come from the per-IO bitmap pool — no
 //! stack-allocated `[u8; N]` arrays for cert content.
 
-use caliptra_mcu_spdm_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, SHA384_HASH_SIZE};
+use caliptra_mcu_spdm_codec::{
+    DigestsRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, SHA384_HASH_SIZE,
+};
 use caliptra_mcu_spdm_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo,
     SpdmPalIoTransport, MAX_SLOTS,

--- a/runtime/userspace/api/spdm-lib/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/digests.rs
@@ -7,7 +7,7 @@
 //! array. Chunk buffers come from the per-IO bitmap pool — no
 //! stack-allocated `[u8; N]` arrays for cert content.
 
-use caliptra_mcu_spdm_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu, SHA384_HASH_SIZE};
+use caliptra_mcu_spdm_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, SHA384_HASH_SIZE};
 use caliptra_mcu_spdm_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo,
     SpdmPalIoTransport, MAX_SLOTS,
@@ -51,7 +51,13 @@ pub(crate) async fn handle_get_digests_req<'a, Pal: SpdmPal>(
         return Err(SPDM_INVALID_REQUEST);
     }
 
-    let supported = pal.supported_slots();
+    // DSP0274: DIGESTS Param1 is SupportedSlotMask only in 1.3+ (Table 35);
+    // in 1.2 and earlier (Table 28) Param1 is Reserved and shall be 0.
+    let supported = if state.version >= SpdmVersion::V13 {
+        pal.supported_slots()
+    } else {
+        0
+    };
     let provisioned = pal.provisioned_slots();
     let digest_size = SpdmPalHashAlgo::Sha384.hash_size();
     let num_slots = provisioned.count_ones() as usize;
@@ -101,7 +107,13 @@ pub(crate) async fn handle_get_digests_req<'a, Pal: SpdmPal>(
     let resp = build_response(pal, io, state.version, &digests_body)?;
 
     let head = pal.header_size();
-    state.transcript.append_m1(pal, io, spdm_msg).await?;
+    // Trim transport padding (e.g. PCIe-VDM DWORD alignment): only the exact
+    // 4-byte GET_DIGESTS message (header + Param1 + Param2) feeds M1, matching
+    // what the requester hashes.
+    let req_msg = spdm_msg
+        .get(..SpdmMsgHdrPdu::SIZE + 2)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    state.transcript.append_m1(pal, io, req_msg).await?;
     state
         .transcript
         .append_m1(pal, io, &resp[head..head + spdm_len])

--- a/runtime/userspace/api/spdm-lib/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/version.rs
@@ -79,7 +79,14 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     // DSP0274 §10.4.1: GET_VERSION + VERSION contribute to VCA.
     // Use spdm_len to exclude any transport-layer padding (e.g. DOE DWORD alignment).
     let head = pal.header_size();
-    state.transcript.append_vca(pal, io, io.request()).await?;
+    // Trim transport padding (e.g. PCIe-VDM DWORD alignment): only the exact
+    // 4-byte GET_VERSION message (header + Param1 + Param2) contributes to VCA,
+    // matching what the requester hashes.
+    let req_msg = io
+        .request()
+        .get(..SpdmMsgHdrPdu::SIZE + 2)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    state.transcript.append_vca(pal, io, req_msg).await?;
     state
         .transcript
         .append_vca(pal, io, &resp[head..head + spdm_len])


### PR DESCRIPTION
## Problem
Transport layers (e.g. PCIe VDM) may pad SPDM requests to DWORD granularity. The responder currently hashes the **raw padded request** into the VCA and M1 transcripts. The requester hashes only the exact SPDM message bytes, so the responder's transcript diverges from the requester's and `CHALLENGE_AUTH` signature verification fails once any request arrives padded.

## Fix
Trim each request to its exact SPDM message length before appending it to VCA/M1 in the `spdm-lib` stack:

| Message | Trim length |
|---|---|
| `GET_VERSION` / `GET_DIGESTS` | header + 2 param bytes |
| `GET_CAPABILITIES` | header + `CapabilitiesBody` (18 bytes) |
| `NEGOTIATE_ALGORITHMS` | the `Length` field carried in the fixed body (DSP0274 Table 18) |
| `GET_CERTIFICATE` | header + standard (6) or large (14) request body |
| `CHALLENGE` | header + `ChallengeReqBody` (+ `RequesterContext` in 1.3+) |

The response side already trims via `spdm_len`; this brings the request side to parity.

Also gates the `DIGESTS` `SupportedSlotMask` (Param1) to SPDM 1.3+ per DSP0274 Table 35 — in 1.2 and earlier Param1 is Reserved and shall be 0.

## Why the other transcript-feeding requests don't need this change
This PR covers exactly the request handlers that were appending **raw** request bytes to a transcript. Every other request that contributes to a hashed/signed transcript already trims to the exact SPDM message length before appending, so no change is needed:

| Transcript | Request | Status |
|---|---|---|
| L1 (signed `GET_MEASUREMENTS`) | `GET_MEASUREMENTS` | already trims — `measurements.rs` appends `&req[..spdm_req_len]` |
| TH (`KEY_EXCHANGE_RSP` signature) | `KEY_EXCHANGE` | already trims — `key_exchange.rs` appends `req[..spdm_req_len]` ("use only the actual SPDM bytes, not transport padding") |
| TH (`FINISH` HMAC) | `FINISH` | already trims — `finish.rs` appends `&spdm_msg[..finish_prefix_len]` (and `req_verify_data` is an exact-length slice) |

The in-session `GET_DIGESTS` / `GET_CERTIFICATE` / `GET_MEASUREMENTS` paths dispatch into the **same** `handle_*_req` functions fixed here, so they inherit the trim automatically.

Everything else does not contribute to a signed transcript, so request padding is irrelevant to it: `SET_CERTIFICATE`, `VENDOR_DEFINED_REQUEST`, `END_SESSION`, and `CHUNK_GET` / `CHUNK_SEND` (the reassembled request flows back through the trimmed handlers). `PSK_EXCHANGE` / `PSK_FINISH` are not implemented in this stack yet; when added, their request appends will need the same trim.

## Testing
`cargo check -p caliptra-mcu-spdm-stack` passes cleanly. Verified against the Micron Caliptra Plato SPDM responder + DMTF `spdm-emu` requester with a VDM transport that pads requests: CHALLENGE_AUTH now verifies across SPDM 1.2/1.3.
