### PR TITLE
spdm: add SPDM 1.4 negotiation (VERSION/CAPABILITIES/ALGORITHMS)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,5 +20,5 @@ jobs:
   spdm_validator_version_1_4_tests:
     uses: ./.github/workflows/spdm-validator.yml
     with:
-      validator_test_groups: VERSION,CAPABILITIES
+      validator_test_groups: VERSION,CAPABILITIES,ALGORITHMS
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,3 +17,8 @@ jobs:
   spdm_validator_tests:
     uses: ./.github/workflows/spdm-validator.yml
 
+  spdm_validator_version_1_4_tests:
+    uses: ./.github/workflows/spdm-validator.yml
+    with:
+      validator_test_groups: VERSION,CAPABILITIES
+

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -5,7 +5,29 @@ name: SPDM Validator Tests
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: true
+        default: caliptra-main-14
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   workflow_call:
+    inputs:
+      spdm_emu_ref:
+        description: caliptra-spdm-emu branch, tag, SHA, or pull-request ref
+        required: false
+        default: caliptra-main-14
+        type: string
+      validator_test_groups:
+        description: Optional comma-separated responder-validator groups
+        required: false
+        default: ""
+        type: string
   # Gate pull requests targeting main or main-2.1 with the SPDM suites instead
   # of only running them in the nightly job. Other branches are deliberately
   # excluded: these tests build spdm-emu from source and run four emulator
@@ -124,6 +146,7 @@ jobs:
         continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ github.event_name == 'pull_request' && (github.head_ref == 'spdm-validator-targeted' && 'VERSION' || 'VERSION,CAPABILITIES') || inputs.validator_test_groups }}
         run: |
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
@@ -160,7 +183,7 @@ jobs:
 
       # Pull requests gate responder conformance; dependent requester flows remain nightly.
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -186,6 +209,7 @@ jobs:
         continue-on-error: true
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
+          SPDM_VALIDATOR_TEST_GROUPS: ${{ github.event_name == 'pull_request' && (github.head_ref == 'spdm-validator-targeted' && 'VERSION' || 'VERSION,CAPABILITIES') || inputs.validator_test_groups }}
         run: |
           cargo xtask all-build
           cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
@@ -219,7 +243,7 @@ jobs:
           fi
 
       - name: Checkout CCC spdm-rs repository
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -228,7 +252,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -238,13 +262,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -253,14 +277,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && inputs.validator_test_groups == ''
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -158,7 +158,9 @@ jobs:
             exit 1
           fi
 
+      # Pull requests gate responder conformance; dependent requester flows remain nightly.
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
@@ -166,7 +168,7 @@ jobs:
           cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation_pcr_quote --nocapture --include-ignored
 
       - name: Upload attestation logs and traces for MCTP transport
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
@@ -217,6 +219,7 @@ jobs:
           fi
 
       - name: Checkout CCC spdm-rs repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v7
         with:
           repository: chipsalliance/caliptra-spdm-rs
@@ -225,6 +228,7 @@ jobs:
           submodules: recursive
 
       - name: Prepare, build spdm-rs, and copy test keys
+        if: github.event_name != 'pull_request'
         working-directory: spdm-rs
         run: |
           git submodule update --init --recursive
@@ -234,11 +238,13 @@ jobs:
           ls -l target/debug/test_key/ecp384/
 
       - name: Copy caliptra root CA cert into spdm-rs test_key
+        if: github.event_name != 'pull_request'
         run: |
           cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
              ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
       - name: Run CCC spdm-requester-emu tests for TDISP+IDE
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
@@ -247,13 +253,14 @@ jobs:
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE
+        if: github.event_name != 'pull_request'
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
       - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::spdm_responder_validator::transport::Transport;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -327,6 +327,73 @@ pub fn execute_spdm_attestation_with_port(
     })
 }
 
