### PR TITLE
spdm: reject LargeCertChain GET_CERTIFICATE without LARGE_RESP_CAP

### DIFF
--- a/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/certificate.rs
@@ -11,7 +11,7 @@
 //! stack-allocated `[u8; N]` array for cert payload.
 
 use caliptra_mcu_spdm_codec::{
-    CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
+    CapFlags, CertificateLargeRsp, CertificateLargeRspBody, CertificateRsp, CertificateRspBody,
     GetCertificateParam1, GetCertificateReq, ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
     WireWriter,
 };
@@ -24,7 +24,7 @@ use crate::build::{build_error_response, build_response};
 use crate::chunk::LargeResponse;
 use crate::error::{
     SpdmResult, SPDM_DATA_TOO_LARGE, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE,
-    SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
+    SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST,
 };
 use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 
@@ -187,8 +187,17 @@ pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
 
     let req = GetCertificateReq::parse(body).map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    if req.is_large() && state.version < SpdmVersion::V14 {
-        return Err(SPDM_INVALID_REQUEST);
+    // A LargeCertChain GET_CERTIFICATE is only defined in SPDM 1.4+, and
+    // only when the responder advertised LARGE_RESP_CAP. Below 1.4 the
+    // param1 bit is reserved, so the request is malformed (InvalidRequest);
+    // at 1.4+ without the capability it is UnsupportedRequest (DSP0274).
+    if req.is_large() {
+        if state.version < SpdmVersion::V14 {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        if !state.advertised_cap_flags.contains(CapFlags::LARGE_RESP) {
+            return Err(SPDM_UNSUPPORTED_REQUEST);
+        }
     }
 
     let slot_id = req.slot_id();

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/certificate.rs
@@ -259,6 +259,18 @@ fn test_get_certificate_large_on_v13_returns_invalid_request() {
 }
 
 #[test]
+fn test_get_certificate_v14_large_without_large_resp_cap_returns_unsupported() {
+    let pal = TestPal::default();
+    let mut state = init_cert_test_state(SpdmVersion::V14, &pal);
+    // Responder did NOT advertise LARGE_RESP_CAP.
+    let mut sessions = SessionManager::new();
+
+    let req = large_cert_request(SpdmVersion::V14, 0, 0, 0, 1024);
+    let err = dispatch_cert_request(&mut state, &mut sessions, &pal, req).unwrap_err();
+    assert_eq!(err.spec_byte(), SPDM_UNSUPPORTED_REQUEST.spec_byte());
+}
+
+#[test]
 fn test_get_certificate_v14_large_invalid_slot_or_offset() {
     let pal = TestPal::default();
     let mut state = init_cert_test_state(SpdmVersion::V14, &pal);


### PR DESCRIPTION
## Summary

A `GET_CERTIFICATE` carrying the `LargeCertChain` request bit (param1) is only defined in SPDM 1.4+ and only when the responder advertised `LARGE_RESP_CAP`. The handler previously gated that bit on the negotiated version alone, so a 1.4 requester that set `LargeCertChain` against a responder which never advertised `LARGE_RESP_CAP` was serviced with a normal `CERTIFICATE` response instead of being rejected.

This makes the handler return `ERROR(UnsupportedRequest)` when `is_large()` is set at 1.4+ without `LARGE_RESP_CAP` in the advertised capabilities. The `< 1.4` path continues to return `ERROR(InvalidRequest)` (the param1 bit is reserved there).

## Conformance

Fixes the `SPDM-Responder-Validator` conformance case `spdm_test_case_certificate_large_invalid_request` (test 5.9), which currently fails against this responder:

```
test assertion 5.9.2 - FAIL response code - 0x02   (got CERTIFICATE, expected ERROR 0x7f)
test assertion 5.9.3 - FAIL response param1 - 0x80  (expected UnsupportedRequest)
```

The suite recently un-skipped this case, so it now fails on every open main-2.1 PR that runs `spdm_validator_tests`.

## Testing

- `cargo test -p caliptra-mcu-spdm-stack` — 40 passed, incl. new `test_get_certificate_v14_large_without_large_resp_cap_returns_unsupported`
- `cargo fmt --check` clean