### PR TITLE
deps: bump caliptra-sw to latest and Rust toolchain to 1.95

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ env:
   # Pin the Caliptra core ROM to a release tag; image/update crates continue
   # to use the Cargo.toml caliptra-sw rev. main-2.1 pins rom-2.1.2 instead.
   CALIPTRA_ROM_REF: rom-2.1.2
-  RUSTUP_TOOLCHAIN: "1.85-x86_64-unknown-linux-gnu"
+  RUSTUP_TOOLCHAIN: "1.95-x86_64-unknown-linux-gnu"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
@@ -39,7 +39,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Prebuild xtask
         run: |
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Download xtask binary
         uses: actions/download-artifact@v4
@@ -119,7 +119,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Download xtask binary
         uses: actions/download-artifact@v8
@@ -218,7 +218,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Download xtask binary
         uses: actions/download-artifact@v8
@@ -264,7 +264,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Install cargo-nextest (prebuilt binary)
         run: |
@@ -315,7 +315,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm dnsmasq && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Install cargo-nextest (prebuilt binary)
         run: |
@@ -448,7 +448,7 @@ jobs:
         run: |
           sudo apt-get update -qy && \
           sudo apt-get install -qy build-essential curl git libclang-dev llvm && \
-          rustup toolchain install 1.85-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
+          rustup toolchain install 1.95-x86_64-unknown-linux-gnu -c clippy,rust-src,llvm-tools,llvm-tools-preview,rustfmt,rustc-dev -t riscv32imc-unknown-none-elf,aarch64-unknown-linux-gnu
 
       - name: Install cargo-nextest (prebuilt binary)
         run: |

--- a/.github/workflows/fpga-spdm.yml
+++ b/.github/workflows/fpga-spdm.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
         run: |
-          rustup install 1.85
-          cargo +1.85 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
+          rustup install 1.95
+          cargo +1.95 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
 
       # Save the sccache binary immediately so we can reuse it in future runs
       # even if the rest of the current run fails.

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
         run: |
-          rustup install 1.85
-          cargo +1.85 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
+          rustup install 1.95
+          cargo +1.95 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
 
       - name: Save sccache binary
         uses: actions/cache/save@v6
@@ -189,8 +189,8 @@ jobs:
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
         run: |
-          rustup install 1.85
-          cargo +1.85 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
+          rustup install 1.95
+          cargo +1.95 install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
 
       - name: Save sccache binary
         uses: actions/cache/save@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bitflags 2.13.0",
  "caliptra-api-types",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -585,7 +585,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a10
 [[package]]
 name = "caliptra-common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bitfield",
  "bitflags 2.13.0",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-emu-types",
  "caliptra-ureg",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "aes",
  "arrayref",
@@ -784,17 +784,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-common",
 ]
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bitflags 2.13.0",
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -941,7 +941,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958)",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ocp-eat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "arrayvec",
 ]
@@ -2842,12 +2842,12 @@ dependencies = [
 [[package]]
 name = "caliptra-okref"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-registers-latest",
  "caliptra-registers-rev-2-1",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-rev-2-1"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -2872,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2965,12 +2965,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-util-host-commands"
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,32 +371,32 @@ caliptra-mcu-libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 caliptra-mcu-tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 
 # caliptra-sw dependencies
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
 caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "767d4ef59a106aea683b883c07bd65456fb3ba", default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "767d4ef59a106aea683b883c07bd65456fb3ba"}
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", features = ["ocp-lock"] }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", default-features = false }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", features = ["cfi"] }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
-caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93", default-features = false }
-caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", features = ["ocp-lock"] }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", default-features = false }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", features = ["cfi"] }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
+caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc", default-features = false }
+caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98593675c6805c94ead32708c24f5d477d9b8fbc" }
 
 # caliptra-dpe dependencies; keep git revs in sync with version pulled into caliptra-sw
 dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false, features = ["p384"] }

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -796,7 +796,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     // Propagate hw-2-1 from rom_features to runtime builds so that
     // staging SRAM is enabled (required when ImageManifest > 16 KB).
     let propagate_hw_2_1 = rom_features.contains("hw-2-1");
-    if propagate_hw_2_1 && !runtime_features.iter().any(|f| *f == "hw-2-1") {
+    if propagate_hw_2_1 && !runtime_features.contains(&"hw-2-1") {
         runtime_features.push("hw-2-1");
     }
 

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -585,6 +585,12 @@ fn main() -> Result<()> {
             ])
             .env_remove("CARGO_ENCODED_RUSTFLAGS")
             .env_remove("RUSTFLAGS")