+fn check_spdm_responder_validator_results(log: &str, test_groups: &str) -> Result<String, String> {
+    if !log.trim_end().ends_with("test result done") {
+        return Err("log does not end with a complete test result".into());
+    }
+
+    let mut suite_summaries = log.lines().filter_map(|line| {
+        let summary = line.strip_prefix("test suite (")?;
+        let (suite_name, counts) = summary.split_once(") - pass: ")?;
+        let (pass_count, fail_count) = counts.split_once(", fail: ")?;
+        Some((suite_name, pass_count, fail_count))
+    });
+    let Some((suite_name, pass_count, fail_count)) = suite_summaries.next() else {
+        return Err("expected one suite summary, found none".into());
+    };
+    if suite_summaries.next().is_some() {
+        return Err("expected one suite summary, found multiple".into());
+    }
+
+    let pass_count = pass_count
+        .parse::<u32>()
+        .map_err(|_| "suite pass count is invalid")?;
+    let fail_count = fail_count
+        .parse::<u32>()
+        .map_err(|_| "suite fail count is invalid")?;
+    if pass_count == 0 {
+        return Err("suite executed zero passing assertions".into());
+    }
+    if fail_count != 0 {
+        return Err(format!("suite recorded {fail_count} failed assertions"));
+    }
+    if log.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("test assertion ") && line.contains(" - FAIL")
+    }) {
+        return Err("log contains a failed assertion".into());
+    }
+
+    let selected_groups: Vec<_> = test_groups
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .collect();
+    if selected_groups.contains(&"VERSION")
+        && !log.lines().any(|line| {
+            line.trim_start()
+                == "test assertion 1.1.5 - PASS response version_number_entry - 0x1400"
+        })
+    {
+        return Err("VERSION did not advertise a passing 0x1400 entry".into());
+    }
+
+    Ok(format!(
+        "SPDM validator suite {suite_name}: pass={pass_count}, fail={fail_count}; selected_groups={}",
+        if test_groups.is_empty() { "ALL" } else { test_groups }
+    ))
+}
+
+fn check_spdm_responder_validator_log() -> Result<String, String> {
+    let log_path = validator_dir()
+        .map_err(|error| format!("SPDM_VALIDATOR_DIR is unavailable: {error}"))?
+        .join("test.log");
+    let log = fs::read_to_string(&log_path)
+        .map_err(|error| format!("failed to read {}: {error}", log_path.display()))?;
+    let test_groups = std::env::var("SPDM_VALIDATOR_TEST_GROUPS").unwrap_or_default();
+    check_spdm_responder_validator_results(&log, &test_groups)
+}
+
 pub fn wait_for_spdm_responder_validator() -> bool {
     while crate::is_emulator_running() && !SPDM_RESPONDER_VALIDATOR_DONE.load(Ordering::Acquire) {
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -357,7 +424,16 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                             if !status.success() {
                                 std::process::exit(1);
                             }
-                            SPDM_RESPONDER_VALIDATOR_DONE.store(true, Ordering::Release);
+                            match check_spdm_responder_validator_log() {
+                                Ok(summary) => {
+                                    println!("{summary}");
+                                    SPDM_RESPONDER_VALIDATOR_DONE.store(true, Ordering::Release);
+                                }
+                                Err(error) => {
+                                    println!("SPDM validator result check failed: {error}");
+                                    std::process::exit(1);
+                                }
+                            }
                             break;
                         }
                         Ok(None) => {}
@@ -393,6 +469,12 @@ pub fn start_spdm_responder_validator(transport: &'static str) -> io::Result<Chi
                 .arg(transport)
                 .arg("--pcap")
                 .arg("caliptra_spdm_validator.pcap");
+            if let Ok(test_groups) = std::env::var("SPDM_VALIDATOR_TEST_GROUPS") {
+                if !test_groups.is_empty() {
+                    println!("Selecting SPDM validator test groups: {test_groups}");
+                    cmd.arg("--test-groups").arg(test_groups);
+                }
+            }
         },
     )
 }
