### PR TITLE
emulator: make the raw unlock token configurable

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -86,6 +86,13 @@ fn parse_vendor_pqc_type(s: &str) -> Result<FwVerificationPqcKeyType, String> {
     }
 }
 
+fn parse_raw_unlock_token(s: &str) -> Result<[u8; 16], String> {
+    let mut token = [0; 16];
+    hex::decode_to_slice(s, &mut token)
+        .map_err(|_| "raw unlock token must be exactly 32 hexadecimal characters".to_string())?;
+    Ok(token)
+}
+
 /// Map an LC state index (0–20) to the Caliptra device lifecycle string per the HW spec.
 /// TestUnlocked* → "unprovisioned", Dev → "manufacturing", all others → "production".
 fn lc_state_to_device_lifecycle_str(lc_state_index: u32) -> &'static str {
@@ -155,6 +162,11 @@ pub struct EmulatorArgs {
 
     #[arg(long)]
     pub i3c_port: Option<u16>,
+
+    /// Override the unhashed raw unlock token (32 hex characters, in byte order
+    /// from the least-significant byte of TRANSITION_TOKEN_0). Defaults to the RTL token.
+    #[arg(long, value_parser = parse_raw_unlock_token)]
+    pub raw_unlock_token: Option<[u8; 16]>,
 
     /// Device lifecycle value (0=Unprovisioned, 1=Manufacturing, 2=Reserved, 3=Production).
     #[arg(long, value_parser = maybe_hex::<u32>, default_value_t = DeviceLifecycle::Production as u32)]
@@ -885,7 +897,10 @@ impl Emulator {
         // Map DeviceLifecycle to LC state index per the Caliptra SS HW spec
         // (caliptra-ss docs/CaliptraSSHardwareSpecification.md, LCC state table).
         // The lifecycle state was already resolved above from fuses or CLI arg.
-        let lc = LcCtrl::with_state(lc_state_index, lc_transition_cnt);
+        let mut lc = LcCtrl::with_state(lc_state_index, lc_transition_cnt);
+        if let Some(token) = cli.raw_unlock_token {
+            lc.set_raw_unlock_token(token);
+        }
 
         let otp = Otp::new(
             &clock.clone(),
@@ -907,7 +922,6 @@ impl Emulator {
         )?;
 
         // Share OTP partition data with the LC controller for transitions.
-        let mut lc = lc;
         lc.set_otp_partitions(otp.partitions_ref());
         let ext_mcu_mailbox0 = mcu_mailbox0.as_external(MciMailboxRequester::SocAgent(1));
         let soc_ifc = unsafe {
@@ -1412,4 +1426,58 @@ fn read_binary(path: &PathBuf, expect_load_addr: u32) -> io::Result<Vec<u8>> {
     }
 
     Ok(buffer)
+}
+
+#[cfg(test)]
+mod argument_tests {
+    use super::*;
+
+    fn parse_args(extra: &[&str]) -> Result<EmulatorArgs, clap::Error> {
+        let mut args = vec![
+            "emulator",
+            "--rom",
+            "rom.bin",
+            "--firmware",
+            "firmware.bin",
+            "--caliptra-rom",
+            "caliptra-rom.bin",
+            "--caliptra-firmware",
+            "caliptra-firmware.bin",
+            "--soc-manifest",
+            "manifest.bin",
+        ];
+        args.extend_from_slice(extra);
+        EmulatorArgs::try_parse_from(args)
+    }
+
+    #[test]
+    fn raw_unlock_token_is_optional() {
+        assert_eq!(parse_args(&[]).unwrap().raw_unlock_token, None);
+    }
+
+    #[test]
+    fn raw_unlock_token_parses_hex_in_byte_order() {
+        let args = parse_args(&["--raw-unlock-token", "00112233445566778899aAbBcCdDeEfF"]).unwrap();
+        assert_eq!(
+            args.raw_unlock_token,
+            Some([
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff,
+            ])
+        );
+    }
+
+    #[test]
+    fn raw_unlock_token_rejects_invalid_input() {
+        for token in [
+            "",
+            "00112233445566778899aabbccddeef",
+            "00112233445566778899aabbccddeeff00",
+            "00112233445566778899aabbccddeegg",
+            "0x00112233445566778899aabbccddeeff",
+        ] {
+            let error = parse_args(&["--raw-unlock-token", token]).unwrap_err();
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+    }
 }

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -333,6 +333,7 @@ pub unsafe extern "C" fn emulator_init(
         device_security_state: DeviceLifecycle::try_from(config.device_security_state)
             .unwrap_or(DeviceLifecycle::Production) as u32,
         test_feature: None,
+        raw_unlock_token: None,
         vendor_pk_hash: convert_optional_c_string(config.vendor_pk_hash),
         vendor_pqc_type: caliptra_image_types::FwVerificationPqcKeyType::from_u8(
             config.vendor_pqc_type,

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -50,6 +50,7 @@ fn test_emulator_args_creation() {
         i3c_port: None,
         device_security_state: DeviceLifecycle::Production as u32,
         test_feature: None,
+        raw_unlock_token: None,
         vendor_pk_hash: None,
         vendor_pqc_type: FwVerificationPqcKeyType::LMS,
         owner_pk_hash: None,

--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -34,7 +34,7 @@ const LIFE_CYCLE_BYTE_OFFSET: usize = 0xc80;
 // Source: caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
 const LC_TOKENS_SCRAMBLE_KEY: u128 = 0xB7474D640F8A7F5D60822E1FAEC5C72;
 
-// Hardcoded raw unlock token matching the caliptra-ss RTL netlist constant.
+// Default raw unlock token matching the caliptra-ss RTL netlist constant.
 // Source: caliptra-ss/src/lc_ctrl/rtl/lc_ctrl_pkg.sv (RndCnstRawUnlockToken)
 const RAW_UNLOCK_TOKEN: [u8; 16] = [
     0xca, 0xa0, 0x32, 0xb5, 0x87, 0x96, 0xce, 0x74, 0x9a, 0xef, 0xec, 0xa2, 0x65, 0xbe, 0x41, 0x61,
@@ -152,6 +152,8 @@ pub struct LcCtrl {
     transition_target: u32,
     token: [u32; 4],
 
+    raw_unlock_token: [u8; 16],
+
     /// Shared reference to OTP partition data for token reads and state writes.
     otp_partitions: Option<Rc<RefCell<Vec<u8>>>>,
 }
@@ -184,6 +186,7 @@ impl LcCtrl {
             mutex_claimed: false,
             transition_target: 0,
             token: [0; 4],
+            raw_unlock_token: RAW_UNLOCK_TOKEN,
             otp_partitions: None,
         }
     }
@@ -191,6 +194,13 @@ impl LcCtrl {
     /// Provide OTP partition access after construction.
     pub fn set_otp_partitions(&mut self, otp: Rc<RefCell<Vec<u8>>>) {
         self.otp_partitions = Some(otp);
+    }
+
+    /// Override the unhashed token for Raw -> TestUnlocked0.
+    /// Bytes are ordered from the least-significant byte of TRANSITION_TOKEN_0.
+    /// This configuration is retained across resets and does not change OTP tokens.
+    pub fn set_raw_unlock_token(&mut self, token: [u8; 16]) {
+        self.raw_unlock_token = token;
     }
 
     /// Re-read lifecycle state from OTP and reset transient state.
@@ -291,7 +301,7 @@ impl LcCtrl {
         match token_req {
             TokenRequirement::None => {}
             TokenRequirement::RawUnlock => {
-                if self.token_as_bytes() != RAW_UNLOCK_TOKEN {
+                if self.token_as_bytes() != self.raw_unlock_token {
                     self.transition_error(STATUS_TOKEN_ERROR);
                     return;
                 }
@@ -521,6 +531,45 @@ mod tests {
     fn test_raw_to_test_unlocked0_wrong_token() {
         let mut lc = make_lc_ctrl(RAW, 0, &TEST_RAW_TOKEN);
         let status = do_transition(&mut lc, TEST_UNLOCKED0, [0xdead, 0xbeef, 0xcafe, 0xbabe]);
+        assert_ne!(status & STATUS_TOKEN_ERROR, 0);
+    }
+
+    #[test]
+    fn test_raw_unlock_token_override() {
+        let mut lc = make_lc_ctrl(RAW, 0, &TEST_RAW_TOKEN);
+        lc.set_raw_unlock_token(TEST_RAW_TOKEN);
+        let status = do_transition(&mut lc, TEST_UNLOCKED0, token_to_words(&TEST_RAW_TOKEN));
+        assert_ne!(status & STATUS_TRANSITION_SUCCESSFUL, 0);
+        assert_eq!(lc.lc_state_index, POST_TRANSITION);
+        assert_eq!(lc.lc_transition_cnt, 1);
+
+        let mut lc = make_lc_ctrl(RAW, 0, &TEST_RAW_TOKEN);
+        lc.set_raw_unlock_token(TEST_RAW_TOKEN);
+        let status = do_transition(&mut lc, TEST_UNLOCKED0, token_to_words(&RAW_UNLOCK_TOKEN));
+        assert_ne!(status & STATUS_TOKEN_ERROR, 0);
+    }
+
+    #[test]
+    fn test_raw_unlock_token_override_survives_warm_reset() {
+        use caliptra_mcu_emulator_registers_generated::lc::LcPeripheral;
+
+        let mut lc = make_lc_ctrl(RAW, 0, &TEST_RAW_TOKEN);
+        lc.set_raw_unlock_token(TEST_RAW_TOKEN);
+        lc.warm_reset();
+        let status = do_transition(&mut lc, TEST_UNLOCKED0, token_to_words(&TEST_RAW_TOKEN));
+        assert_ne!(status & STATUS_TRANSITION_SUCCESSFUL, 0);
+    }
+
+    #[test]
+    fn test_raw_unlock_override_does_not_replace_otp_tokens() {
+        let mut lc = make_lc_ctrl(PROD, 10, &TEST_RAW_TOKEN);
+        lc.set_raw_unlock_token([0; 16]);
+        let status = do_transition(&mut lc, RMA, token_to_words(&TEST_RAW_TOKEN));
+        assert_ne!(status & STATUS_TRANSITION_SUCCESSFUL, 0);
+
+        let mut lc = make_lc_ctrl(PROD, 10, &TEST_RAW_TOKEN);
+        lc.set_raw_unlock_token([0; 16]);
+        let status = do_transition(&mut lc, RMA, [0; 4]);
         assert_ne!(status & STATUS_TOKEN_ERROR, 0);
     }
 


### PR DESCRIPTION
Add an optional `--raw-unlock-token` argument and `LcCtrl::set_raw_unlock_token` so the emulator can model a different raw-unlock token.

The CLI accepts the unhashed token as exactly 16 bytes represented by 32 hexadecimal characters, ordered from the least-significant byte of `TRANSITION_TOKEN_0`. Invalid input is rejected during argument parsing. The existing RTL token remains the default, and the override is retained across lifecycle-controller resets.

This does not change lifecycle transition policy, OTP-backed token verification, or the C configuration ABI. Existing C-binding consumers use the default token.

Tests cover the default and overridden tokens, rejection of the old token after an override, reset retention, unchanged OTP-token checks, and CLI validation.
