### PR TITLE
lwip-rs: align host pools to pointer width

### DIFF
--- a/network/net/lwip-rs/include/lwipopts.h
+++ b/network/net/lwip-rs/include/lwipopts.h
@@ -25,7 +25,7 @@
    ---------- Memory options ----------
    ------------------------------------
 */
-#define MEM_ALIGNMENT                   4
+#define MEM_ALIGNMENT                   8
 #define MEM_SIZE                        (16 * 1024)
 
 #define MEMP_NUM_PBUF                   32


### PR DESCRIPTION
## Issue

Resolves the host-build portion of security assessment finding TS-MS207-6.

The Unix/TAP lwIP configuration used `MEM_ALIGNMENT=4` on 64-bit hosts. Memory-pool objects containing pointers can require 8-byte alignment, allowing undefined misaligned member accesses under UBSAN and on strict-alignment architectures.

## Changes

Set the host-specific alignment to 8 bytes. The separate bare-metal RISC-V 32-bit configuration remains at 4-byte alignment, so firmware memory layout and DCCM usage are unchanged.

## Validation

- Default host lwIP compilation
- Bare-metal stateful DHCPv6 compilation
- All 18 `caliptra-mcu-tests-integration` network tests
- `cargo xtask precheckin`