### PR TITLE
spdm: HEARTBEAT / HEARTBEAT_ACK with watchdog (backport of #1927 to main-2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,9 @@ version = "0.1.0"
 dependencies = [
  "caliptra-mcu-attestation-evidence",
  "caliptra-mcu-libsyscall-caliptra",
+ "caliptra-mcu-libtock_alarm",
  "caliptra-mcu-libtock_platform",
+ "caliptra-mcu-libtockasync",
  "caliptra-mcu-measurement-api",
  "caliptra-mcu-runtime-userspace-error",
  "caliptra-mcu-scratch-alloc",

--- a/runtime/userspace/api/spdm-lib/codec/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/key_exchange.rs
@@ -14,6 +14,32 @@ pub const ECDH_P384_EXCHANGE_DATA_SIZE: usize = 96;
 /// Random data length in KEY_EXCHANGE req/rsp.
 pub const KEY_EXCHANGE_RANDOM_DATA_LEN: usize = 32;
 
+/// KEY_EXCHANGE_RSP HeartbeatPeriod (Param1 of the response, DSP0274): a count
+/// of **seconds**. Zero is a distinguished value — heartbeat is supported but
+/// not desired on this session, so no liveness watchdog runs. Wrapping the raw
+/// byte keeps the unit and that semantics in the type instead of passing bare
+/// `u8`s around.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct HeartBeatPeriod(pub u8);
+
+impl HeartBeatPeriod {
+    /// Heartbeat supported but not desired: no watchdog on this session.
+    pub const DISABLED: HeartBeatPeriod = HeartBeatPeriod(0);
+
+    /// Whole seconds carried by this period.
+    #[inline]
+    pub fn secs(self) -> u8 {
+        self.0
+    }
+
+    /// True when a non-zero period was negotiated (liveness watchdog active).
+    #[inline]
+    pub fn is_enabled(self) -> bool {
+        self.0 != 0
+    }
+}
+
 // ---- Request ---------------------------------------------------------------
 
 /// KEY_EXCHANGE request fixed body (after SPDM header).
@@ -61,6 +87,7 @@ impl KeyExchangeReqBody {
 ///   signature(96) | responder_verify_data(0|48) ]
 /// ```
 pub struct KeyExchangeRsp<'a> {
+    pub heartbeat_period: HeartBeatPeriod,
     pub rsp_session_id: u16,
     pub random_data: &'a [u8; KEY_EXCHANGE_RANDOM_DATA_LEN],
     pub exchange_data: &'a [u8; ECDH_P384_EXCHANGE_DATA_SIZE],
@@ -89,8 +116,8 @@ impl ResponseBody for KeyExchangeRsp<'_> {
     }
 
     fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
-        // heartbeat_period = 0 (no heartbeat)
-        w.write_bytes(&[0u8])?;
+        // heartbeat_period (0 = no heartbeat on this session)
+        w.write_bytes(&[self.heartbeat_period.0])?;
         // reserved
         w.write_bytes(&[0u8])?;
         // rsp_session_id (LE)
@@ -140,5 +167,48 @@ impl KeyExchangeRsp<'_> {
         } else {
             0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ResponseBody, SpdmMsgHdrPdu, SpdmVersion, WireWriter};
+
+    fn encode(period: u8) -> ([u8; 256], usize) {
+        let random = [0u8; KEY_EXCHANGE_RANDOM_DATA_LEN];
+        let exchange = [0u8; ECDH_P384_EXCHANGE_DATA_SIZE];
+        let body = KeyExchangeRsp {
+            heartbeat_period: HeartBeatPeriod(period),
+            rsp_session_id: 0xABCD,
+            random_data: &random,
+            exchange_data: &exchange,
+            meas_summary_hash: None,
+            opaque_data: &[],
+            signature: &[],
+            responder_verify_data: None,
+        };
+        let mut buf = [0u8; 256];
+        let mut w = WireWriter::new(&mut buf);
+        body.encode_with_header(SpdmVersion::V13, &mut w).unwrap();
+        let len = w.position();
+        (buf, len)
+    }
+
+    // The HeartbeatPeriod is the first body byte (immediately after the 2-byte
+    // common header) and must carry exactly the negotiated value.
+    #[test]
+    fn heartbeat_period_is_first_body_byte() {
+        let (buf, _) = encode(3);
+        assert_eq!(buf[SpdmMsgHdrPdu::SIZE], 3);
+        // reserved byte stays zero.
+        assert_eq!(buf[SpdmMsgHdrPdu::SIZE + 1], 0);
+    }
+
+    // A zero period (heartbeat not desired / not supported) encodes as zero.
+    #[test]
+    fn heartbeat_period_zero_encodes_zero() {
+        let (buf, _) = encode(0);
+        assert_eq!(buf[SpdmMsgHdrPdu::SIZE], 0);
     }
 }