+            // caliptra-builder denies warnings when it is compiled with
+            // GITHUB_ACTIONS set. A released ROM ref is pinned third-party
+            // source we cannot patch, so lints added by a newer toolchain would
+            // fail the build. Drop the variable so the helper builds without
+            // -Dwarnings; our own crates are still linted by the clippy job.
+            .env_remove("GITHUB_ACTIONS")
             .status()
             .context("Failed to run Caliptra ROM helper build")?;
         if !status.success() {

--- a/builder/src/network_rom.rs
+++ b/builder/src/network_rom.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 ///
 /// # Arguments
 /// * `feature` - Optional feature flag to pass to cargo build. If provided, the binary
-///               will be named `network-rom-feature-<feature_name>.bin`.
+///   will be named `network-rom-feature-<feature_name>.bin`.
 ///
 /// Returns the path to the built binary.
 pub fn network_rom_build(feature: Option<&str>) -> Result<String> {

--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "bitflags 2.11.1",
  "caliptra-api-types",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -464,17 +464,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-error",
  "caliptra-lms-types",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "zerocopy",
  "zeroize",
@@ -619,7 +619,6 @@ name = "caliptra-mcu-mctp-vdm-common"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "caliptra-api",
  "zerocopy",
 ]
 
@@ -682,7 +681,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-registers-latest",
  "caliptra-registers-rev-2-1",
@@ -691,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -699,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-rev-2-1"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -748,7 +747,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93#557fd1a9864831a7d1cdfaffd3b33fd2e26f5e93"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98593675c6805c94ead32708c24f5d477d9b8fbc#98593675c6805c94ead32708c24f5d477d9b8fbc"
 
 [[package]]
 name = "caliptra-util-host"

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -444,7 +444,7 @@ impl<'a> SpdmVdmClient<'a> {
             .map_err(|e| anyhow::anyhow!("DOT_OVERRIDE failed: {:?}", e))
     }
 
-    fn create_session(&mut self) -> Result<CaliptraSession> {
+    fn create_session(&mut self) -> Result<CaliptraSession<'_>> {
         let mut session = CaliptraSession::new(1, &mut self.transport as &mut dyn Transport)
             .map_err(|e| anyhow::anyhow!("Failed to create session: {:?}", e))?;
         session

--- a/caliptra-util-host/osal/src/time.rs
+++ b/caliptra-util-host/osal/src/time.rs
@@ -235,7 +235,7 @@ pub fn init(_resolution_us: u64) -> OsalResult<()> {
             next_handle: core::sync::atomic::AtomicU32::new(1),
         };
         unsafe {
-            TIMER = Some(&STD_TIMER as &(dyn Timer));
+            TIMER = Some(&STD_TIMER as &dyn Timer);
         }
     }
 

--- a/common/ocp/src/cms/slice_fifo.rs
+++ b/common/ocp/src/cms/slice_fifo.rs
@@ -38,7 +38,7 @@ impl<'a> SliceFifoRegion<'a> {
         region_type: FifoCmsRegionType,
         max_transfer_4b: u32,
     ) -> Result<Self, OcpError> {
-        if buf.is_empty() || buf.len() % 4 != 0 {
+        if buf.is_empty() || !buf.len().is_multiple_of(4) {
             return Err(OcpError::InvalidCmsBufferSize);
         }
         Ok(Self {
@@ -90,7 +90,7 @@ impl<'a> SliceFifoRegion<'a> {
     /// Returns [`CmsError::FifoFull`] if there is not enough space for the
     /// (4-byte-rounded) data.
     pub fn push_data(&mut self, data: &[u8]) -> Result<(), CmsError> {
-        let data_4b = ((data.len() as u32) + 3) / 4;
+        let data_4b = (data.len() as u32).div_ceil(4);
         if data_4b > self.space_available_4b() {
             return Err(CmsError::FifoFull);
         }
@@ -119,7 +119,7 @@ impl<'a> SliceFifoRegion<'a> {
         let occupancy_4b = (self.write_idx + cap - self.read_idx) % cap;
         let available_bytes = occupancy_4b as usize * 4;
         let read_len = buf.len().min(available_bytes);
-        let consume_4b = ((read_len as u32) + 3) / 4;
+        let consume_4b = (read_len as u32).div_ceil(4);
 
         let buf_byte_len = cap as usize * 4;
         for (i, slot) in buf.iter_mut().enumerate().take(read_len) {

--- a/common/ocp/src/cms/slice_indirect.rs
+++ b/common/ocp/src/cms/slice_indirect.rs
@@ -27,7 +27,7 @@ impl<'a> SliceIndirectRegion<'a> {
     /// Returns [`OcpError::InvalidCmsBufferSize`] if `buf` is empty or its length
     /// is not a multiple of 4.
     pub fn new(buf: &'a mut [u8], region_type: CmsRegionType) -> Result<Self, OcpError> {
-        if buf.is_empty() || buf.len() % 4 != 0 {
+        if buf.is_empty() || !buf.len().is_multiple_of(4) {
             return Err(OcpError::InvalidCmsBufferSize);
         }
         Ok(Self {

--- a/common/otp-fuse/src/lib.rs
+++ b/common/otp-fuse/src/lib.rs
@@ -163,12 +163,12 @@ pub fn fuse_read_dai_params(
     }
 
     let entry_offset = entry as usize;
-    if entry_offset >= info.byte_size || entry_offset % 4 != 0 {
+    if entry_offset >= info.byte_size || !entry_offset.is_multiple_of(4) {
         return Err(McuError::ROM_OTP_FUSE_READ_ENTRY_OUT_OF_BOUNDS);
     }
 
     let remaining_bytes = info.byte_size - entry_offset;
-    let remaining_words = (remaining_bytes + 3) / 4;
+    let remaining_words = remaining_bytes.div_ceil(4);
     let words_to_read = remaining_words.min(max_words);
     let base_word_addr = (info.byte_offset + entry_offset) / 4;
     let valid_bits = (remaining_bytes.min(words_to_read * 4) * 8) as u32;

--- a/common/pldm/src/message/firmware_update/request_fw_data.rs
+++ b/common/pldm/src/message/firmware_update/request_fw_data.rs
@@ -61,7 +61,7 @@ impl RequestFirmwareDataResponse<'_> {
         instance_id: InstanceId,
         completion_code: u8,
         data: &[u8],
-    ) -> RequestFirmwareDataResponse {
+    ) -> RequestFirmwareDataResponse<'_> {
         let fixed = RequestFirmwareDataResponseFixed {
             hdr: PldmMsgHeader::new(
                 instance_id,

--- a/common/testing/src/doe_util/common.rs
+++ b/common/testing/src/doe_util/common.rs
@@ -20,7 +20,7 @@ impl DoeUtil {
         object_type: DataObjectType,
         tx: &mut Sender<Vec<u8>>,
     ) -> Result<(), DoeUtilError> {
-        if data.is_empty() || data.len() % 4 != 0 {
+        if data.is_empty() || !data.len().is_multiple_of(4) {
             println!("DOE_UTIL: Data length must be non-zero and a multiple of 4 bytes.");
             return Err(DoeUtilError::InvalidDataLength);
         }
@@ -46,7 +46,7 @@ impl DoeUtil {
     }
 
     pub fn send_raw_data_object(data: &[u8], tx: &mut Sender<Vec<u8>>) -> Result<(), DoeUtilError> {
-        if data.is_empty() || data.len() % 4 != 0 {
+        if data.is_empty() || !data.len().is_multiple_of(4) {
             println!("DOE_UTIL: Data length must be non-zero and a multiple of 4 bytes.");
             return Err(DoeUtilError::InvalidDataLength);
         }

--- a/common/testing/src/logging_seed.rs
+++ b/common/testing/src/logging_seed.rs
@@ -20,7 +20,7 @@ pub fn encode_logging_partition(
     page_size: usize,
 ) -> Vec<u8> {
     assert!(
-        partition_size % page_size == 0,
+        partition_size.is_multiple_of(page_size),
         "partition_size ({}) must be a multiple of page_size ({})",
         partition_size,
         page_size,

--- a/emulator/app/src/dis.rs
+++ b/emulator/app/src/dis.rs
@@ -5916,15 +5916,11 @@ fn decode_inst_format(dec: &mut RvDecode) -> String {
             '\t' => {
                 buf += " ".repeat(TAB_SIZE.saturating_sub(buf.len())).as_str();
             }
-            'A' => {
-                if dec.aq != 0 {
-                    buf += ".aq";
-                }
+            'A' if dec.aq != 0 => {
+                buf += ".aq";
             }
-            'R' => {
-                if dec.rl != 0 {
-                    buf += ".rl";
-                }
+            'R' if dec.rl != 0 => {
+                buf += ".rl";
             }
             _ => {}
         }

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -809,23 +809,23 @@ impl Emulator {
                 .unwrap()
             };
 
-        let primary_flash_initial_content = if cli.primary_flash_image.is_some() {
-            let flash_image_path = cli.primary_flash_image.as_ref().unwrap();
-            println!("Loading flash image from {}", flash_image_path.display());
-            const FLASH_SIZE: usize =
-                DummyFlashCtrl::PAGE_SIZE * DummyFlashCtrl::MAX_PAGES as usize;
-            let mut flash_image = vec![0; FLASH_SIZE];
-            let mut file = File::open(flash_image_path)?;
-            let bytes_read = file.read(&mut flash_image)?;
-            if bytes_read > FLASH_SIZE {
-                println!("Flash image size exceeds {} bytes", FLASH_SIZE);
-                exit(-1);
-            }
+        let primary_flash_initial_content =
+            if let Some(flash_image_path) = cli.primary_flash_image.as_ref() {
+                println!("Loading flash image from {}", flash_image_path.display());
+                const FLASH_SIZE: usize =
+                    DummyFlashCtrl::PAGE_SIZE * DummyFlashCtrl::MAX_PAGES as usize;
+                let mut flash_image = vec![0; FLASH_SIZE];
+                let mut file = File::open(flash_image_path)?;
+                let bytes_read = file.read(&mut flash_image)?;
+                if bytes_read > FLASH_SIZE {
+                    println!("Flash image size exceeds {} bytes", FLASH_SIZE);
+                    exit(-1);
+                }
 
-            Some(flash_image[..bytes_read].to_vec())
-        } else {
-            None
-        };
+                Some(flash_image[..bytes_read].to_vec())
+            } else {
+                None
+            };
 
         let primary_flash_controller = create_flash_controller(
             "primary_flash",
@@ -834,22 +834,22 @@ impl Emulator {
             primary_flash_initial_content.as_deref(),
         );
 
-        let secondary_flash_initial_content = if cli.secondary_flash_image.is_some() {
-            let flash_image_path = cli.secondary_flash_image.as_ref().unwrap();
-            const FLASH_SIZE: usize =
-                DummyFlashCtrl::PAGE_SIZE * DummyFlashCtrl::MAX_PAGES as usize;
-            let mut flash_image = vec![0; FLASH_SIZE];
-            let mut file = File::open(flash_image_path)?;
-            let bytes_read = file.read(&mut flash_image)?;
-            if bytes_read > FLASH_SIZE {
-                println!("Flash image size exceeds {} bytes", FLASH_SIZE);
-                exit(-1);
-            }
+        let secondary_flash_initial_content =
+            if let Some(flash_image_path) = cli.secondary_flash_image.as_ref() {
+                const FLASH_SIZE: usize =
+                    DummyFlashCtrl::PAGE_SIZE * DummyFlashCtrl::MAX_PAGES as usize;
+                let mut flash_image = vec![0; FLASH_SIZE];
+                let mut file = File::open(flash_image_path)?;
+                let bytes_read = file.read(&mut flash_image)?;
+                if bytes_read > FLASH_SIZE {
+                    println!("Flash image size exceeds {} bytes", FLASH_SIZE);
+                    exit(-1);
+                }
 
-            Some(flash_image[..bytes_read].to_vec())
-        } else {
-            None
-        };
+                Some(flash_image[..bytes_read].to_vec())
+            } else {
+                None
+            };
 
         let secondary_flash_controller = create_flash_controller(
             "secondary_flash",
@@ -1128,11 +1128,10 @@ impl Emulator {
             crate::tests::caliptra_util_host_validator::run_caliptra_util_host_validator();
         }
 
-        if cli.streaming_boot.is_some() {
+        if let Some(pldm_fw_pkg_path) = cli.streaming_boot.as_ref() {
             let _ = simple_logger::SimpleLogger::new()
                 .with_level(log::LevelFilter::Info)
                 .init();
-            let pldm_fw_pkg_path = cli.streaming_boot.as_ref().unwrap();
             println!(
                 "Starting streaming boot using PLDM package {}",
                 pldm_fw_pkg_path.display()
@@ -1332,7 +1331,7 @@ impl Emulator {
 
         let now = self.mcu_cpu.clock.now();
         self.state.ticks.store(now, Ordering::Relaxed);
-        if now % 1000 == 0 {
+        if now.is_multiple_of(1000) {
             self.state.tick_cond.notify_all();
             let milestones =
                 McuBootMilestones::from((self.mci_regs.borrow().flow_status >> 16) as u16);

--- a/emulator/app/src/gdb/gdb_target.rs
+++ b/emulator/app/src/gdb/gdb_target.rs
@@ -301,7 +301,7 @@ impl Target for GdbTarget {
     type Arch = gdbstub_arch::riscv::Riscv32;
     type Error = &'static str;
 
-    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
         BaseOps::SingleThread(self)
     }
 

--- a/emulator/bmc/pldm-fw-pkg/src/manifest.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/manifest.rs
@@ -640,10 +640,9 @@ impl FirmwareManifest {
             let mut image_data = vec![0u8; size];
             // Read the image data from the reader
             reader.read_exact(&mut image_data)?;
-            if output_dir_path.is_some() {
+            if let Some(output_dir_path) = output_dir_path {
                 // Write the image data to a file, the filename has a prefix of img_xx where xx is the component identifier
-                let file_path =
-                    format!("{}/img_{:02}.bin", output_dir_path.unwrap(), component_idx);
+                let file_path = format!("{}/img_{:02}.bin", output_dir_path, component_idx);
                 let mut file = File::create(&file_path)?;
                 file.write_all(&image_data)?;
                 // Update the image location of the component to the filename

--- a/emulator/bmc/pldm-ua/src/discovery_sm.rs
+++ b/emulator/bmc/pldm-ua/src/discovery_sm.rs
@@ -330,7 +330,7 @@ fn packet_to_event<T: PldmCodec>(
 pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
     debug!("Handling packet: {}", packet);
     let header = PldmMsgHeader::decode(&packet.payload.data[..packet.payload.len])
-        .map_err(|_| (error!("Error decoding packet!")))?;
+        .map_err(|_| error!("Error decoding packet!"))?;
     if !header.is_hdr_ver_valid() {
         error!("Invalid header version!");
         return Err(());

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -816,8 +816,8 @@ pub trait StateMachineActions {
         &mut self,
         ctx: &mut InnerContext<impl PldmSocket + Send + 'static>,
     ) -> Result<(), ()> {
-        if ctx.activation_time.is_some() {
-            if Instant::now() < ctx.activation_time.unwrap() {
+        if let Some(activation_time) = ctx.activation_time {
+            if Instant::now() < activation_time {
                 // If the activation time is not yet reached, continue scheduling another get status request, this will be automatically cancelled
                 // when the expected status is received or a activation timeout occurs
                 ctx.timer.schedule(
@@ -1131,7 +1131,7 @@ fn packet_to_event<T: PldmCodec>(
 pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
     debug!("Handling packet: {}", packet);
     let header = PldmMsgHeader::decode(&packet.payload.data[..packet.payload.len])
-        .map_err(|_| (error!("Error decoding packet!")))?;
+        .map_err(|_| error!("Error decoding packet!"))?;
     if !header.is_hdr_ver_valid() {
         error!("Invalid header version!");
         return Err(());

--- a/emulator/compliance-test/src/exec.rs
+++ b/emulator/compliance-test/src/exec.rs
@@ -16,7 +16,7 @@ Abstract:
 use crate::fs::annotate_error;
 use std::ffi::OsString;
 use std::fmt;
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, Write};
 
 /// Executes a command (subprocess).
 ///
@@ -56,7 +56,7 @@ pub struct ExecError {
 }
 impl ExecError {
     fn into_io_error(self) -> io::Error {
-        io::Error::new(ErrorKind::Other, self)
+        io::Error::other(self)
     }
 }
 impl std::error::Error for ExecError {}
@@ -86,6 +86,7 @@ fn collect_args(cmd: &std::process::Command) -> Vec<OsString> {
 mod tests {
     use super::*;
     use crate::fs::TempFile;
+    use std::io::ErrorKind;
 
     #[cfg(target_family = "unix")]
     #[test]

--- a/emulator/compliance-test/src/fs.rs
+++ b/emulator/compliance-test/src/fs.rs
@@ -120,10 +120,10 @@ fn rand_str() -> std::io::Result<String> {
     let chars = b"abcdefghijklmnopqrstuvwxyz123456";
     let mut result = vec![0u8; 24];
     if let Err(err) = getrandom::getrandom(&mut result) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Unable to retrive random data from OS: {}", err),
-        ));
+        return Err(std::io::Error::other(format!(
+            "Unable to retrive random data from OS: {}",
+            err
+        )));
     }
     for ch in result.iter_mut() {
         *ch = chars[usize::from(*ch & 0x1f)];

--- a/emulator/compliance-test/src/main.rs
+++ b/emulator/compliance-test/src/main.rs
@@ -19,7 +19,6 @@ use caliptra_mcu_emulator_consts::DEFAULT_CPU_ARGS;
 use clap::{arg, value_parser};
 use fs::TempDir;
 use std::error::Error;
-use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::{cell::Cell, env::set_var, rc::Rc};
 use test_data::{get_binary_data, get_signature_data, run_riscof};
@@ -161,7 +160,7 @@ static TESTS_TO_RUN: &[TestInfo] = &[
 ];
 
 fn into_io_error(err: impl Into<Box<dyn Error + Send + Sync>>) -> std::io::Error {
-    std::io::Error::new(ErrorKind::Other, err)
+    std::io::Error::other(err)
 }
 
 fn check_reference_data(expected_txt: &str, bus: &mut impl Bus) -> std::io::Result<()> {
@@ -178,13 +177,10 @@ fn check_reference_data(expected_txt: &str, bus: &mut impl Bus) -> std::io::Resu
             }
         };
         if expected_word != actual_word {
-            return Err(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "At addr {:#x}, expected {:#010x} but was {:#010x}",
-                    addr, expected_word, actual_word
-                ),
-            ));
+            return Err(std::io::Error::other(format!(
+                "At addr {:#x}, expected {:#010x} but was {:#010x}",
+                addr, expected_word, actual_word
+            )));
         }
         addr += 4;
     }
@@ -242,10 +238,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         if !is_test_complete(&mut cpu.bus) {
-            Err(std::io::Error::new(
-                ErrorKind::Other,
-                "test did not complete",
-            ))?;
+            Err(std::io::Error::other("test did not complete"))?;
         }
 
         check_reference_data(&reference_txt, &mut cpu.bus)?;

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -703,9 +703,8 @@ impl I3cPeripheral for I3c {
                 self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1
                     .reg
                     .set(
-                        ((address + std::mem::size_of::<caliptra_emu_types::RvData>())
-                            .next_multiple_of(std::mem::size_of::<u32>())
-                            / std::mem::size_of::<u32>()) as u32,
+                        (address + std::mem::size_of::<caliptra_emu_types::RvData>())
+                            .div_ceil(std::mem::size_of::<u32>()) as u32,
                     );
             } else {
                 println!("[I3C-Emulator] Unknown bypass configuration: {bypass_cfg}");

--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -104,7 +104,7 @@ fn validate_transition(from: u32, to: u32) -> Option<TokenRequirement> {
     // TestUnlocked(N) states have odd indices 1,3,5,...,15
     // TestLocked(N) states have even indices 2,4,6,...,14
     let is_test_unlocked = |s: u32| (TEST_UNLOCKED0..=TEST_UNLOCKED7).contains(&s) && s % 2 == 1;
-    let is_test_locked = |s: u32| (TEST_LOCKED0..=14).contains(&s) && s % 2 == 0;
+    let is_test_locked = |s: u32| (TEST_LOCKED0..=14).contains(&s) && s.is_multiple_of(2);
 
     match (from, to) {
         // Raw -> TestUnlocked0: hardcoded raw unlock token

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -1459,15 +1459,15 @@ impl MciPeripheral for Mci {
 
             // Set the corresponding bit for the event if enabled
             match event {
-                crate::mcu_mbox0::IrqEventToMcu::Mbox0CmdAvailable => {
-                    if notif_en & Notif0IntrEnT::NotifMbox0CmdAvailEn::SET.value != 0 {
-                        notif_reg |= Notif0IntrT::NotifMbox0CmdAvailSts::SET.value;
-                    }
+                crate::mcu_mbox0::IrqEventToMcu::Mbox0CmdAvailable
+                    if notif_en & Notif0IntrEnT::NotifMbox0CmdAvailEn::SET.value != 0 =>
+                {
+                    notif_reg |= Notif0IntrT::NotifMbox0CmdAvailSts::SET.value;
                 }
-                crate::mcu_mbox0::IrqEventToMcu::Mbox0TargetDone => {
-                    if notif_en & Notif0IntrEnT::NotifMbox0TargetDoneEn::SET.value != 0 {
-                        notif_reg |= Notif0IntrT::NotifMbox0TargetDoneSts::SET.value;
-                    }
+                crate::mcu_mbox0::IrqEventToMcu::Mbox0TargetDone
+                    if notif_en & Notif0IntrEnT::NotifMbox0TargetDoneEn::SET.value != 0 =>
+                {
+                    notif_reg |= Notif0IntrT::NotifMbox0TargetDoneSts::SET.value;
                 }
                 // mbox1 events should never originate from mailbox0
                 _ => {}
@@ -1496,15 +1496,15 @@ impl MciPeripheral for Mci {
                 .intr_block_rf_notif0_intr_en_r;
 
             match event {
-                crate::mcu_mbox0::IrqEventToMcu::Mbox1CmdAvailable => {
-                    if notif_en & Notif0IntrEnT::NotifMbox1CmdAvailEn::SET.value != 0 {
-                        notif_reg |= Notif0IntrT::NotifMbox1CmdAvailSts::SET.value;
-                    }
+                crate::mcu_mbox0::IrqEventToMcu::Mbox1CmdAvailable
+                    if notif_en & Notif0IntrEnT::NotifMbox1CmdAvailEn::SET.value != 0 =>
+                {
+                    notif_reg |= Notif0IntrT::NotifMbox1CmdAvailSts::SET.value;
                 }
-                crate::mcu_mbox0::IrqEventToMcu::Mbox1TargetDone => {
-                    if notif_en & Notif0IntrEnT::NotifMbox1TargetDoneEn::SET.value != 0 {
-                        notif_reg |= Notif0IntrT::NotifMbox1TargetDoneSts::SET.value;
-                    }
+                crate::mcu_mbox0::IrqEventToMcu::Mbox1TargetDone
+                    if notif_en & Notif0IntrEnT::NotifMbox1TargetDoneEn::SET.value != 0 =>
+                {
+                    notif_reg |= Notif0IntrT::NotifMbox1TargetDoneSts::SET.value;
                 }
                 // mbox0 events should never originate from mailbox1
                 _ => {}

--- a/emulator/periph/src/usbdev.rs
+++ b/emulator/periph/src/usbdev.rs
@@ -114,7 +114,7 @@ impl UsbDevState {
 
     fn read_data_from_buffer(&mut self, buffer_id: u8, size: usize) -> Vec<u8> {
         let base = usize::from(buffer_id) * WORDS_PER_BUFFER;
-        let num_words = (size + 3) / 4;
+        let num_words = size.div_ceil(4);
         let mut data = Vec::with_capacity(num_words * 4);
         for i in 0..num_words {
             data.extend_from_slice(&self.generated.read_buffer(base + i).to_le_bytes());

--- a/firmware-bundler/src/bundle.rs
+++ b/firmware-bundler/src/bundle.rs
@@ -77,10 +77,10 @@ pub fn bundle(
                     elf,
                     app.binary.binary.clone(),
                 )?;
-                runtime.extend(header_bytes.into_iter());
+                runtime.extend(header_bytes);
 
                 let app_bin = std::fs::read(&app.binary.binary)?;
-                runtime.extend(app_bin.into_iter());
+                runtime.extend(app_bin);
             }
         }
         RuntimeVariant::BareMetal((bare_metal, _)) => {

--- a/firmware-bundler/src/ld.rs
+++ b/firmware-bundler/src/ld.rs
@@ -396,7 +396,7 @@ impl<'a> LdGeneration<'a> {
 
         // If the tracker currently doeesn't match the alignment, consume the number of bytes
         // required to reach that alignment.
-        if tracker.offset % alignment != 0 {
+        if !tracker.offset.is_multiple_of(alignment) {
             tracker.consume(alignment - (tracker.offset % alignment))?;
         }
 

--- a/hw/model/src/bus_logger.rs
+++ b/hw/model/src/bus_logger.rs
@@ -30,6 +30,7 @@ impl Write for LogFile {
     }
 }
 
+#[allow(dead_code)]
 pub struct NullBus();
 impl Bus for NullBus {
     fn read(&mut self, _size: RvSize, _addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -23,8 +23,8 @@ pub use model_emulated::ModelEmulated;
 pub use network_mgr::NetworkManager;
 use rand::{rngs::StdRng, SeedableRng};
 use sha2::Digest;
+use std::io::stdout;
 use std::io::Write;
-use std::io::{stdout, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::mpsc;
@@ -464,19 +464,16 @@ pub trait McuHwModel {
             match self.output().exit_status().or(self.exit_status()) {
                 Some(ExitStatus::Passed) => return Ok(()),
                 Some(ExitStatus::Failed) => {
-                    return Err(std::io::Error::new(
-                        ErrorKind::Other,
-                        "firmware exited with failure",
-                    ))
+                    return Err(std::io::Error::other("firmware exited with failure"))
                 }
                 None => {}
             }
             // Check for fatal error in MCI register
             if let Some(fatal_error) = self.mci_fw_fatal_error() {
-                return Err(std::io::Error::new(
-                    ErrorKind::Other,
-                    format!("firmware fatal error: 0x{:08x}", fatal_error),
-                ));
+                return Err(std::io::Error::other(format!(
+                    "firmware fatal error: 0x{:08x}",
+                    fatal_error
+                )));
             }
             self.step();
         }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -635,7 +635,10 @@ impl McuHwModel for ModelEmulated {
         }
         let events = self.events_from_caliptra.try_iter().collect::<Vec<_>>();
         self.collected_events_from_caliptra.extend(events);
-        if self.cycle_count() % caliptra_mcu_testing_common::TICK_NOTIFY_TICKS == 0 {
+        if self
+            .cycle_count()
+            .is_multiple_of(caliptra_mcu_testing_common::TICK_NOTIFY_TICKS)
+        {
             caliptra_mcu_testing_common::update_ticks(self.cycle_count());
             let milestones =
                 McuBootMilestones::from((self.mci_regs.borrow().flow_status >> 16) as u16);

--- a/hw/model/src/otp_provision.rs
+++ b/hw/model/src/otp_provision.rs
@@ -59,7 +59,7 @@ pub(crate) use caliptra_mcu_emulator_periph::OTP_SCRAMBLE_KEYS;
 const LC_TOKENS_KEY_IDX: usize = 6;
 
 fn otp_scramble_data(data: &mut [u8], key_idx: usize) -> Result<()> {
-    if data.len() % 8 != 0 {
+    if !data.len().is_multiple_of(8) {
         bail!("Data length must be a multiple of 8 bytes for scrambling");
     }
     if key_idx >= OTP_SCRAMBLE_KEYS.len() {
@@ -75,7 +75,7 @@ fn otp_scramble_data(data: &mut [u8], key_idx: usize) -> Result<()> {
 
 #[allow(unused)]
 fn otp_unscramble_data(data: &mut [u8], key_idx: usize) -> Result<()> {
-    if data.len() % 8 != 0 {
+    if !data.len().is_multiple_of(8) {
         bail!("Data length must be a multiple of 8 bytes for scrambling");
     }
     if key_idx >= OTP_SCRAMBLE_KEYS.len() {

--- a/hw/model/src/vmem.rs
+++ b/hw/model/src/vmem.rs
@@ -45,7 +45,7 @@ pub fn read_otp_vmem_data(vmem_data: &[u8]) -> Result<Vec<u8>> {
 #[allow(unused)]
 pub(crate) fn write_otp_vmem_data(bytes: &[u8]) -> Result<String> {
     let mut output = String::new();
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         bail!("OTP memory data length must be even, got {}", bytes.len());
     }
 

--- a/hw/model/test-fw/mailbox-responder/src/main.rs
+++ b/hw/model/test-fw/mailbox-responder/src/main.rs
@@ -42,7 +42,7 @@ fn run() -> ! {
             // the command-id prepended.
             0x1000_0000 => {
                 let len = dlen.get();
-                let len_words = usize::try_from((len + 3) / 4).unwrap();
+                let len_words = usize::try_from(len.div_ceil(4)).unwrap();
                 let mut buf = [0u32; 8];
                 for i in 0..len_words {
                     buf[i] = sram[i].get();
@@ -74,7 +74,7 @@ fn run() -> ! {
             // Store a buf to be returned by 0x3000_0001
             0x3000_0000 => {
                 let len = dlen.get();
-                let len_words = usize::try_from((len + 3) / 4).unwrap();
+                let len_words = usize::try_from(len.div_ceil(4)).unwrap();
                 for i in 0..usize::min(len_words, replay_buf.len()) {
                     replay_buf[i] = sram[i].get();
                 }
@@ -83,7 +83,7 @@ fn run() -> ! {
             }
             0x3000_0001 => {
                 dlen.set(replay_buf_len);
-                let dlen_words = usize::try_from((replay_buf_len + 3) / 4).unwrap();
+                let dlen_words = usize::try_from(replay_buf_len.div_ceil(4)).unwrap();
                 for i in 0..dlen_words {
                     sram[i].set(replay_buf[i]);
                 }

--- a/hw/model/test-fw/usb-responder/src/main.rs
+++ b/hw/model/test-fw/usb-responder/src/main.rs
@@ -52,7 +52,7 @@ fn run() -> ! {
 
         // Read the received payload from the packet buffer
         let rx_word_base = (rx_buf * 16) as usize;
-        let num_words = ((rx_size as usize) + 3) / 4;
+        let num_words = (rx_size as usize).div_ceil(4);
         let resp_buf = next_response_buf;
         let resp_word_base = (resp_buf * 16) as usize;
 

--- a/network/app/example-ipv6/src/main.rs
+++ b/network/app/example-ipv6/src/main.rs
@@ -69,7 +69,7 @@ fn storage_open(filename: &str) -> *mut c_void {
     match File::create(output_dir.join(basename)) {
         Ok(file) => {
             *FILE_HANDLE.lock().unwrap() = Some(file);
-            1 as *mut c_void
+            std::ptr::dangling_mut::<c_void>()
         }
         Err(_) => std::ptr::null_mut(),
     }
@@ -247,7 +247,7 @@ fn run_app() -> Result<(), AppError> {
                 println!("[DHCPv6] === Transfer Complete ===");
                 println!(
                     "[DHCPv6] File saved to: /tmp/tftp_downloads/{}",
-                    boot_file.split('/').last().unwrap_or(&boot_file)
+                    boot_file.split('/').next_back().unwrap_or(&boot_file)
                 );
                 println!("[DHCPv6] Total bytes: {}", bytes);
                 state = AppState::Exit;

--- a/network/app/example/src/main.rs
+++ b/network/app/example/src/main.rs
@@ -61,7 +61,7 @@ fn storage_open(filename: &str) -> *mut c_void {
     match File::create(format!("{}/{}", output_dir, basename)) {
         Ok(file) => {
             *FILE_HANDLE.lock().unwrap() = Some(file);
-            1 as *mut c_void
+            std::ptr::dangling_mut::<c_void>()
         }
         Err(_) => std::ptr::null_mut(),
     }
@@ -225,7 +225,7 @@ fn run_app() -> Result<(), AppError> {
                 println!("[DHCP-TFTP] === Transfer Complete ===");
                 println!(
                     "[DHCP-TFTP] File saved to: /tmp/tftp_downloads/{}",
-                    boot_file.split('/').last().unwrap_or(&boot_file)
+                    boot_file.split('/').next_back().unwrap_or(&boot_file)
                 );
                 println!("[DHCP-TFTP] Total bytes: {}", bytes);
                 state = AppState::Exit;

--- a/network/app/test/src/dhcp_test.rs
+++ b/network/app/test/src/dhcp_test.rs
@@ -314,11 +314,7 @@ impl DhcpDiscovery {
 
         // Total frame size: header + options, padded so DHCP payload >= 300 bytes
         let dhcp_payload_len = core::mem::size_of::<DhcpFixedFields>() + 4 + offset; // fixed + cookie + options
-        let padding = if dhcp_payload_len < DHCP_MIN_PAYLOAD {
-            DHCP_MIN_PAYLOAD - dhcp_payload_len
-        } else {
-            0
-        };
+        let padding = DHCP_MIN_PAYLOAD.saturating_sub(dhcp_payload_len);
         let total_frame_len = header_size + offset + padding;
 
         // Fill in IP and UDP lengths

--- a/network/drivers/src/network_mbox.rs
+++ b/network/drivers/src/network_mbox.rs
@@ -145,7 +145,7 @@ impl NetworkMboxDriver<'_> {
     fn write_sram_data(&self, data: impl Iterator<Item = u32>, dw_len: usize, dlen: usize) {
         for (i, dword) in data.take(dw_len).enumerate() {
             // If this is the last dword and dlen is not 4-byte aligned, mask it.
-            if i == dw_len - 1 && dlen % 4 != 0 {
+            if i == dw_len - 1 && !dlen.is_multiple_of(4) {
                 let mask = (1u32 << (dlen % 4 * 8)) - 1;
                 self.regs.network_mbox_sram[i].set(dword & mask);
             } else {
@@ -180,10 +180,8 @@ impl NetworkMboxDriver<'_> {
     /// Poll for incoming requests or target done events.
     fn poll_inner(&self) {
         match self.state.get() {
-            DriverState::RxWait => {
-                if self.is_execute_set() {
-                    self.handle_incoming_request();
-                }
+            DriverState::RxWait if self.is_execute_set() => {
+                self.handle_incoming_request();
             }
             DriverState::WaitingForTargetDone => {
                 let target_status = self.read_target_status();

--- a/network/net/lwip-rs/src/netif_baremetal.rs
+++ b/network/net/lwip-rs/src/netif_baremetal.rs
@@ -325,7 +325,7 @@ impl BaremetalNetIf {
             if len == 0 {
                 return None;
             }
-            let bytes = &(*dhcp6_ptr).boot_file_url[..len];
+            let bytes = &(&(*dhcp6_ptr).boot_file_url)[..len];
             Some(core::slice::from_raw_parts(
                 bytes.as_ptr() as *const u8,
                 len,

--- a/platforms/emulator/rom/src/mcu_image_verifier.rs
+++ b/platforms/emulator/rom/src/mcu_image_verifier.rs
@@ -3,6 +3,9 @@
 use caliptra_mcu_rom_common::ImageVerifier;
 use caliptra_mcu_romtime::otp::Otp;
 
+// Constructed only in `mod riscv`, which is gated on `target_arch = "riscv32"`,
+// so host builds see no constructor.
+#[allow(dead_code)]
 pub struct McuImageVerifier;
 
 impl ImageVerifier for McuImageVerifier {

--- a/platforms/emulator/rom/usb/src/lib.rs
+++ b/platforms/emulator/rom/usb/src/lib.rs
@@ -151,7 +151,7 @@ impl ExamplarUsbDriver {
 
             self.wait_in_sent();
         }
-        if data.len() < expected && data.len() % MAX_PKT == 0 {
+        if data.len() < expected && data.len().is_multiple_of(MAX_PKT) {
             self.send_zlp_in()?;
         }
         Ok(())

--- a/platforms/emulator/runtime/kernel/drivers/mcu_mbox/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/mcu_mbox/src/lib.rs
@@ -192,7 +192,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a> for McuMailbox<'a, A> {
             }
 
             // If dlen is not 4-byte aligned, mask the last dword
-            if dlen % 4 != 0 {
+            if !dlen.is_multiple_of(4) {
                 let mask = (1u32 << (dlen % 4 * 8)) - 1;
                 buf[dw_len - 1] &= mask;
             }

--- a/platforms/emulator/runtime/src/io.rs
+++ b/platforms/emulator/runtime/src/io.rs
@@ -33,7 +33,6 @@ pub(crate) static mut WRITER: Writer = Writer {};
 /// # Safety
 /// Accesses memory-mapped registers.
 #[cfg(all(not(test), not(feature = "release")))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);
@@ -53,7 +52,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 /// # Safety
 /// Accesses memory-mapped registers.
 #[cfg(all(not(test), feature = "release"))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::fmt::Write as _;

--- a/platforms/emulator/runtime/userspace/apps/user/build.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/build.rs
@@ -414,5 +414,8 @@ fn push_u16(out: &mut Vec<u8>, value: u16) {
 fn push_fixed_platform_info(out: &mut Vec<u8>, value: &[u8]) {
     debug_assert!(value.len() <= ATTESTATION_MANIFEST_PLATFORM_INFO_MAX_LEN);
     out.extend_from_slice(value);
-    out.extend(std::iter::repeat(0).take(ATTESTATION_MANIFEST_PLATFORM_INFO_MAX_LEN - value.len()));
+    out.extend(std::iter::repeat_n(
+        0,
+        ATTESTATION_MANIFEST_PLATFORM_INFO_MAX_LEN - value.len(),
+    ));
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/debug_log.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/debug_log.rs
@@ -49,12 +49,9 @@ pub async fn drain(dst: &mut [u8]) -> Result<GetLogResult, CaliptraCompletionCod
     let mut written = 0usize;
     let mut more_data = false;
 
-    loop {
-        let Some(remaining) = dst.get_mut(written..) else {
-            // `written > dst.len()` is impossible by construction, but the
-            // get_mut keeps this loop panic-free.
-            break;
-        };
+    // `written > dst.len()` is impossible by construction, but driving the loop
+    // off `get_mut` keeps it panic-free.
+    while let Some(remaining) = dst.get_mut(written..) {
         if remaining.is_empty() {
             // dst is full; if there is more in the log we'd see SIZE on next
             // call. Signal more_data so the caller polls again.

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -283,8 +283,7 @@ async fn image_loading<D: DMAMapping>(
 
         let pending = {
             let pending_partition_id = boot_config.get_pending_partition().await;
-            if pending_partition_id.is_ok() {
-                let pending_partition_id = pending_partition_id.unwrap();
+            if let Ok(pending_partition_id) = pending_partition_id {
                 let pending_partition = boot_config
                     .get_partition_from_id(pending_partition_id)
                     .map_err(|_| ErrorCode::Fail)?;

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -24,6 +24,12 @@ pub(crate) use caliptra_mcu_userlog::{Bytes, Dbg, Hex32};
 pub use caliptra_mcu_libsyscall_caliptra::console_writeln;
 
 pub(crate) mod auth_keys;
+// Only the feature-gated command services below construct
+// `CaliptraCmdBackend`; without them the whole module is unused.
+#[cfg_attr(
+    not(any(feature = "mcu-mbox-service", feature = "mctp-vdm-service")),
+    allow(dead_code)
+)]
 mod caliptra_cmd_handler;
 // SPDM is the only current consumer; widen this gate when another protocol
 // integrates the boot-provisioned certificate chains.

--- a/platforms/fpga/runtime/src/io.rs
+++ b/platforms/fpga/runtime/src/io.rs
@@ -36,7 +36,6 @@ const FPGA_UART_OUTPUT: *mut u32 = 0xa401_1014 as *mut u32;
 /// # Safety
 /// Accesses memory-mapped registers.
 #[cfg(all(not(test), not(feature = "release")))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);
@@ -56,7 +55,6 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
 /// # Safety
 /// Accesses memory-mapped registers.
 #[cfg(all(not(test), feature = "release"))]
-#[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     use core::fmt::Write as _;

--- a/registers/systemrdl-new/src/lexer.rs
+++ b/registers/systemrdl-new/src/lexer.rs
@@ -253,7 +253,7 @@ fn next_while(iter: &mut Chars, mut f: impl FnMut(char) -> bool) {
     }
 }
 
-fn parse_num(s: &str, radix: u32) -> TokenKind {
+fn parse_num(s: &str, radix: u32) -> TokenKind<'_> {
     let replaced;
     let s = if s.contains('_') {
         replaced = s.replace('_', "");

--- a/registers/systemrdl-new/src/parser.rs
+++ b/registers/systemrdl-new/src/parser.rs
@@ -447,7 +447,7 @@ fn constraint_value(i: &mut Tokens<'_>) -> Result<ConstraintValue> {
     ))
     .parse_next(i)?
     {
-        return Ok(ConstraintValue::Range(a, b));
+        Ok(ConstraintValue::Range(a, b))
     } else {
         fail.parse_next(i)
     }

--- a/registers/systemrdl-new/src/token.rs
+++ b/registers/systemrdl-new/src/token.rs
@@ -42,21 +42,21 @@ impl winnow::stream::ContainsToken<&'_ Token<'_>> for TokenKind<'_> {
 impl winnow::stream::ContainsToken<&'_ Token<'_>> for &'_ [TokenKind<'_>] {
     #[inline]
     fn contains_token(&self, token: &'_ Token<'_>) -> bool {
-        self.iter().any(|t| *t == token.kind)
+        self.contains(&token.kind)
     }
 }
 
 impl<const LEN: usize> winnow::stream::ContainsToken<&'_ Token<'_>> for &'_ [TokenKind<'_>; LEN] {
     #[inline]
     fn contains_token(&self, token: &'_ Token<'_>) -> bool {
-        self.iter().any(|t| *t == token.kind)
+        self.contains(&token.kind)
     }
 }
 
 impl<const LEN: usize> winnow::stream::ContainsToken<&'_ Token<'_>> for [TokenKind<'_>; LEN] {
     #[inline]
     fn contains_token(&self, token: &'_ Token<'_>) -> bool {
-        self.iter().any(|t| *t == token.kind)
+        self.contains(&token.kind)
     }
 }
 

--- a/registers/systemrdl/src/lexer.rs
+++ b/registers/systemrdl/src/lexer.rs
@@ -195,7 +195,7 @@ fn next_while(iter: &mut Chars, mut f: impl FnMut(char) -> bool) {
     }
 }
 
-fn parse_num(s: &str, radix: u32) -> Token {
+fn parse_num(s: &str, radix: u32) -> Token<'_> {
     let replaced;
     let s = if s.contains('_') {
         replaced = s.replace('_', "");

--- a/registers/systemrdl/src/lib.rs
+++ b/registers/systemrdl/src/lib.rs
@@ -121,7 +121,7 @@ impl<'a> ParseError<'a> {
             error,
         }
     }
-    pub fn location(&self) -> FileLocation {
+    pub fn location(&self) -> FileLocation<'_> {
         let mut line = 1;
         let mut column = 1;
         let mut line_start: &str = self.file_text;

--- a/registers/systemrdl/src/scope.rs
+++ b/registers/systemrdl/src/scope.rs
@@ -181,7 +181,7 @@ impl Scope {
         }
     }
 
-    pub fn as_parent(&self) -> ParentScope {
+    pub fn as_parent(&self) -> ParentScope<'_> {
         ParentScope {
             scope: self,
             parent: None,

--- a/registers/systemrdl/src/value.rs
+++ b/registers/systemrdl/src/value.rs
@@ -307,7 +307,7 @@ pub enum ScopeType {
     Component(ComponentType),
 }
 
-pub fn parse_str_literal(s: &str) -> Result<String> {
+pub fn parse_str_literal(s: &str) -> Result<'_, String> {
     if s.len() < 2 || !s.starts_with('"') || !s.ends_with('"') {
         return Err(RdlError::BadStringLiteral);
     }

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -1511,7 +1511,7 @@ pub fn process_fw_manifest_dot_commands(
     let has_lock = cmds
         .iter()
         .any(|&c| c == FW_MANIFEST_DOT_CMD_LOCK || c == FW_MANIFEST_DOT_CMD_DISABLE);
-    let has_unlock = cmds.iter().any(|&c| c == FW_MANIFEST_DOT_CMD_UNLOCK);
+    let has_unlock = cmds.contains(&FW_MANIFEST_DOT_CMD_UNLOCK);
     if has_lock && has_unlock {
         return Err(McuError::ROM_FW_MANIFEST_DOT_CONFLICTING_COMMANDS);
     }

--- a/rom/src/dot_override.rs
+++ b/rom/src/dot_override.rs
@@ -99,7 +99,7 @@ impl Mbox0Helpers {
         for b in cmd.to_le_bytes() {
             sum = sum.wrapping_add(b as u32);
         }
-        let payload_len = if dlen > 4 { dlen - 4 } else { 0 };
+        let payload_len = dlen.saturating_sub(4);
         let payload_words = payload_len.div_ceil(4).min(sram.len().saturating_sub(1));
         for i in 0..payload_words {
             if let Some(&word) = sram.get(i + 1) {

--- a/rom/src/mailbox.rs
+++ b/rom/src/mailbox.rs
@@ -58,14 +58,23 @@ fn ctx_as_u32(ctx: &[u8; CMB_SHA_CONTEXT_SIZE]) -> &[u32; CTX_DWORDS] {
 /// the ~4 KiB stack allocations that the request structs would otherwise
 /// require.
 pub fn cm_sha384(soc_manager: &mut CaliptraSoC, data: &[u32]) -> [u8; 48] {
-    let first_chunk = data.len().min(CHUNK_DWORDS);
-
-    let (first_chunk, rest) = data.split_at(first_chunk);
+    // `split_at` and `chunks` both carry a panicking bounds check that the
+    // optimizer does not reliably discharge, which would pull the panic
+    // machinery into the ROM. Walk the slice with `get` instead.
+    let mut offset = data.len().min(CHUNK_DWORDS);
+    let Some(first_chunk) = data.get(..offset) else {
+        fatal_error(McuError::ROM_COLD_BOOT_ROM_DIGEST_MISMATCH)
+    };
 
     let mut sha_context = cm_sha_init(soc_manager, first_chunk);
 
-    for chunk in rest.chunks(CHUNK_DWORDS) {
+    while offset < data.len() {
+        let end = offset.saturating_add(CHUNK_DWORDS).min(data.len());
+        let Some(chunk) = data.get(offset..end) else {
+            fatal_error(McuError::ROM_COLD_BOOT_ROM_DIGEST_MISMATCH)
+        };
         cm_sha_update(soc_manager, chunk, &mut sha_context);
+        offset = end;
     }
 
     cm_sha_final(soc_manager, &[], sha_context)
@@ -92,7 +101,7 @@ fn cm_sha_init(soc_manager: &mut CaliptraSoC, chunk: &[u32]) -> [u8; CMB_SHA_CON
         .chain(core::iter::once(hash_algorithm))
         .chain(core::iter::once(input_size))
         .chain(chunk.iter().copied())
-        .chain(core::iter::repeat(0u32).take(padding));
+        .chain(core::iter::repeat_n(0u32, padding));
 
     if let Err(err) = soc_manager.start_mailbox_req(cmd, total_bytes, iter) {
         caliptra_mcu_romtime::println!(
@@ -143,7 +152,7 @@ fn cm_sha_update(
         .chain(ctx.iter().copied())
         .chain(core::iter::once(input_size))
         .chain(chunk.iter().copied())
-        .chain(core::iter::repeat(0u32).take(padding));
+        .chain(core::iter::repeat_n(0u32, padding));
 
     if let Err(err) = soc_manager.start_mailbox_req(cmd, total_bytes, iter) {
         caliptra_mcu_romtime::println!(
@@ -192,7 +201,7 @@ fn cm_sha_final(
         .chain(ctx.iter().copied())
         .chain(core::iter::once(input_size))
         .chain(remaining.iter().copied())
-        .chain(core::iter::repeat(0u32).take(padding));
+        .chain(core::iter::repeat_n(0u32, padding));
 
     if let Err(err) = soc_manager.start_mailbox_req(cmd, total_bytes, iter) {
         caliptra_mcu_romtime::println!(

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -877,18 +877,13 @@ bitflags::bitflags! {
 }
 
 /// Policy controlling whether DOT backup-blob recovery is attempted.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum DotRecoveryPolicy {
     /// Attempt backup blob recovery (default).
+    #[default]
     BackupBlob,
     /// Do not attempt any recovery.
     None,
-}
-
-impl Default for DotRecoveryPolicy {
-    fn default() -> Self {
-        Self::BackupBlob
-    }
 }
 
 #[derive(Default)]

--- a/romtime/src/fuse_layout.rs
+++ b/romtime/src/fuse_layout.rs
@@ -412,7 +412,7 @@ pub fn write_fuse_value<const N: usize, const M: usize>(
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             // ensure that we have the right number of words
-            if M % dupe.get() != 0 {
+            if !M.is_multiple_of(dupe.get()) {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             for (i, &x) in value.iter().enumerate() {
@@ -466,7 +466,7 @@ pub fn write_fuse_value<const N: usize, const M: usize>(
             if total_bits > M * 32 {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
-            if M % dupe.get() != 0 {
+            if !M.is_multiple_of(dupe.get()) {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             for (i, &x) in value.iter().enumerate() {
@@ -569,7 +569,7 @@ pub fn extract_fuse_value<const N: usize>(
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             // ensure that we have the right number of words
-            if raw_value.len() % dupe.get() != 0 {
+            if !raw_value.len().is_multiple_of(dupe.get()) {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             for (i, chunk) in raw_value.chunks_exact(dupe.get()).enumerate() {
@@ -623,7 +623,7 @@ pub fn extract_fuse_value<const N: usize>(
             if N != bits.get() / 32 {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
-            if raw_value.len() % dupe.get() != 0 {
+            if !raw_value.len().is_multiple_of(dupe.get()) {
                 return Err(McuError::ROM_FUSE_LAYOUT_TOO_LARGE);
             }
             for (i, chunk) in raw_value.chunks_exact(dupe.get()).enumerate() {

--- a/romtime/src/mci_mbox_cmd.rs
+++ b/romtime/src/mci_mbox_cmd.rs
@@ -69,7 +69,7 @@ fn sram_to_buf(
     buf: &mut [u8],
     byte_count: usize,
 ) {
-    let words = (byte_count + 3) / 4;
+    let words = byte_count.div_ceil(4);
     for i in 0..words.min(sram.len()).min(buf.len() / 4) {
         buf[i * 4..i * 4 + 4].copy_from_slice(&sram[i].get().to_le_bytes());
     }

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -160,7 +160,7 @@ impl Otp {
     }
 
     fn read_data(&self, addr: usize, len: usize, data: &mut [u8]) -> McuResult<()> {
-        if data.len() < len || addr % 4 != 0 || len % 4 != 0 {
+        if data.len() < len || !addr.is_multiple_of(4) || !len.is_multiple_of(4) {
             return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
         }
 
@@ -747,7 +747,7 @@ impl Otp {
     }
 
     pub fn write_data(&self, addr: usize, len: usize, data: &[u8]) -> McuResult<()> {
-        if addr % 4 != 0 || len % 4 != 0 {
+        if !addr.is_multiple_of(4) || !len.is_multiple_of(4) {
             return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
         }
 

--- a/romtime/src/soc_manager.rs
+++ b/romtime/src/soc_manager.rs
@@ -283,7 +283,7 @@ impl CaliptraSoC {
         &mut self,
         resp_min_size: usize,
         resp_size: usize,
-    ) -> core::result::Result<Option<CaliptraMailboxResponse>, CaliptraApiError> {
+    ) -> core::result::Result<Option<CaliptraMailboxResponse<'_>>, CaliptraApiError> {
         if resp_size < mem::size_of::<MailboxRespHeader>() {
             return Err(CaliptraApiError::MailboxRespTypeTooSmall);
         }

--- a/runtime/kernel/capsules/src/doe/driver.rs
+++ b/runtime/kernel/capsules/src/doe/driver.rs
@@ -79,7 +79,7 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
     fn start_transmit(&self, app_buf: &ReadableProcessSlice) -> Result<(), ErrorCode> {
         // Ensure the buffer is large enough
         let data_len_bytes = app_buf.len();
-        if data_len_bytes % 4 != 0 {
+        if !data_len_bytes.is_multiple_of(4) {
             return Err(ErrorCode::INVAL);
         }
 

--- a/runtime/kernel/capsules/src/logging/logging_flash.rs
+++ b/runtime/kernel/capsules/src/logging/logging_flash.rs
@@ -449,7 +449,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
 
                 // Initialise the writable pagebuffer.
                 if let Some(pagebuffer) = self.pagebuffer.take() {
-                    let copy_pagebuffer = last_page_len % self.page_size != 0;
+                    let copy_pagebuffer = !last_page_len.is_multiple_of(self.page_size);
                     if copy_pagebuffer {
                         // Mirror the newest page into the writable buffer
                         // so further appends extend it.
@@ -537,7 +537,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
             }
 
             // Skip the page header at the very start of a page.
-            if entry_id % self.page_size == 0 {
+            if entry_id.is_multiple_of(self.page_size) {
                 self.read_entry_id.set(entry_id + PAGE_HEADER_SIZE);
                 continue;
             }
@@ -728,7 +728,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         self.length.set(length);
 
         let append_entry_id = self.append_entry_id.get();
-        let flush_prev_page = append_entry_id % self.page_size == 0;
+        let flush_prev_page = append_entry_id.is_multiple_of(self.page_size);
         let space_remaining = self.page_size - append_entry_id % self.page_size;
 
         if !flush_prev_page && entry_size <= space_remaining {
@@ -791,7 +791,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         // Pad end of page.
         let mut pad_ptr = self.append_entry_id.get();
         let page = pagebuffer.as_mut();
-        while pad_ptr % self.page_size != 0 {
+        while !pad_ptr.is_multiple_of(self.page_size) {
             page[pad_ptr % self.page_size] = PAD_BYTE;
             pad_ptr += 1;
         }
@@ -845,7 +845,7 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
             return false;
         }
 
-        if append_entry_id % self.page_size != 0 {
+        if !append_entry_id.is_multiple_of(self.page_size) {
             append_entry_id += self.page_size - append_entry_id % self.page_size;
         }
 
@@ -1102,7 +1102,7 @@ impl<F: Flash + 'static> flash::Client<F> for Log<'_, F> {
                     return;
                 }
                 // If the synced page was full, prepare the next page.
-                if self.append_entry_id.get() % self.page_size == 0 {
+                if self.append_entry_id.get().is_multiple_of(self.page_size) {
                     let _ = self.reset_pagebuffer(pagebuffer);
                 }
                 self.pagebuffer.replace(pagebuffer);

--- a/runtime/kernel/capsules/src/mctp/mux.rs
+++ b/runtime/kernel/capsules/src/mctp/mux.rs
@@ -348,19 +348,16 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> TransportRxClient for MuxMCT
         let (mctp_header, msg_type, payload_offset) = self.interpret_packet(&rx_buffer[0..len]);
         if let Some(msg_type) = msg_type {
             match msg_type {
-                MessageType::MctpControl => {
+                MessageType::MctpControl
                     if mctp_header.tag_owner() == 1
                         && mctp_header.som() == 1
-                        && mctp_header.eom() == 1
-                    {
-                        let _ = self
-                            .process_mctp_control_msg(mctp_header, &rx_buffer[payload_offset..len]);
-                    } else {
-                        capsule_debug!(
-                            "MCTP-MUX",
-                            "Invalid MCTP Control message. Dropping packet."
-                        );
-                    }
+                        && mctp_header.eom() == 1 =>
+                {
+                    let _ =
+                        self.process_mctp_control_msg(mctp_header, &rx_buffer[payload_offset..len]);
+                }
+                MessageType::MctpControl => {
+                    capsule_debug!("MCTP-MUX", "Invalid MCTP Control message. Dropping packet.");
                 }
                 MessageType::Pldm
                 | MessageType::Spdm

--- a/runtime/kernel/drivers/flash/src/flash_storage_to_pages.rs
+++ b/runtime/kernel/drivers/flash/src/flash_storage_to_pages.rs
@@ -139,7 +139,7 @@ impl<'a, F: hil::flash::Flash> crate::hil::FlashStorage<'a> for FlashStorageToPa
         self.state.set(State::Write);
         self.length.set(length);
 
-        if address % page_size == 0 && length >= page_size {
+        if address.is_multiple_of(page_size) && length >= page_size {
             // This write is aligned to a page and we are writing an entire page.
             // Copy data into page buffer.
             page_buffer.as_mut()[..page_size].copy_from_slice(&buffer[..page_size]);
@@ -185,7 +185,7 @@ impl<'a, F: hil::flash::Flash> crate::hil::FlashStorage<'a> for FlashStorageToPa
         let erase_size = self.erase_size;
 
         // Validate that the erase address is aligned to the erase size.
-        if address % erase_size != 0 {
+        if !address.is_multiple_of(erase_size) {
             return Err(ErrorCode::INVAL);
         }
 

--- a/runtime/kernel/veer/src/pic.rs
+++ b/runtime/kernel/veer/src/pic.rs
@@ -82,7 +82,7 @@ impl Pic {
             unsafe {
                 write_volatile(
                     (meivt_base + irq * 4) as *mut u32,
-                    rv32i::_start_trap as usize as u32,
+                    rv32i::_start_trap as *const () as usize as u32,
                 );
             }
         }

--- a/runtime/userspace/api/attestation-evidence/build.rs
+++ b/runtime/userspace/api/attestation-evidence/build.rs
@@ -336,7 +336,7 @@ fn decode_optional_hex(value: &Option<String>, name: &str) -> Option<Vec<u8>> {
 
 fn decode_hex(value: &str, name: &str) -> Vec<u8> {
     let value = value.strip_prefix("0x").unwrap_or(value);
-    if value.len() % 2 != 0 {
+    if !value.len().is_multiple_of(2) {
         panic!("{name} must have an even number of hex digits");
     }
     let mut out = Vec::with_capacity(value.len() / 2);

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -1075,7 +1075,7 @@ pub async fn default_copy_to_memory<const TRANSFER_SIZE: usize>(
             .await?;
 
         // Print progress every 10KB
-        if (current_offset - offset) % 10240 == 0 {
+        if (current_offset - offset).is_multiple_of(10240) {
             console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] copy_to_memory progress: {}/{} bytes",
@@ -1151,7 +1151,7 @@ impl PayloadStream for MailboxPayloadStream {
             return Ok(0); // No more data to read
         }
 
-        if (self.cursor - self.offset) % 10240 == 0 {
+        if (self.cursor - self.offset).is_multiple_of(10240) {
             console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] MailboxPayloadStream: read progress: {}/{} bytes",

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -201,7 +201,7 @@ pub async fn pldm_initiator(
             if session.is_some() {
                 // yield every so often still so that we handle cancelations
                 counter = counter.wrapping_add(1);
-                if counter % YIELD_EVERY_ITERATIONS == 0 {
+                if counter.is_multiple_of(YIELD_EVERY_ITERATIONS) {
                     let _ = AsyncAlarm::<DefaultSyscalls>::sleep_ticks(1).await;
                 }
             } else {

--- a/runtime/userspace/libtock/unittest/src/fake/ieee802154/mod.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/ieee802154/mod.rs
@@ -165,7 +165,7 @@ impl Ieee802154Phy {
         // conditional check (due to unsigned integer
         // arithmetic).
         assert!(rbuf.len() > RING_BUF_METADATA_SIZE);
-        assert!((rbuf.len() - RING_BUF_METADATA_SIZE) % USER_FRAME_MAX_SIZE == 0);
+        assert!((rbuf.len() - RING_BUF_METADATA_SIZE).is_multiple_of(USER_FRAME_MAX_SIZE));
 
         let mut read_index = rbuf[0] as usize;
         let mut write_index = rbuf[1] as usize;

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -6,7 +6,7 @@ use crate::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::allow_ro::AllowRo;
 use caliptra_mcu_libtock_platform::share;
 use caliptra_mcu_libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
-use core::{iter::repeat, marker::PhantomData};
+use core::marker::PhantomData;
 
 pub const VENDOR_PK_HASH_SIZE: usize =
     caliptra_mcu_registers_generated::fuses::OTP_CPTRA_CORE_VENDOR_PK_HASH_0.byte_size;
@@ -197,7 +197,10 @@ impl<S: Syscalls> Otp<S> {
             // Return early when the fuse already contains the hash
             return Ok(());
         }
-        if fuse_value.iter().ne(repeat(&0).take(fuse_value.len())) {
+        if fuse_value
+            .iter()
+            .ne(core::iter::repeat_n(&0, fuse_value.len()))
+        {
             // Error if the fuse is already containing something
             return Err(ErrorCode::Invalid);
         }
@@ -298,7 +301,7 @@ impl<S: Syscalls> Otp<S> {
 
         // Check if the slot is provisioned to not burn an empty slot
         let pk_hash = self.read_vendor_pk_hash(vendor_pk_hash_slot)?;
-        if pk_hash.iter().eq(repeat(&0).take(pk_hash.len())) {
+        if pk_hash.iter().eq(core::iter::repeat_n(&0, pk_hash.len())) {
             Err(ErrorCode::Invalid)?
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.85"
+channel = "1.95"
 components = ["clippy", "rust-src", "llvm-tools", "rustfmt", "rustc-dev"]
 targets = [
   "x86_64-unknown-linux-gnu",

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -134,7 +134,7 @@ fn get_elf_bytes(target_dir: &Path, fwid: FwId<'_>) -> io::Result<Vec<u8>> {
 }
 
 fn other_err(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, e)
+    io::Error::other(e)
 }
 
 pub fn elf_stack_size(elf_bytes: &[u8]) -> io::Result<u64> {

--- a/xtask/src/header.rs
+++ b/xtask/src/header.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use caliptra_mcu_builder::PROJECT_ROOT;
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Error, ErrorKind},
+    io::{BufRead, BufReader, Error},
     path::{Path, PathBuf},
 };
 use walkdir::DirEntry;
@@ -79,7 +79,7 @@ fn add_path_walkdir_error(path: &Path) -> impl Fn(walkdir::Error) -> Error + Cop
         let path = remove_root(path);
         match e.io_error() {
             Some(e) => Error::new(e.kind(), format!("{path:?}: {e}")),
-            None => Error::new(ErrorKind::Other, format!("{path:?}: {e}")),
+            None => Error::other(format!("{path:?}: {e}")),
         }
     }
 }
@@ -101,10 +101,9 @@ fn check_file_contents(path: &Path, contents: impl BufRead) -> Result<(), Error>
         }
     }
     let path = remove_root(path);
-    Err(Error::new(
-        ErrorKind::Other,
-        format!("File {path:?} doesn't contain {REQUIRED_TEXT:?} in the first {N} lines"),
-    ))
+    Err(Error::other(format!(
+        "File {path:?} doesn't contain {REQUIRED_TEXT:?} in the first {N} lines"
+    )))
 }
 
 fn check_file(path: &Path) -> Result<(), Error> {
@@ -120,10 +119,9 @@ fn fix_file(path: &Path) -> Result<(), Error> {
         Some("toml" | "sh" | "py" | "yaml" | "yml") => format!("# {REQUIRED_TEXT}\n"),
         Some("ld" | "s" | "S") => format!("/* {REQUIRED_TEXT} */\n"),
         other => {
-            return Err(std::io::Error::new(
-                ErrorKind::Other,
-                format!("Unknown extension {other:?}"),
-            ))
+            return Err(std::io::Error::other(format!(
+                "Unknown extension {other:?}"
+            )))
         }
     });
     let mut prev_contents = std::fs::read(path).map_err(wrap_err)?;
@@ -176,6 +174,7 @@ pub(crate) fn find_files(
 #[cfg(test)]
 mod test {
     use crate::header::*;
+    use std::io::ErrorKind;
 
     #[test]
     fn test_check_success() {

--- a/xtask/src/pldm_fw_pkg.rs
+++ b/xtask/src/pldm_fw_pkg.rs
@@ -11,11 +11,8 @@ pub(crate) fn create(manifest_path: &str, output_path: &str) -> Result<()> {
     let result = firmware_manifest
         .unwrap()
         .generate_firmware_package(&output_path.to_string());
-    if result.is_err() {
-        bail!(
-            "Failed to generate firmware package: {}",
-            result.unwrap_err()
-        );
+    if let Err(err) = result {
+        bail!("Failed to generate firmware package: {}", err);
     }
     println!("Encoded FirmwarePackage to binary file: {}", output_path);
     Ok(())


### PR DESCRIPTION
Bump the caliptra-sw rev pins and move the toolchain from 1.85 to 1.95 (rust-toolchain.toml plus the three CI workflows).

1.95 fallout fixed here:
- #[no_mangle] on #[panic_handler] is now a hard error.
- ROM lost panic-freeness: split_at is no longer inlined, so its bounds-check panic reached the ROM via mailbox.rs::cm_sha384.
- New clippy lints, and dead-code warnings now that trait impls no longer count as uses.