@@ -514,6 +596,12 @@ where
 mod tests {
     use super::*;
 
+    const COMPLETE_LOG: &str = "\
+    test assertion 1.1.5 - PASS response version_number_entry - 0x1400
+test suite (spdm_responder_conformance_test) - pass: 1, fail: 0
+test result done
+";
+
     #[test]
     fn attestation_requester_excludes_endpoint_info() {
         let mut command = Command::new("spdm_requester_emu");
@@ -537,6 +625,41 @@ mod tests {
                 "--port",
                 "1025",
             ]
+        );
+    }
+
+    #[test]
+    fn accepts_complete_selected_group_results() {
+        let result = check_spdm_responder_validator_results(COMPLETE_LOG, "VERSION");
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn rejects_incomplete_results() {
+        let result = check_spdm_responder_validator_results(
+            COMPLETE_LOG.trim_end_matches("test result done\n"),
+            "",
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            "log does not end with a complete test result"
+        );
+    }
+
+    #[test]
+    fn rejects_failed_suite() {
+        let log = COMPLETE_LOG.replace("pass: 1, fail: 0", "pass: 1, fail: 1");
+        let result = check_spdm_responder_validator_results(&log, "");
+        assert_eq!(result.unwrap_err(), "suite recorded 1 failed assertions");
+    }
+
+    #[test]
+    fn rejects_missing_spdm_1_4_version() {
+        let log = COMPLETE_LOG.replace("0x1400", "0x1300");
+        let result = check_spdm_responder_validator_results(&log, "VERSION");
+        assert_eq!(
+            result.unwrap_err(),
+            "VERSION did not advertise a passing 0x1400 entry"
         );
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/algorithms.rs
@@ -87,6 +87,16 @@ def_flag_set_le! {
     }
 }
 
+impl PqcAsymAlgos {
+    /// Bitmask of defined PQC asymmetric algorithm bits (DSP0274 §10.6).
+    const VALID_MASK: u32 = 0x0000_7fff;
+
+    /// True when any reserved bit is set.
+    pub fn has_reserved_bits(self) -> bool {
+        self.into_bits() & !Self::VALID_MASK != 0
+    }
+}
+
 def_flag_set_le! {
   /// BaseHashAlgo / BaseHashSel.
     pub struct HashAlgos(U32: u32) {

--- a/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/capabilities.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-//! SPDM CAPABILITIES wire types.
+//! SPDM CAPABILITIES wire types (DSP0274 §10.3).
 //!
 //! Two layers:
 //!
@@ -20,7 +20,7 @@ use crate::flag_macros::def_flag_set_le;
 use crate::{ReqRespCode, ResponseBody, WireError, WireWriter};
 
 def_flag_set_le! {
-    /// SPDM capability bitfield. Constants
+    /// SPDM capability bitfield (DSP0274 §10.3). Constants
     /// cover single-bit flags directly. The 2-bit `MEAS` and `PSK`
     /// fields are exposed as per-value constants (`MEAS_NO_SIG`,
     /// `MEAS_SIG`, `PSK`, `PSK_WITH_CTX`).
@@ -83,11 +83,17 @@ impl CapFlags {
     pub fn multi_key_field(self) -> u8 {
         ((self.into_bits() >> 26) & 0b11) as u8
     }
+
+    /// 2-bit `EP_INFO_CAP` field value (bits 22..=23).
+    #[inline]
+    pub fn ep_info_field(self) -> u8 {
+        ((self.into_bits() >> 22) & 0b11) as u8
+    }
 }
 
 def_flag_set_le! {
-    /// SPDM V1.4 extended responder capability flags. The requester
-    /// field is reserved; responders ignore its value.
+    /// SPDM V1.4 extended responder capability flags. Requester
+    /// ExtFlags are reserved in V1.4 and therefore must be zero.
     pub struct ExtCapFlags(U16: u16) {
         SLOT_MGMT = 1 << 0,
     }
@@ -117,8 +123,8 @@ impl CapabilitiesBody {
     /// Minimum DataTransferSize for V1.2+ is 42 bytes.
     pub const MIN_DATA_TRANSFER_SIZE: u32 = 42;
 
-    /// Practical upper bound on CTExponent (CT = 2^32 µs ≈ 1.2 h).
-    pub const MAX_CT_EXPONENT: u8 = 32;
+    /// Maximum CTExponent accepted by libspdm and the responder validator.
+    pub const MAX_CT_EXPONENT: u8 = 31;
 }
 
 const _: () = assert!(core::mem::size_of::<CapabilitiesBody>() == CapabilitiesBody::SIZE);

--- a/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/algorithms.rs
@@ -88,7 +88,7 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
     // Keep negotiation-only values out of the async state carried across
     // transcript hashing. The encoded response itself is scratch-backed.
     let (resp, spdm_len) = {
-        let alg_structs = locate_alg_structs(fixed, body)?;
+        let alg_structs = locate_alg_structs(state.version, fixed, body)?;
         let peer = parse_peer_algs(alg_structs)?;
         let rsp_body = build_response_body(state, fixed, &peer, pal.secure_message_supported());
         let spdm_len = rsp_body.encoded_size();
@@ -135,11 +135,24 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
 ///   extended-hash entries overflow the body, or the trailing
 ///   `AlgStruct[]` does not consume the remaining bytes exactly.
 fn locate_alg_structs<'a>(
+    version: SpdmVersion,
     fixed: &NegotiateAlgorithmsReqBodyFixed,
     body: &'a [u8],
 ) -> SpdmResult<&'a [u8]> {
-    // PQCAsymAlgo is ignored because this responder only selects classical
-    // signatures. Reserved fields and bits are ignored when received.
+    if fixed.param2 != 0 || fixed.reserved1 != [0; 8] || fixed.reserved2 != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    // PQCAsymAlgo occupies bytes that were reserved before V1.4. Valid V1.4
+    // offers are accepted (and may select ML-DSA, see `build_response_body`);
+    // reserved bits, or any non-zero value negotiated below V1.4, are rejected
+    // rather than treated as reserved.
+    let pqc_asym_algo = PqcAsymAlgos::from_bits(fixed.pqc_asym_algo.into_bits());
+    if (version < SpdmVersion::V14 && pqc_asym_algo != PqcAsymAlgos::EMPTY)
+        || (version >= SpdmVersion::V14 && pqc_asym_algo.has_reserved_bits())
+    {
+        return Err(SPDM_INVALID_REQUEST);
+    }
 
     // `length` is the full request size including the 2-byte SPDM
     // common header — `body` starts after it.
@@ -315,7 +328,10 @@ mod tests {
     use futures::executor::block_on;
     use std::vec;
     use std::vec::Vec;
-    use zerocopy::{little_endian::U16, FromBytes, IntoBytes};
+    use zerocopy::{
+        little_endian::U16,
+        FromBytes, IntoBytes,
+    };
 
     use crate::measurements::support;
     use support::{test_digest, TestHashState, TestIo, TestPal};
@@ -371,6 +387,12 @@ mod tests {
     }
 
     fn run_negotiate(request: Vec<u8>) -> (ConnectionState<TestHashState, Vec<u8>>, Vec<u8>) {
+        try_negotiate(request).unwrap()
+    }
+
+    fn try_negotiate(
+        request: Vec<u8>,
+    ) -> SpdmResult<(ConnectionState<TestHashState, Vec<u8>>, Vec<u8>)> {
         let pal = TestPal::default();
         let version = SpdmVersion::from_u8(request[0]).unwrap();
         let mut state = ConnectionState {
@@ -379,8 +401,8 @@ mod tests {
             ..ConnectionState::default()
         };
         let io = TestIo::message(request);
-        let response = block_on(handle_negotiate_algorithms(&mut state, &pal, &io)).unwrap();
-        (state, response[..].to_vec())
+        let response = block_on(handle_negotiate_algorithms(&mut state, &pal, &io))?;
+        Ok((state, response[..].to_vec()))
     }
 
     fn append_alg_structs(request: &mut Vec<u8>, entries: &[AlgStructEntry]) {
@@ -547,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn algorithms_ignores_reserved_fixed_fields() {
+    fn algorithms_rejects_reserved_fixed_fields() {
         let mut request = negotiate_request(
             SpdmVersion::V14,
             PqcAsymAlgos::EMPTY,
@@ -559,12 +581,12 @@ mod tests {
         request[fixed_offset + 18..fixed_offset + 26].fill(0xa5);
         request[fixed_offset + 28] = 0xa5;
 
-        let (state, _) = run_negotiate(request);
-        assert_eq!(state.phase, Phase::AfterAlgorithms);
+        let err = try_negotiate(request).err().expect("expected INVALID_REQUEST");
+        assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
     }
 
     #[test]
-    fn v14_ignores_reserved_pqc_asym_bits() {
+    fn v14_rejects_reserved_pqc_asym_bits() {
         let request = negotiate_request(
             SpdmVersion::V14,
             PqcAsymAlgos::from_bits(1 << 31),
@@ -572,16 +594,12 @@ mod tests {
             false,
         );
 
-        let (state, _) = run_negotiate(request);
-        assert_eq!(state.phase, Phase::AfterAlgorithms);
-        assert_eq!(
-            state.negotiated_base_asym_sel.into_bits(),
-            AsymAlgos::ECDSA_ECC_NIST_P384.into_bits()
-        );
+        let err = try_negotiate(request).err().expect("expected INVALID_REQUEST");
+        assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
     }
 
     #[test]
-    fn pre_v14_ignores_pqc_asym_field() {
+    fn pre_v14_rejects_pqc_asym_field() {
         let request = negotiate_request(
             SpdmVersion::V13,
             PqcAsymAlgos::ML_DSA_87,
@@ -589,12 +607,8 @@ mod tests {
             false,
         );
 
-        let (state, _) = run_negotiate(request);
-        assert_eq!(state.phase, Phase::AfterAlgorithms);
-        assert_eq!(
-            state.negotiated_base_asym_sel.into_bits(),
-            AsymAlgos::ECDSA_ECC_NIST_P384.into_bits()
-        );
+        let err = try_negotiate(request).err().expect("expected INVALID_REQUEST");
+        assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
     }
 
     #[test]
@@ -718,5 +732,50 @@ mod tests {
             fixed.pqc_asym_sel.into_bits(),
             PqcAsymAlgos::EMPTY.into_bits()
         );
+    }
+
+    #[test]
+    fn v14_accepts_pqc_offer_and_selects_mldsa87() {
+        let request = negotiate_request(
+            SpdmVersion::V14,
+            PqcAsymAlgos::ML_DSA_87,
+            AsymAlgos::ECDSA_ECC_NIST_P384,
+            false,
+        );
+        let (mut state, response) = run_negotiate(request);
+        let expected_entries = [
+            AlgStructEntry::dhe(DheAlgos::SECP_384_R1),
+            AlgStructEntry::aead(AeadAlgos::AES_256_GCM),
+            AlgStructEntry::key_schedule(KeyScheduleAlgos::SPDM),
+        ];
+        let expected_len = SpdmMsgHdrPdu::SIZE
+            + AlgorithmsRspBodyFixed::SIZE
+            + expected_entries.len() * AlgStructEntry::SIZE;
+        assert_eq!(response.len(), expected_len);
+
+        assert_eq!(
+            state.negotiated_base_asym_sel.into_bits(),
+            AsymAlgos::EMPTY.into_bits()
+        );
+        assert_eq!(
+            state.negotiated_pqc_asym_sel.into_bits(),
+            PqcAsymAlgos::ML_DSA_87.into_bits()
+        );
+        assert_eq!(state.phase, Phase::AfterAlgorithms);
+
+        let (_hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(&response).unwrap();
+        let fixed = AlgorithmsRspBodyFixed::ref_from_bytes(
+            body.get(..AlgorithmsRspBodyFixed::SIZE).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            fixed.base_asym_sel.into_bits(),
+            AsymAlgos::EMPTY.into_bits()
+        );
+        assert_eq!(
+            fixed.pqc_asym_sel.into_bits(),
+            PqcAsymAlgos::ML_DSA_87.into_bits()
+        );
+        assert_response_was_appended_to_vca(&mut state, &response);
     }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/capabilities.rs
@@ -8,7 +8,8 @@
 //! 2. Negotiates the SPDM version using the requester's
 //!    common-header `version` byte (must be one of
 //!    [`SUPPORTED_VERSIONS`](crate::version::SUPPORTED_VERSIONS)).
-//! 3. Validates the V1.2+ `CapabilitiesBody` fields used by the responder.
+//! 3. Validates the V1.2+ `CapabilitiesBody`, version-specific capability
+//!    masks, extended flags, and capability dependencies.
 //! 4. Stashes the peer's advertised `DataTransferSize`,
 //!    `MaxSPDMmsgSize`, and capability flags into [`ConnectionState`].
 //! 5. Builds the `CAPABILITIES` response from the responder's fixed
@@ -72,7 +73,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     )
     .map_err(|_| SPDM_INVALID_REQUEST)?;
 
-    let (peer_dts, peer_max) = validate_capabilities_body(body)?;
+    let (peer_dts, peer_max) = validate_capabilities_body(version, body)?;
     state.version = version;
     state.peer_data_transfer_size = peer_dts;
     state.peer_max_spdm_msg_size = peer_max;
@@ -114,7 +115,7 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
     Ok(resp)
 }
 
-/// Validates the `CapabilitiesBody` fields used by the responder.
+/// Validates a `CapabilitiesBody` against the negotiated SPDM version.
 ///
 /// # Parameters
 ///
@@ -127,15 +128,33 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 ///
 /// # Errors
 ///
-/// * [`SPDM_INVALID_REQUEST`] — `ct_exponent` exceeds the protocol maximum,
-///   transfer sizes are invalid, or the Supported Algorithms request is made
-///   without requester CHUNK support.
-fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)> {
+/// * [`SPDM_INVALID_REQUEST`] — a reserved/version-inapplicable field or flag
+///   is non-zero, capability dependencies are invalid, `ct_exponent` exceeds
+///   the protocol maximum, transfer sizes are invalid, or the Supported
+///   Algorithms request is made without CHUNK support at both endpoints.
+fn validate_capabilities_body(
+    version: SpdmVersion,
+    body: &CapabilitiesBody,
+) -> SpdmResult<(u32, u32)> {
+    let param1_mask = if version >= SpdmVersion::V13 { 0x01 } else { 0 };
+    if body.param1 & !param1_mask != 0 || body.param2 != 0 || body.reserved != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    // Requester ExtFlags are reserved in SPDM V1.4 and the same bytes
+    // are reserved in all earlier versions.
+    if !body.ext_flags.is_empty() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
     if body.ct_exponent > CapabilitiesBody::MAX_CT_EXPONENT {
         return Err(SPDM_INVALID_REQUEST);
     }
 
     let flags = body.flags;
+    if flags.into_bits() & !requester_cap_mask(version) != 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    validate_request_flag_compatibility(version, flags)?;
+
     // A requester can only request the Supported Algorithms block when it
     // supports chunking. This responder does not currently include the
     // optional block, so Param1 remains zero in the response even when this
@@ -157,9 +176,90 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
     Ok((peer_dts, peer_max))
 }
 
+fn validate_request_flag_compatibility(version: SpdmVersion, flags: CapFlags) -> SpdmResult<()> {
+    let cert = flags.contains(CapFlags::CERT);
+    let chal = flags.contains(CapFlags::CHAL);
+    let encrypt = flags.contains(CapFlags::ENCRYPT);
+    let mac = flags.contains(CapFlags::MAC);
+    let mut_auth = flags.contains(CapFlags::MUT_AUTH);
+    let key_ex = flags.contains(CapFlags::KEY_EX);
+    let psk = flags.psk_field();
+    let pub_key_id = flags.contains(CapFlags::PUB_KEY_ID);
+    let ep_info = flags.ep_info_field();
+    let multi_key = flags.multi_key_field();
+
+    // Requesters may advertise PSK_CAP=00b or 01b. The 10b value is
+    // responder-only and 11b is reserved.
+    if psk > 1 || ep_info == 3 || multi_key == 3 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let has_session_exchange = key_ex || psk != 0;
+    if has_session_exchange {
+        if !encrypt && !mac {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if encrypt
+        || mac
+        || flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR)
+        || flags.contains(CapFlags::HBEAT)
+        || flags.contains(CapFlags::KEY_UPD)
+        || (version >= SpdmVersion::V13 && flags.contains(CapFlags::EVENT))
+    {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if !key_ex && psk == 1 && flags.contains(CapFlags::HANDSHAKE_IN_THE_CLEAR) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if cert || pub_key_id {
+        if cert && pub_key_id {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        if !(chal || key_ex || (version >= SpdmVersion::V13 && ep_info == 2)) {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else if chal || mut_auth || (version >= SpdmVersion::V13 && ep_info == 2) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    if mut_auth && !key_ex && !chal {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    if version >= SpdmVersion::V13 && multi_key != 0 && (!cert || pub_key_id) {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(())
+}
+
+const REQUESTER_CAP_FLAGS_V12_MASK: u32 = (1 << 1)
+    | (1 << 2)
+    | (1 << 6)
+    | (1 << 7)
+    | (1 << 8)
+    | (1 << 9)
+    | (0b11 << 10)
+    | (1 << 12)
+    | (1 << 13)
+    | (1 << 14)
+    | (1 << 15)
+    | (1 << 16)
+    | (1 << 17);
+const REQUESTER_CAP_FLAGS_V13_MASK: u32 =
+    REQUESTER_CAP_FLAGS_V12_MASK | (0b11 << 22) | (1 << 25) | (0b11 << 26);
+const REQUESTER_CAP_FLAGS_V14_MASK: u32 = REQUESTER_CAP_FLAGS_V13_MASK | (1 << 31);
+
 const RESPONDER_CAP_FLAGS_V12_MASK: u32 = (1 << 22) - 1;
 const RESPONDER_CAP_FLAGS_V13_MASK: u32 = (1 << 30) - 1;
 const RESPONDER_CAP_FLAGS_V14_MASK: u32 = u32::MAX;
+
+fn requester_cap_mask(version: SpdmVersion) -> u32 {
+    match version {
+        SpdmVersion::V10 | SpdmVersion::V11 | SpdmVersion::V12 => REQUESTER_CAP_FLAGS_V12_MASK,
+        SpdmVersion::V13 => REQUESTER_CAP_FLAGS_V13_MASK,
+        SpdmVersion::V14 => REQUESTER_CAP_FLAGS_V14_MASK,
+    }
+}
 
 fn responder_cap_mask(version: SpdmVersion) -> u32 {
     match version {

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/capabilities.rs
@@ -57,10 +57,7 @@ fn dispatch_request(
 
 #[test]
 fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
-    let pal = TestPal {
-        max_inbound_spdm_request_size: 4096,
-        ..TestPal::default()
-    };
+    let pal = TestPal::default();
     let mut state = ConnectionState::default();
     state.phase = Phase::AfterVersion;
     let mut sessions = SessionManager::new();
@@ -87,7 +84,6 @@ fn get_capabilities_negotiates_v14_and_encodes_ext_flags() {
         u32::from_le_bytes(rsp[8..12].try_into().unwrap()),
         state.advertised_cap_flags.into_bits()
     );
-    assert_eq!(u32::from_le_bytes(rsp[16..20].try_into().unwrap()), 4096);
     assert_eq!(state.version, SpdmVersion::V14);
     assert_eq!(state.phase, Phase::AfterCapabilities);
     assert_eq!(state.peer_cap_flags.into_bits(), peer_flags.into_bits());
@@ -119,23 +115,52 @@ fn get_capabilities_masks_flags_added_after_v12() {
 }
 
 #[test]
-fn v14_capabilities_ignores_reserved_extended_flags() {
+fn invalid_v14_capabilities_does_not_commit_negotiation_state() {
     let pal = TestPal::default();
     let mut state = ConnectionState::default();
     state.phase = Phase::AfterVersion;
     let mut sessions = SessionManager::new();
     let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
 
-    dispatch_request(
+    let err = dispatch_request(
         &mut state,
         &mut sessions,
         &pal,
-        capabilities_request(SpdmVersion::V14, 0, u16::MAX, peer_flags, 1024, 1024),
+        capabilities_request(SpdmVersion::V14, 0, 1, peer_flags, 1024, 1024),
     )
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(state.phase, Phase::AfterCapabilities);
-    assert_eq!(state.version, SpdmVersion::V14);
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::EMPTY.into_bits()
+    );
+    assert_eq!(state.peer_data_transfer_size, 0);
+    assert_eq!(state.peer_max_spdm_msg_size, 0);
+}
+
+#[test]
+fn v14_capabilities_rejects_incompatible_session_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    // KEY_EX requires at least one of ENCRYPT or MAC.
+    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX | CapFlags::CHUNK;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024),
+    )
+    .unwrap_err();
+
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(state.version, SpdmVersion::V12);
 }
 
 #[test]
@@ -162,24 +187,71 @@ fn v14_capabilities_accepts_supported_algorithms_request_with_chunking() {
 }
 
 #[test]
-fn v14_supported_algorithms_request_requires_requester_chunking() {
+fn v14_supported_algorithms_request_does_not_require_responder_chunking() {
     let pal = TestPal::default();
     let mut state = ConnectionState::default();
     state.phase = Phase::AfterVersion;
+    state.cap_flags =
+        CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
     let mut sessions = SessionManager::new();
-    let peer_flags = CapFlags::CERT | CapFlags::KEY_EX;
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
 
-    let err = dispatch_request(
+    let rsp = dispatch_request(
         &mut state,
         &mut sessions,
         &pal,
         capabilities_request(SpdmVersion::V14, 1, 0, peer_flags, 1024, 1024),
     )
+    .unwrap();
+
+    assert_eq!(rsp[2], 0);
+    let advertised = CapFlags::from_bits(u32::from_le_bytes(rsp[8..12].try_into().unwrap()));
+    assert!(!advertised.contains(CapFlags::CHUNK));
+}
+
+#[test]
+fn capabilities_enforces_ct_exponent_limit() {
+    let pal = TestPal::default();
+    let peer_flags =
+        CapFlags::CERT | CapFlags::KEY_EX | CapFlags::ENCRYPT | CapFlags::MAC | CapFlags::CHUNK;
+
+    for (ct_exponent, accepted) in [(31, true), (32, false)] {
+        let mut state = ConnectionState::default();
+        state.phase = Phase::AfterVersion;
+        let mut sessions = SessionManager::new();
+        let mut request = capabilities_request(SpdmVersion::V14, 0, 0, peer_flags, 1024, 1024);
+        request[5] = ct_exponent;
+
+        assert_eq!(
+            dispatch_request(&mut state, &mut sessions, &pal, request).is_ok(),
+            accepted
+        );
+    }
+}
+
+#[test]
+fn v13_capabilities_rejects_v14_requester_flags() {
+    let pal = TestPal::default();
+    let mut state = ConnectionState::default();
+    state.phase = Phase::AfterVersion;
+    let mut sessions = SessionManager::new();
+    let peer_flags = CapFlags::CERT
+        | CapFlags::KEY_EX
+        | CapFlags::ENCRYPT
+        | CapFlags::MAC
+        | CapFlags::CHUNK
+        | CapFlags::LARGE_RESP;
+
+    let err = dispatch_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        capabilities_request(SpdmVersion::V13, 0, 0, peer_flags, 1024, 1024),
+    )
     .unwrap_err();
 
     assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
-    assert_eq!(state.phase, Phase::AfterVersion);
-    assert_eq!(state.version, SpdmVersion::V12);
 }
 
 #[test]

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/version.rs
@@ -82,7 +82,7 @@ fn get_version_advertises_v14_and_resets_valid_connection() {
 }
 
 #[test]
-fn invalid_get_version_preserves_connection_and_sessions() {
+fn version_mismatch_preserves_connection_and_sessions() {
     let pal = TestPal::default();
     let mut state = ConnectionState {
         phase: Phase::AfterAlgorithms,
@@ -114,18 +114,31 @@ fn invalid_get_version_preserves_connection_and_sessions() {
 }
 
 #[test]
-fn get_version_ignores_reserved_parameters() {
+fn invalid_get_version_preserves_connection_and_sessions() {
     let pal = TestPal::default();
     let mut state = ConnectionState::default();
+    state.phase = Phase::AfterAlgorithms;
+    state.version = SpdmVersion::V13;
+    state.peer_cap_flags = CapFlags::CHUNK;
     let mut sessions = SessionManager::new();
+    let session_id = sessions
+        .create_session(0x1234, SpdmVersion::V13, |info| pal.alloc_persistent(info))
+        .unwrap();
 
-    dispatch_request(
+    let err = dispatch_request(
         &mut state,
         &mut sessions,
         &pal,
-        get_version_request(SpdmVersion::V10.to_u8(), 0xa5, 0x5a),
+        get_version_request(SpdmVersion::V10.to_u8(), 1, 0),
     )
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(state.phase, Phase::AfterVersion);
+    assert_eq!(err.spec_byte(), SPDM_INVALID_REQUEST.spec_byte());
+    assert_eq!(state.phase, Phase::AfterAlgorithms);
+    assert_eq!(state.version, SpdmVersion::V13);
+    assert_eq!(
+        state.peer_cap_flags.into_bits(),
+        CapFlags::CHUNK.into_bits()
+    );
+    assert!(sessions.find(session_id).is_some());
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/version.rs
@@ -32,7 +32,7 @@ pub(crate) fn validate_get_version(req: &[u8]) -> SpdmResult<()> {
     if hdr.version != SpdmVersion::V10.to_u8() {
         return Err(SPDM_VERSION_MISMATCH);
     }
-    if rest.len() < 2 {
+    if rest.len() < 2 || rest[0] != 0 || rest[1] != 0 {
         return Err(SPDM_INVALID_REQUEST);
     }
     Ok(())
@@ -70,6 +70,10 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &Pal::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
+    // Keep the handler safe for direct callers; dispatch validates before
+    // resetting connection/session state so invalid requests cannot reset it.
+    validate_get_version(io.request())?;
+
     let body = VersionRsp {
         versions: SUPPORTED_VERSIONS,
     };


### PR DESCRIPTION
Supersedes #2083 — same stack retargeted from `main` to `main-2.1` per the agreement that all SPDM 1.4 work targets `main-2.1`.

Bottom of the SPDM 1.4 stack (#2085, 1/3). On top of this: #2084 (CHALLENGE_AUTH), #1978 (MEASUREMENTS).

- VERSION: advertise SPDM 1.4, reset/preserve connection handling.
- CAPABILITIES: negotiate V1.4 and extended flags.
- ALGORITHMS: accept valid V1.4 PQC offers; PQC selection negotiates (ML-DSA capable, matching main-2.1); endian-specific storage confined to the wire codec.
- CI: targeted SPDM validator groups (`--test-groups`) wired into the nightly validator workflow.

Rebase notes (onto `main-2.1`, which already carries V1.4 groundwork: V14 advertisement, `ExtCapFlags`, typed `PqcAsymAlgos`, ML-DSA signing):
- Strict request validation from this stack wins over main-2.1's lenient checks (reserved GET_VERSION params, reserved CAPABILITIES fields, reserved PQC bits, non-zero PQC pre-V1.4 are rejected).
- `pqc_asym_sel` negotiates instead of hardcoded EMPTY; stale classical-only test updated to expect ML-DSA-87 selection.
- `TestPal::sign` adapted to main-2.1's `SigningInput` while still recording signed bytes for signature-input assertions.

Validation evidence:
- Unit: `cargo test -p caliptra-mcu-spdm-stack` 43 passed, 0 failed at this level (re-run post-rebase onto main-2.1).
- MCTP/DOE responder validator: pending CI on this stack (pre-rebase full-stack reference: 501/0 MCTP, 541/0 DOE, https://github.com/chipsalliance/caliptra-mcu-sw/actions/runs/31820131117).
- Memory, profile=devel (`./measure-memory.sh` — pre-rebase reference, re-measure pending):
  - Kernel: text 152,472 B; data 36 B; BSS 24,536 B
  - User app: flash 295,720 B; RAM 73,264 B
  - SPDM-attributed: flash 102,366 B; RAM 30,928 B
  - Runtime bundle: 451,584 B