--- a/runtime/userspace/api/spdm-lib/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/codec/src/lib.rs
@@ -52,7 +52,8 @@ pub use header::{
     SPDM_CONTEXT_LEN, SPDM_MSG_HDR_SIZE, SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
 pub use key_exchange::{
-    KeyExchangeReqBody, KeyExchangeRsp, ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN,
+    HeartBeatPeriod, KeyExchangeReqBody, KeyExchangeRsp, ECDH_P384_EXCHANGE_DATA_SIZE,
+    KEY_EXCHANGE_RANDOM_DATA_LEN,
 };
 pub use measurements::{
     DmtfMeasurementBlockHeader, GetMeasurementsReqBody, MeasurementsRsp, MEAS_BLOCK_METADATA_SIZE,

--- a/runtime/userspace/api/spdm-lib/pal/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/pal/Cargo.toml
@@ -16,6 +16,8 @@ caliptra-mcu-scratch-alloc = { workspace = true }
 mcu-error = { workspace = true }
 caliptra-mcu-libsyscall-caliptra = { workspace = true, optional = true }
 caliptra-mcu-libtock_platform = { workspace = true, optional = true }
+caliptra-mcu-libtock_alarm = { workspace = true, optional = true }
+caliptra-mcu-libtockasync = { workspace = true, optional = true }
 zerocopy = { workspace = true }
 
 [features]
@@ -25,4 +27,12 @@ set-certificate = [
   "caliptra-mcu-spdm-traits/set-certificate",
   "caliptra-mcu-libsyscall-caliptra",
   "caliptra-mcu-libtock_platform",
+]
+# HEARTBEAT liveness watchdog: pulls in the libtock alarm capsule so the PAL
+# can provide a real monotonic clock (now_ms/sleep_ms) to the stack.
+spdm-set-heartbeat = [
+  "caliptra-mcu-libsyscall-caliptra",
+  "caliptra-mcu-libtock_platform",
+  "caliptra-mcu-libtock_alarm",
+  "caliptra-mcu-libtockasync",
 ]

--- a/runtime/userspace/api/spdm-lib/pal/src/clock.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/clock.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache-2.0 license
+
+//! Monotonic clock for the HEARTBEAT liveness watchdog.
+//!
+//! Wraps the libtock alarm capsule (driver 0) so [`McuSpdmPal`] can hand the
+//! stack a real millisecond clock (`now_ms`) and an async delay (`sleep_ms`).
+//! The delay is raced against `recv_request` in the responder run loop, so a
+//! silent peer's session is torn down on watchdog expiry.
+//!
+//! This mirrors the async-alarm pattern already used by `pldm-lib/src/timer.rs`
+//! and `mcu-mbox-lib/src/fips_periodic.rs`. It is compiled only when the
+//! `spdm-set-heartbeat` feature is enabled.
+
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_alarm::{Convert, Hz, Milliseconds};
+use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
+use caliptra_mcu_libtockasync::TockSubscribe;
+
+const DRIVER_NUM: u32 = 0;
+
+mod command {
+    pub const FREQUENCY: u32 = 1;
+    pub const TIME: u32 = 2;
+    pub const SET_RELATIVE: u32 = 5;
+}
+
+fn get_frequency() -> Result<u32, ErrorCode> {
+    DefaultSyscalls::command(DRIVER_NUM, command::FREQUENCY, 0, 0).to_result()
+}
+
+fn get_ticks() -> Result<u32, ErrorCode> {
+    DefaultSyscalls::command(DRIVER_NUM, command::TIME, 0, 0).to_result()
+}
+
+/// Current value of the free-running monotonic millisecond clock. Returns 0 if
+/// the alarm capsule is unavailable, which keeps the watchdog inert rather than
+/// tearing sessions down spuriously.
+pub(crate) fn now_ms() -> u64 {
+    let (Ok(ticks), Ok(freq)) = (get_ticks(), get_frequency()) else {
+        return 0;
+    };
+    if freq == 0 {
+        return 0;
+    }
+    (ticks as u64).saturating_div((freq as u64).saturating_div(1000).max(1))
+}
+
+/// Sleep for at least `ms` milliseconds using the alarm capsule.
+pub(crate) async fn sleep_ms(ms: u32) {
+    let Ok(freq) = get_frequency() else {
+        // No clock: fall back to never-resolving so the run loop waits on
+        // recv_request alone (the pre-heartbeat behavior).
+        core::future::pending::<()>().await;
+        return;
+    };
+    let ticks = Milliseconds(ms).to_ticks(Hz(freq)).0;
+    let sub = TockSubscribe::subscribe::<DefaultSyscalls>(DRIVER_NUM, 0);
+    if DefaultSyscalls::command(DRIVER_NUM, command::SET_RELATIVE, ticks, 0)
+        .to_result::<u32, ErrorCode>()
+        .is_err()
+    {
+        core::future::pending::<()>().await;
+        return;
+    }
+    let _ = sub.await;
+}

--- a/runtime/userspace/api/spdm-lib/pal/src/io.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/io.rs
@@ -204,4 +204,20 @@ impl<M: MeasurementProvider> SpdmPalIoTransport for McuSpdmPal<M> {
         let transport = unsafe { self.transport_mut() };
         transport.send_response(kind, msg).await
     }
+
+    /// Monotonic millisecond clock backed by the libtock alarm capsule,
+    /// used by the HEARTBEAT liveness watchdog. Returns 0 when the alarm
+    /// capsule is unavailable, which keeps the watchdog inert.
+    #[cfg(feature = "spdm-set-heartbeat")]
+    fn now(&self) -> Milliseconds {
+        Milliseconds(super::clock::now_ms())
+    }
+
+    /// Sleep until at least `dur` elapses, via the libtock alarm capsule.
+    /// Raced against `recv_request` in the responder run loop so an idle
+    /// session is torn down on watchdog expiry.
+    #[cfg(feature = "spdm-set-heartbeat")]
+    async fn sleep(&self, dur: Milliseconds) {
+        super::clock::sleep_ms(u32::try_from(dur.0).unwrap_or(u32::MAX)).await
+    }
 }

--- a/runtime/userspace/api/spdm-lib/pal/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/lib.rs
@@ -35,6 +35,8 @@
 
 mod alloc;
 pub mod cert;
+#[cfg(feature = "spdm-set-heartbeat")]
+mod clock;
 mod hash;
 mod io;
 pub mod measurements;

--- a/runtime/userspace/api/spdm-lib/stack/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/stack/Cargo.toml
@@ -24,6 +24,12 @@ futures.workspace = true
 [features]
 default = []
 set-certificate = ["caliptra-mcu-spdm-traits/set-certificate"]
+# HEARTBEAT liveness watchdog: advertise HBEAT_CAP, negotiate a non-zero
+# HeartbeatPeriod, and race the run loop against a per-session deadline so an
+# idle session is torn down. Off by default (spec-legal "heartbeat not
+# supported"); the PAL must provide a real now_ms/sleep_ms clock for the
+# watchdog to advance.
+spdm-set-heartbeat = []
 generic-large-request = []
 debug-trace = [
   "caliptra-mcu-libtock_console",

--- a/runtime/userspace/api/spdm-lib/stack/src/heartbeat.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/heartbeat.rs
@@ -1,0 +1,118 @@
+// Licensed under the Apache-2.0 license
+
+//! HEARTBEAT to HEARTBEAT_ACK handler.
+//!
+//! HEARTBEAT is a session-only keep-alive with no request payload beyond the
+//! common header (Param1/Param2 reserved). The responder replies with a
+//! HEARTBEAT_ACK whose Param1/Param2 are reserved (zero). The command is only
+//! reachable inside an established secure session (enforced by the dispatcher's
+//! phase gate); this handler validates the request shape and builds the ACK,
+//! which the caller encrypts.
+
+use caliptra_mcu_spdm_codec::{ReqRespCode, SpdmMsgHdrPdu, SpdmVersion};
+use zerocopy::FromBytes;
+
+use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_VERSION_MISMATCH};
+
+/// Size of the HEARTBEAT_ACK SPDM message (common header + 2 reserved bytes).
+pub(crate) const HEARTBEAT_ACK_SPDM_SIZE: usize = SpdmMsgHdrPdu::SIZE + 2;
+
+/// Default HeartbeatPeriod (seconds) advertised in KEY_EXCHANGE_RSP when both
+/// endpoints support HEARTBEAT. Matches the Micron Aegis6 reference default.
+/// Not feature-gated so `heartbeat_period_for` can select on it with `cfg!()`
+/// (both branches must compile); the value is dead-code-eliminated when the
+/// `spdm-set-heartbeat` feature is off.
+pub(crate) const DEFAULT_HEARTBEAT_PERIOD_SECS: u8 = 3;
+
+/// Number of successive missed HeartbeatPeriods after which the responder
+/// tears the session down. The watchdog fires at this multiple of the period.
+pub(crate) const HEARTBEAT_TIMEOUT_MULTIPLIER: u64 = 2;
+
+/// Handle a decrypted HEARTBEAT request and produce the HEARTBEAT_ACK bytes.
+pub(crate) fn handle_heartbeat(
+    version: SpdmVersion,
+    spdm_msg: &[u8],
+) -> SpdmResult<[u8; HEARTBEAT_ACK_SPDM_SIZE]> {
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(spdm_msg).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != version.to_u8() {
+        return Err(SPDM_VERSION_MISMATCH);
+    }
+    // The request is exactly the 2-byte common header plus the two reserved
+    // Param1/Param2 bytes. Per DSP0274, reserved fields are ignored on read, so
+    // their contents are not validated -- but reject a request carrying trailing
+    // bytes beyond the fixed layout.
+    if rest.len() != 2 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let mut rsp_buf = [0u8; HEARTBEAT_ACK_SPDM_SIZE];
+    rsp_buf[0] = version.to_u8();
+    rsp_buf[1] = ReqRespCode::HEARTBEAT_ACK.0;
+    // rsp_buf[2..4] left zero: Param1/Param2 reserved.
+    Ok(rsp_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{SPDM_INVALID_REQUEST, SPDM_VERSION_MISMATCH};
+
+    /// A well-formed HEARTBEAT request: [version, HEARTBEAT, Param1=0, Param2=0].
+    fn heartbeat_req(version: SpdmVersion) -> [u8; 4] {
+        [version.to_u8(), ReqRespCode::HEARTBEAT.0, 0, 0]
+    }
+
+    #[test]
+    fn heartbeat_ack_is_well_formed() {
+        let req = heartbeat_req(SpdmVersion::V13);
+        let ack = handle_heartbeat(SpdmVersion::V13, &req).unwrap();
+        assert_eq!(
+            ack,
+            [SpdmVersion::V13.to_u8(), ReqRespCode::HEARTBEAT_ACK.0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn heartbeat_rejects_version_mismatch() {
+        // Request header carries V12 but the session negotiated V13.
+        let req = heartbeat_req(SpdmVersion::V12);
+        let err = handle_heartbeat(SpdmVersion::V13, &req).unwrap_err();
+        assert_eq!(err, SPDM_VERSION_MISMATCH);
+    }
+
+    #[test]
+    fn heartbeat_accepts_nonzero_reserved() {
+        // DSP0274: reserved fields are ignored on read, so a nonzero Param1/Param2
+        // must not be rejected. The ACK still zeroes them.
+        let mut req = heartbeat_req(SpdmVersion::V13);
+        req[2] = 1; // Param1 reserved -- ignored, not an error.
+        req[3] = 0xFF; // Param2 reserved -- ignored, not an error.
+        let ack = handle_heartbeat(SpdmVersion::V13, &req).unwrap();
+        assert_eq!(
+            ack,
+            [SpdmVersion::V13.to_u8(), ReqRespCode::HEARTBEAT_ACK.0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn heartbeat_rejects_truncated_request() {
+        // Only the 2-byte common header, missing the reserved bytes.
+        let req = [SpdmVersion::V13.to_u8(), ReqRespCode::HEARTBEAT.0];
+        let err = handle_heartbeat(SpdmVersion::V13, &req).unwrap_err();
+        assert_eq!(err, SPDM_INVALID_REQUEST);
+    }
+
+    #[test]
+    fn heartbeat_rejects_trailing_bytes() {
+        // A request with bytes beyond the fixed 4-byte layout is rejected.
+        let req = [
+            SpdmVersion::V13.to_u8(),
+            ReqRespCode::HEARTBEAT.0,
+            0,
+            0,
+            0xAA,
+        ];
+        let err = handle_heartbeat(SpdmVersion::V13, &req).unwrap_err();
+        assert_eq!(err, SPDM_INVALID_REQUEST);
+    }
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/key_exchange.rs
@@ -14,10 +14,10 @@
 //! 8. Build final response with signature + verify_data
 
 use caliptra_mcu_spdm_codec::{
-    encode_version_selection, parse_supported_versions, select_version, KeyExchangeReqBody,
-    KeyExchangeRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion, ECC_P384_SIGNATURE_SIZE,
-    ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN, OPAQUE_VERSION_SELECTION_SIZE,
-    SHA384_HASH_SIZE, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
+    encode_version_selection, parse_supported_versions, select_version, HeartBeatPeriod,
+    KeyExchangeReqBody, KeyExchangeRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    ECC_P384_SIGNATURE_SIZE, ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN,
+    OPAQUE_VERSION_SELECTION_SIZE, SHA384_HASH_SIZE, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
 use caliptra_mcu_spdm_traits::*;
 use zerocopy::FromBytes;
@@ -174,7 +174,11 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     our_exchange_data: &[u8],
     selected_version: &[u8; 2],
 ) -> SpdmResult<PalBytes<'a, Pal>> {
+    // Same HeartbeatPeriod byte must feed both the partial and full builds (folded into the transcript).
+    let hb_period = heartbeat_period_for::<Pal>(state);
+
     let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+    session.heartbeat_period = hb_period;
     let mut workspace = pal.alloc_bytes(io, KEY_EXCHANGE_WORKSPACE_SIZE)?;
     workspace.fill(0);
     let mut rest = &mut workspace[..];
@@ -272,6 +276,7 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
 
     // ── Build partial response (no signature, no verify_data) ───────
     let partial_body = KeyExchangeRsp {
+        heartbeat_period: hb_period,
         rsp_session_id,
         random_data: nonce,
         exchange_data: our_exchange_data.try_into().map_err(|_| SPDM_UNSPECIFIED)?,
@@ -356,6 +361,7 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
 
     // ── Build full response ─────────────────────────────────────────
     let full_body = KeyExchangeRsp {
+        heartbeat_period: hb_period,
         rsp_session_id,
         random_data: nonce,
         exchange_data: our_exchange_data.try_into().map_err(|_| SPDM_UNSPECIFIED)?,
@@ -369,6 +375,22 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
         build_response(pal, io, state.version, &full_body).map_err(|_| SPDM_UNSPECIFIED)?;
 
     Ok(full_resp)
+}
+
+/// HeartbeatPeriod to advertise in KEY_EXCHANGE_RSP for this connection.
+/// Enabled only when both the responder and the peer set HBEAT_CAP; otherwise
+/// `DISABLED` (per DSP0274, zero when either endpoint lacks Heartbeat support).
+/// Always `DISABLED` when the `spdm-set-heartbeat` feature is off.
+fn heartbeat_period_for<Pal: SpdmPal>(state: &ConnState<'_, Pal>) -> HeartBeatPeriod {
+    use caliptra_mcu_spdm_codec::CapFlags;
+    if cfg!(feature = "spdm-set-heartbeat")
+        && state.cap_flags.contains(CapFlags::HBEAT)
+        && state.peer_cap_flags.contains(CapFlags::HBEAT)
+    {
+        HeartBeatPeriod(crate::heartbeat::DEFAULT_HEARTBEAT_PERIOD_SECS)
+    } else {
+        HeartBeatPeriod::DISABLED
+    }
 }
 
 // ── Signing helpers ─────────────────────────────────────────────────

--- a/runtime/userspace/api/spdm-lib/stack/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/lib.rs
@@ -42,9 +42,12 @@ mod digests;
 mod end_session;
 mod error;
 mod finish;
+mod heartbeat;
 mod key_exchange;
 pub mod key_schedule;
 mod measurements;
+#[cfg(feature = "spdm-set-heartbeat")]
+mod select;
 pub mod session;
 #[cfg(feature = "set-certificate")]
 mod set_certificate;

--- a/runtime/userspace/api/spdm-lib/stack/src/select.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/select.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache-2.0 license
+
+//! Minimal two-future `select` for the HEARTBEAT liveness run loop.
+//!
+//! Races `recv_request` against the watchdog `sleep_ms` so an idle session can
+//! be torn down without pulling in an external `select` combinator (the
+//! vendored offline build has no `embassy-futures`). Polls `a` first each wake
+//! so an arriving request is always preferred over a simultaneously-expiring
+//! timer.
+//!
+//! Compiled only when the `spdm-set-heartbeat` feature is enabled.
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+/// Which branch of a [`select`] completed first.
+pub(crate) enum Either<A, B> {
+    /// The first future (`a`) completed; carries its output.
+    First(A),
+    /// The second future (`b`) completed; carries its output.
+    Second(B),
+}
+
+/// Poll `a` and `b` concurrently, resolving to [`Either`] as soon as one
+/// completes. The loser is dropped (its side effects, if any, are abandoned),
+/// so both futures must be cancellation-safe.
+pub(crate) fn select<A, B>(a: A, b: B) -> Select<A, B> {
+    Select { a, b }
+}
+
+pub(crate) struct Select<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A: Future, B: Future> Future for Select<A, B> {
+    type Output = Either<A::Output, B::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: we never move `a` or `b` out of `self`; we only re-pin them in
+        // place for polling, and `self` is already pinned by the caller.
+        let this = unsafe { self.get_unchecked_mut() };
+        let a = unsafe { Pin::new_unchecked(&mut this.a) };
+        if let Poll::Ready(out) = a.poll(cx) {
+            return Poll::Ready(Either::First(out));
+        }
+        let b = unsafe { Pin::new_unchecked(&mut this.b) };
+        if let Poll::Ready(out) = b.poll(cx) {
+            return Poll::Ready(Either::Second(out));
+        }
+        Poll::Pending
+    }
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/session.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/session.rs
@@ -11,7 +11,7 @@
 //! 3. Session used for secured message framing
 //! 4. GET_VERSION or error → [`SessionManager::remove_all_and_destroy`]
 
-use caliptra_mcu_spdm_codec::{errors::SPDM_SESSION_LIMIT_EXCEEDED, SpdmVersion};
+use caliptra_mcu_spdm_codec::{errors::SPDM_SESSION_LIMIT_EXCEEDED, HeartBeatPeriod, SpdmVersion};
 use caliptra_mcu_spdm_traits::{McuResult, SpdmPalHash, SpdmPalIo};
 use core::ops::{Deref, DerefMut};
 
@@ -145,6 +145,11 @@ pub struct SessionInfo<K: Clone, S> {
     pub key_schedule: KeySchedule<K>,
     /// Per-session TH transcript hash state.
     pub transcript: SessionTranscript<S>,
+    /// HeartbeatPeriod negotiated for this session; `DISABLED` (zero) disables
+    /// the watchdog.
+    pub heartbeat_period: HeartBeatPeriod,
+    /// Absolute watchdog deadline (monotonic ms); `None` while unarmed.
+    pub deadline_ms: Option<u64>,
 }
 
 impl<K: Clone, S> Drop for SessionInfo<K, S> {
@@ -164,7 +169,35 @@ impl<K: Clone, S> SessionInfo<K, S> {
             state: SessionState::HandshakeInProgress,
             key_schedule: KeySchedule::new(spdm_version_str(version)),
             transcript: SessionTranscript::new(),
+            heartbeat_period: HeartBeatPeriod::DISABLED,
+            deadline_ms: None,
         }
+    }
+
+    /// Arm the liveness watchdog at session establishment. Sets the deadline to
+    /// `now_ms + HEARTBEAT_TIMEOUT_MULTIPLIER * period` (the DSP0274 "terminate
+    /// after two successive missed HeartbeatPeriods" rule). No-op when the
+    /// negotiated period is zero (heartbeat disabled for this session).
+    pub fn arm_heartbeat(&mut self, now_ms: u64) {
+        self.deadline_ms = self.heartbeat_deadline(now_ms);
+    }
+
+    /// Restart the liveness watchdog on any secured traffic. Only re-arms an
+    /// already-armed watchdog; a session with heartbeat disabled stays inert.
+    pub fn touch_heartbeat(&mut self, now_ms: u64) {
+        if self.deadline_ms.is_some() {
+            self.deadline_ms = self.heartbeat_deadline(now_ms);
+        }
+    }
+
+    fn heartbeat_deadline(&self, now_ms: u64) -> Option<u64> {
+        if !self.heartbeat_period.is_enabled() {
+            return None;
+        }
+        let window_ms = crate::heartbeat::HEARTBEAT_TIMEOUT_MULTIPLIER
+            .saturating_mul(self.heartbeat_period.secs() as u64)
+            .saturating_mul(1000);
+        Some(now_ms.saturating_add(window_ms))
     }
 }
 
@@ -257,6 +290,38 @@ impl<K: Clone, S, B: Deref<Target = SessionInfo<K, S>> + DerefMut, const N: usiz
                 return;
             }
         }
+    }
+
+    /// Nearest liveness-watchdog deadline (monotonic ms) across all armed
+    /// sessions, or `None` if no session has an armed watchdog. The run loop
+    /// uses this to schedule its timeout wake.
+    pub fn nearest_deadline_ms(&self) -> Option<u64> {
+        self.sessions
+            .iter()
+            .flatten()
+            .filter_map(|s| s.deadline_ms)
+            .min()
+    }
+
+    /// Tear down every session whose liveness watchdog has expired at `now_ms`
+    /// (deadline reached). Keys are erased via the same path as
+    /// [`Self::remove_and_destroy`]. Returns the number of sessions cleared.
+    pub fn expire_due(&mut self, now_ms: u64) -> usize {
+        let mut cleared = 0;
+        for slot in self.sessions.iter_mut() {
+            let expired = slot
+                .as_ref()
+                .and_then(|s| s.deadline_ms)
+                .is_some_and(|d| now_ms >= d);
+            if expired {
+                if let Some(info) = slot.as_mut() {
+                    info.key_schedule.destroy_all();
+                }
+                *slot = None;
+                cleared += 1;
+            }
+        }
+        cleared
     }
 
     /// Remove all sessions and clear all local key blobs.

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -33,7 +33,7 @@ use crate::key_schedule::SessionKeyType;
 use crate::session::{SessionInfo, SessionManager, SessionState};
 use crate::{
     algorithms, capabilities, certificate, challenge, chunk, digests, end_session, finish,
-    key_exchange, measurements, vendor_defined, version,
+    heartbeat, key_exchange, measurements, vendor_defined, version,
 };
 
 /// Type alias for the SessionManager with full PAL type resolution.
@@ -172,6 +172,7 @@ impl<S, L> ConnectionState<S, L> {
             | CapFlags::ENCRYPT
             | CapFlags::MAC
             | CapFlags::CHUNK
+            | heartbeat_cap_flags()
             | set_certificate_cap_flags();
         let other_param_support =
             OtherParamSupport::OPAQUE_DATA_FMT1 | set_certificate_other_params();
@@ -320,6 +321,61 @@ fn set_certificate_other_params() -> OtherParamSupport {
     OtherParamSupport::EMPTY
 }
 
+// Advertise HBEAT_CAP only when the heartbeat liveness watchdog is compiled in.
+// With the feature off, no HBEAT_CAP is advertised, so per DSP0274 the
+// HeartbeatPeriod is always zero and no liveness is expected (spec-legal
+// "heartbeat not supported").
+fn heartbeat_cap_flags() -> CapFlags {
+    if cfg!(feature = "spdm-set-heartbeat") {
+        CapFlags::HBEAT
+    } else {
+        CapFlags::EMPTY
+    }
+}
+
+/// Receive the next request for the run loop.
+///
+/// With the heartbeat liveness watchdog compiled in and at least one session
+/// armed, this races `recv_request` against the nearest liveness deadline; if
+/// the timer wins, every expired session is torn down and the wait restarts.
+/// With no armed session — or with the feature off — it is a plain blocking
+/// receive, unchanged.
+///
+/// Taken as a free function over split borrows (`pal` shared, `sessions`
+/// mutable) rather than a `&mut self` method: the returned `Io` borrows only
+/// `pal`, so the caller keeps `sessions`/`state` free to borrow mutably for
+/// dispatch. This also keeps the feature-flag branching out of the run loop.
+#[cfg(feature = "spdm-set-heartbeat")]
+async fn recv_next<'p, Pal: SpdmPal, const N: usize>(
+    pal: &'p Pal,
+    sessions: &mut Sessions<Pal, N>,
+) -> McuResult<<Pal as SpdmPalIoTransport>::Io<'p>> {
+    use crate::select::{select, Either};
+    loop {
+        match sessions.nearest_deadline_ms() {
+            Some(deadline) => {
+                let delay = deadline.saturating_sub(pal.now().0);
+                match select(pal.recv_request(), pal.sleep(Milliseconds(delay))).await {
+                    Either::First(io) => return io,
+                    Either::Second(()) => {
+                        sessions.expire_due(pal.now().0);
+                        continue;
+                    }
+                }
+            }
+            None => return pal.recv_request().await,
+        }
+    }
+}
+
+#[cfg(not(feature = "spdm-set-heartbeat"))]
+async fn recv_next<'p, Pal: SpdmPal, const N: usize>(
+    pal: &'p Pal,
+    _sessions: &mut Sessions<Pal, N>,
+) -> McuResult<<Pal as SpdmPalIoTransport>::Io<'p>> {
+    pal.recv_request().await
+}
+
 /// SPDM responder state machine + dispatcher.
 ///
 /// Owns a `Pal` (transport + allocator), the [`ConnectionState`],
@@ -405,7 +461,12 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
             caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
         >::writer();
         loop {
-            let io = self.pal.recv_request().await?;
+            // Receive the next request. With the heartbeat watchdog compiled in,
+            // this races the receive against the nearest session liveness
+            // deadline; with the feature off it is a plain blocking receive.
+            // Kept disjoint from the other fields so `io` (which borrows
+            // `self.pal`) does not pin a `&mut self` borrow across the loop.
+            let io = recv_next(&self.pal, &mut self.sessions).await?;
             #[cfg(feature = "debug-trace")]
             {
                 let r = io.request();
@@ -653,7 +714,11 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         ReqRespCode::KEY_EXCHANGE => {
             key_exchange::handle_key_exchange(state, sessions, pal, io).await
         }
-        ReqRespCode::FINISH | ReqRespCode::END_SESSION => Err(SPDM_SESSION_REQUIRED),
+        // HEARTBEAT is advertised (HBEAT cap) but only valid inside a session,
+        // so an unsecured request gets SessionRequired, not UnsupportedRequest.
+        ReqRespCode::FINISH | ReqRespCode::END_SESSION | ReqRespCode::HEARTBEAT => {
+            Err(SPDM_SESSION_REQUIRED)
+        }
         ReqRespCode(0) => Err(SPDM_INVALID_REQUEST),
         _ => Err(SPDM_UNSUPPORTED_REQUEST.with_data(code.0)),
     }
@@ -823,7 +888,7 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
         state.large_msg_ctx.reset();
     }
 
-    match spdm_hdr.code {
+    let result = match spdm_hdr.code {
         ReqRespCode::FINISH => {
             let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
             let (finish_rsp, finish_rsp_len) =
@@ -840,6 +905,10 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             .await?;
             session.key_schedule.destroy_handshake_secrets();
             session.state = SessionState::Established;
+            // Arm the liveness watchdog at the FINISH_RSP transmission point
+            // (DSP0274 1.3.0 section 10.20). No-op when the negotiated period
+            // is zero (heartbeat disabled / feature off).
+            session.arm_heartbeat(pal.now().0);
             Ok(rsp)
         }
         ReqRespCode::END_SESSION => {
@@ -857,6 +926,20 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             .await?;
             sessions.remove_and_destroy(session_id);
             Ok(rsp)
+        }
+        ReqRespCode::HEARTBEAT => {
+            let heartbeat_ack = heartbeat::handle_heartbeat(version, spdm_msg)?;
+            let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+            encrypt_secured_spdm_response(
+                pal,
+                io,
+                session,
+                session_id,
+                version,
+                response_key_type,
+                &heartbeat_ack,
+            )
+            .await
         }
         ReqRespCode::GET_DIGESTS => {
             let (digests_rsp, spdm_len) =
@@ -969,7 +1052,19 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             .await
         }
         _ => Err(SPDM_UNSUPPORTED_REQUEST.with_data(spdm_hdr.code.0)),
+    };
+
+    // Keep-alive: any successfully handled secured command restarts the
+    // liveness watchdog (DSP0274 1.3.0 section 10.20 "session traffic"). FINISH
+    // arms it above and END_SESSION removes the session, so both are skipped
+    // here; touch is a no-op on a session whose watchdog is unarmed.
+    if result.is_ok() && code != ReqRespCode::FINISH && code != ReqRespCode::END_SESSION {
+        if let Some(session) = sessions.find_mut(session_id) {
+            session.touch_heartbeat(pal.now().0);
+        }
     }
+
+    result
 }
 
 fn validate_message_allowed_phase(
@@ -998,7 +1093,9 @@ fn validate_message_allowed_phase(
         ReqRespCode::GET_DIGESTS
         | ReqRespCode::GET_CERTIFICATE
         | ReqRespCode::GET_MEASUREMENTS
-        | ReqRespCode::END_SESSION => application_key(),
+        | ReqRespCode::END_SESSION
+        // HEARTBEAT is only valid in an established secure session.
+        | ReqRespCode::HEARTBEAT => application_key(),
         ReqRespCode::SET_CERTIFICATE => Err(SPDM_UNSUPPORTED_REQUEST.with_data(code.0)),
         ReqRespCode::FINISH => {
             if session_state == SessionState::HandshakeInProgress {
@@ -1139,3 +1236,7 @@ mod capabilities_tests;
 #[cfg(test)]
 #[path = "tests/certificate.rs"]
 mod certificate_tests;
+
+#[cfg(test)]
+#[path = "tests/heartbeat_liveness.rs"]
+mod heartbeat_liveness_tests;

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/heartbeat_liveness.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/heartbeat_liveness.rs
@@ -1,0 +1,146 @@
+// Licensed under the Apache-2.0 license
+
+//! HEARTBEAT liveness-watchdog tests (DSP0274 1.3.0 section 10.20).
+//!
+//! Covers the per-session watchdog independent of the run loop: arming at
+//! establishment, keep-alive on secured traffic, and teardown after two missed
+//! HeartbeatPeriods. The wire-level "period advertised iff both caps" and
+//! feature-off behavior are also asserted.
+
+extern crate std;
+
+use super::*;
+use caliptra_mcu_spdm_codec::HeartBeatPeriod;
+use caliptra_mcu_spdm_traits::NoVdmBackend;
+use futures::executor::block_on;
+use std::vec;
+use std::vec::Vec;
+
+#[path = "support.rs"]
+mod support;
+use support::*;
+
+// 2 x period x 1000 ms; period defaults to 3 s in the reference config.
+const PERIOD_SECS: u8 = 3;
+const WINDOW_MS: u64 = 2 * PERIOD_SECS as u64 * 1000;
+
+// Arming at establishment sets the deadline to now + 2*period*1000 ms.
+#[test]
+fn arm_sets_deadline_from_period() {
+    let pal = TestPal::default();
+    let (_state, mut sessions, session_id) = established_session(&pal);
+    let session = sessions.find_mut(session_id).unwrap();
+    session.heartbeat_period = HeartBeatPeriod(PERIOD_SECS);
+    session.arm_heartbeat(1000);
+    assert_eq!(session.deadline_ms, Some(1000 + WINDOW_MS));
+}
+
+// A zero period (heartbeat not desired) leaves the watchdog unarmed.
+#[test]
+fn arm_is_inert_when_period_zero() {
+    let pal = TestPal::default();
+    let (_state, mut sessions, session_id) = established_session(&pal);
+    let session = sessions.find_mut(session_id).unwrap();
+    session.heartbeat_period = HeartBeatPeriod::DISABLED;
+    session.arm_heartbeat(1000);
+    assert_eq!(session.deadline_ms, None);
+}
+
+// Keep-alive: touch restarts an armed watchdog, but never arms a disabled one.
+#[test]
+fn touch_restarts_only_armed_watchdog() {
+    let pal = TestPal::default();
+    let (_state, mut sessions, session_id) = established_session(&pal);
+    let session = sessions.find_mut(session_id).unwrap();
+    session.heartbeat_period = HeartBeatPeriod(PERIOD_SECS);
+    session.arm_heartbeat(1000);
+    session.touch_heartbeat(5000);
+    assert_eq!(session.deadline_ms, Some(5000 + WINDOW_MS));
+
+    // Disabled watchdog: touch is a no-op.
+    session.deadline_ms = None;
+    session.touch_heartbeat(9000);
+    assert_eq!(session.deadline_ms, None);
+}
+
+// nearest_deadline_ms reports the minimum armed deadline (or None).
+#[test]
+fn nearest_deadline_reports_min() {
+    let pal = TestPal::default();
+    let (_state, mut sessions, session_id) = established_session(&pal);
+    assert_eq!(sessions.nearest_deadline_ms(), None);
+    let session = sessions.find_mut(session_id).unwrap();
+    session.heartbeat_period = HeartBeatPeriod(PERIOD_SECS);
+    session.arm_heartbeat(1000);
+    assert_eq!(sessions.nearest_deadline_ms(), Some(1000 + WINDOW_MS));
+}
+
+// Teardown: a session whose deadline has passed is cleared by expire_due; a
+// not-yet-expired session survives.
+#[test]
+fn expire_due_clears_only_expired_sessions() {
+    let pal = TestPal::default();
+    let (_state, mut sessions, session_id) = established_session(&pal);
+    let session = sessions.find_mut(session_id).unwrap();
+    session.heartbeat_period = HeartBeatPeriod(PERIOD_SECS);
+    session.arm_heartbeat(1000);
+    let deadline = 1000 + WINDOW_MS;
+
+    // Just before the deadline: survives.
+    assert_eq!(sessions.expire_due(deadline - 1), 0);
+    assert!(sessions.find(session_id).is_some());
+
+    // At the deadline: torn down.
+    assert_eq!(sessions.expire_due(deadline), 1);
+    assert!(sessions.find(session_id).is_none());
+}
+
+// Keep-alive through the secured dispatch path: a HEARTBEAT received after the
+// clock advances pushes the deadline forward rather than letting it expire.
+#[test]
+fn secured_heartbeat_refreshes_deadline() {
+    let pal = TestPal::default();
+    let (mut state, mut sessions, session_id) = established_session(&pal);
+    {
+        let session = sessions.find_mut(session_id).unwrap();
+        session.heartbeat_period = HeartBeatPeriod(PERIOD_SECS);
+        session.arm_heartbeat(0);
+        assert_eq!(session.deadline_ms, Some(WINDOW_MS));
+    }
+
+    // Advance the clock and deliver a secured HEARTBEAT.
+    pal.set_now_ms(1500);
+    let inner = vec![state.version.to_u8(), ReqRespCode::HEARTBEAT.0, 0, 0];
+    let io = secured_io(session_id, &inner);
+    block_on(handle_secured_request(
+        &mut state,
+        &mut sessions,
+        &pal,
+        &io,
+        &NoVdmBackend,
+    ))
+    .expect("secured handler must not fatally error")
+    .expect("a HEARTBEAT_ACK must be produced");
+
+    let session = sessions.find(session_id).unwrap();
+    assert_eq!(session.deadline_ms, Some(1500 + WINDOW_MS));
+}
+
+// With the feature enabled, the responder advertises HBEAT_CAP.
+#[cfg(feature = "spdm-set-heartbeat")]
+#[test]
+fn responder_advertises_hbeat_cap_when_enabled() {
+    use caliptra_mcu_spdm_codec::CapFlags;
+    let state = ConnectionState::<TestHashState, Vec<u8>>::caliptra();
+    assert!(state.cap_flags.contains(CapFlags::HBEAT));
+}
+
+// With the feature disabled, HBEAT_CAP is not advertised (spec-legal
+// "heartbeat not supported").
+#[cfg(not(feature = "spdm-set-heartbeat"))]
+#[test]
+fn responder_hides_hbeat_cap_when_disabled() {
+    use caliptra_mcu_spdm_codec::CapFlags;
+    let state = ConnectionState::<TestHashState, Vec<u8>>::caliptra();
+    assert!(!state.cap_flags.contains(CapFlags::HBEAT));
+}

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -10,9 +10,9 @@ use caliptra_mcu_spdm_codec::{
     LARGE_RESPONSE_SIZE_FIELD_SIZE, SECURED_MSG_HDR_SIZE,
 };
 use caliptra_mcu_spdm_traits::{
-    MeasurementInfo, SigningInput, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash,
-    SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoKind, SpdmPalIoTransport, SpdmPalMeasurements,
-    SpdmPalSessionCrypto, SPDM_NONCE_LEN,
+    MeasurementInfo, Milliseconds, SigningInput, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore,
+    SpdmPalHash, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoKind, SpdmPalIoTransport,
+    SpdmPalMeasurements, SpdmPalSessionCrypto, SPDM_NONCE_LEN,
 };
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -116,6 +116,14 @@ pub struct TestPal {
     pub op: RefCell<Option<StoreOp>>,
     pub stream_cert: RefCell<Vec<u8>>,
     pub stream_aborts: Cell<usize>,
+    pub now_ms: RefCell<u64>,
+}
+
+impl TestPal {
+    /// Advance / set the fake monotonic clock used by `now_ms()`.
+    pub fn set_now_ms(&self, ms: u64) {
+        *self.now_ms.borrow_mut() = ms;
+    }
 }
 
 impl Default for TestPal {
@@ -137,6 +145,7 @@ impl Default for TestPal {
             op: RefCell::new(None),
             stream_cert: RefCell::new(Vec::new()),
             stream_aborts: Cell::new(0),
+            now_ms: RefCell::new(0),
         }
     }
 }
@@ -239,6 +248,14 @@ impl SpdmPalIoTransport for TestPal {
         _msg: &mut [u8],
     ) -> McuResult<()> {
         Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    fn now(&self) -> Milliseconds {
+        Milliseconds(*self.now_ms.borrow())
+    }
+
+    async fn sleep(&self, _dur: Milliseconds) {
+        // Tests drive the clock explicitly via `set_now_ms`; never block.
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/traits/src/io.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/io.rs
@@ -38,6 +38,14 @@ pub trait SpdmPalIo {
     fn request(&self) -> &[u8];
 }
 
+/// A quantity of milliseconds used by the HEARTBEAT liveness watchdog for
+/// both the monotonic clock reading and sleep durations. Wrapping the raw
+/// count in a newtype keeps the unit in the type signature so it can't be
+/// confused with an unrelated integer. `u64`-backed so per-session deadlines
+/// don't overflow at seconds-scale heartbeat periods.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+pub struct Milliseconds(pub u64);
+
 /// Transport-layer abstraction for SPDM request/response exchange.
 ///
 /// Implementations of this trait handle the mechanics of receiving SPDM
@@ -116,4 +124,26 @@ pub trait SpdmPalIoTransport {
         kind: SpdmPalIoKind,
         msg: &mut [u8],
     ) -> McuResult<()>;
+
+    /// Current value of a free-running monotonic millisecond clock.
+    ///
+    /// Used by the SPDM stack's HEARTBEAT liveness watchdog to compute and
+    /// check per-session deadlines. The default returns 0; a PAL that wants
+    /// heartbeat-driven session teardown must override this with a real
+    /// monotonic source (e.g. the libtock alarm capsule). With the default,
+    /// `now` never advances so no watchdog deadline is ever reached.
+    fn now(&self) -> Milliseconds {
+        Milliseconds(0)
+    }
+
+    /// Sleep until at least `dur` has elapsed.
+    ///
+    /// Raced against [`Self::recv_request`] in the responder run loop so a
+    /// silent peer's session can be torn down on watchdog expiry. The default
+    /// never resolves, so a PAL that does not provide a real clock simply
+    /// waits on `recv_request` alone (the pre-heartbeat behavior).
+    async fn sleep(&self, dur: Milliseconds) {
+        let _ = dur;
+        core::future::pending::<()>().await
+    }
 }

--- a/runtime/userspace/libtock/unittest/src/fake/alarm/mod.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/alarm/mod.rs
@@ -1,7 +1,9 @@
 //! Fake implementation of the Alarm API.
 //!
-//! Supports frequency and set_relative.
-//! Will schedule the upcall immediately.
+//! Supports frequency, time, and set_relative.
+//! Will schedule the upcall immediately. Each set_relative advances the virtual
+//! `now` counter by its relative argument, so a consumer that sleeps and then
+//! reads time (command TIME) observes the clock move forward monotonically.
 
 use caliptra_mcu_libtock_platform::{CommandReturn, ErrorCode};
 use core::cell::Cell;
@@ -38,6 +40,10 @@ impl crate::fake::SyscallDriver for Alarm {
         match command_number {
             command::EXISTS => crate::command_return::success(),
             command::FREQUENCY => crate::command_return::success_u32(self.frequency_hz),
+            // Current value of the virtual monotonic tick counter. Each
+            // SET_RELATIVE advances `now` by its relative argument (below), so a
+            // consumer that sleeps then reads TIME observes time moving forward.
+            command::TIME => crate::command_return::success_u32(self.now.get().0),
             command::SET_RELATIVE => {
                 // We're not actually sleeping, just ticking the timer.
                 // The semantics of sleeping aren't clear,

--- a/runtime/userspace/libtock/unittest/src/fake/alarm/tests.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/alarm/tests.rs
@@ -12,3 +12,26 @@ fn command() {
         Some(10)
     );
 }
+
+// TIME starts at zero and tracks the accumulated set_relative deltas, so a
+// consumer that sleeps then reads the clock sees it advance.
+#[test]
+fn time_advances_with_set_relative() {
+    use fake::SyscallDriver;
+    let alarm = Alarm::new(1000);
+
+    assert_eq!(
+        alarm.command(command::TIME, 0, 0).get_success_u32(),
+        Some(0)
+    );
+    let _ = alarm.command(command::SET_RELATIVE, 250, 0);
+    assert_eq!(
+        alarm.command(command::TIME, 0, 0).get_success_u32(),
+        Some(250)
+    );
+    let _ = alarm.command(command::SET_RELATIVE, 750, 0);
+    assert_eq!(
+        alarm.command(command::TIME, 0, 0).get_success_u32(),
+        Some(1000)
+    );
+}


### PR DESCRIPTION
## Summary

Backport of #1927 (`spdm: HEARTBEAT / HEARTBEAT_ACK with watchdog`) from `main` to `main-2.1`.

#1927 merged to `main` only. Its automated `backport` check failed, and although the automation
pushed `backport/c847e790-to-main-2.1`, no PR was ever opened from it — so `main-2.1` has no
HEARTBEAT support today: `stack/src/heartbeat.rs` does not exist there, and the only heartbeat
references are the `ReqRespCode` entry in `codec/src/header.rs` and the `KEY_EXCHANGE_RSP`
period field in `codec/src/key_exchange.rs`.

That stale backport branch is 39 commits behind, so this is a fresh cherry-pick of
`c847e790` onto current `main-2.1` rather than a rebase of it.

Contents, unchanged from #1927:

- HEARTBEAT (0xE8) / HEARTBEAT_ACK (0x68) handler, always compiled; validates version and the
  4-byte shape (reserved Param1/Param2 ignored per DSP0274) and is phase-gated to an established
  secure session — an unsecured HEARTBEAT gets `SessionRequired`.
- Full liveness behind the off-by-default `spdm-set-heartbeat` feature (DSP0274 1.3.0 §10.20):
  non-zero HeartbeatPeriod in KEY_EXCHANGE_RSP iff both endpoints set `HBEAT_CAP`, a per-session
  watchdog armed at 2x the period on FINISH_RSP, keep-alive on any successfully handled secured
  command, and session teardown with key erasure on expiry.

## Conflicts resolved

Two, both purely additive — no behavioral change to either side:

- `stack/src/tests/support.rs` — trait import list: `main-2.1` added `SigningInput`, the backport
  adds `Milliseconds`. Kept both.
- `stack/src/stack.rs` — test module list: `main-2.1` added `version`/`capabilities`/`certificate`,
  the backport adds `heartbeat_liveness`. Kept all four.

## Testing

On the cherry-picked branch (Rust 1.95, per `rust-toolchain.toml`):

- `cargo test -p caliptra-mcu-spdm-stack` — 52 passed, 0 failed (includes `main-2.1`'s existing
  version/capabilities/certificate tests and the 7 `heartbeat_liveness` tests)
- `cargo test -p caliptra-mcu-spdm-stack --features spdm-set-heartbeat` — 52 passed, 0 failed
- `cargo test -p caliptra-mcu-spdm-codec -p caliptra-mcu-spdm-pal -p caliptra-mcu-spdm-traits` — pass
- `cargo test -p caliptra-mcu-libtock_unittest` — 96 passed (incl. the fake-alarm tests this adds)
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets` on the four spdm-lib crates — the only 2 warnings are pre-existing
  in `chunk/mod.rs` and reproduce identically on unmodified `main-2.1`
